### PR TITLE
fix pymodbus, default config external openWB

### DIFF
--- a/packages/control/prepare.py
+++ b/packages/control/prepare.py
@@ -29,7 +29,13 @@ class Prepare:
         """ kopiert die Daten, die per MQTT empfangen wurden.
         """
         try:
-            data.data.system_data = copy.deepcopy(subdata.SubData.system_data)
+            # Workaround, da mit Python3.9/pymodbus2.5 eine pymodbus-Instanz nicht mehr kopiert werden kann.
+            # Bei einer Neukonfiguration eines Device/Komponente wird dieses Neuinitialisiert. Nur bei Komponenten
+            # mit simcount werden Werte aktualisiert, diese sollten jedoch nur einmal nach dem Auslesen aktualisiert
+            # werden, sodass die Nutzung einer Referenz erstmal funktioniert.
+            data.data.system_data = {
+                "system": copy.deepcopy(subdata.SubData.system_data["system"])} | {
+                k: subdata.SubData.system_data[k] for k in subdata.SubData.system_data if "device" in k}
         except Exception:
             MainLogger().exception("Fehler im Prepare-Modul")
 

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -419,7 +419,7 @@ class Command:
                     "EV mit ID "+str(payload["data"]["id"])+" gelöscht.")
                 Pub().pub("openWB/vehicle/"+str(payload["data"]["id"]), "")
                 ProcessBrokerBranch(
-                    "vehicle"+str(payload["data"]["id"])).remove_topics()
+                    "vehicle/"+str(payload["data"]["id"])).remove_topics()
             else:
                 pub_error(payload, connection_id, "Vehicle mit ID 0 darf nicht gelöscht werden.")
         else:
@@ -560,6 +560,7 @@ class ProcessBrokerBranch:
         """
         try:
             client.subscribe("openWB/"+self.topic_str+"/#", 2)
+            client.subscribe("openWB/set/"+self.topic_str+"/#", 2)
         except Exception:
             MainLogger().exception("Fehler im Command-Modul")
 

--- a/packages/modules/external_openwb/chargepoint_module.py
+++ b/packages/modules/external_openwb/chargepoint_module.py
@@ -11,9 +11,11 @@ from modules.common.fault_state import ComponentInfo
 def get_default_config() -> Dict:
     return {"id": 0,
             "connection_module": {
-                "type": "mqtt",
-                "configuration":
-                {}
+                "type": "external_openwb",
+                "configuration": {
+                    "ip_address": "192.168.193.5",
+                    "duo_num": 1
+                }
             },
             "power_module": {}}
 


### PR DESCRIPTION
Bugfix Einstellungen: Topic beim Löschen eines Fahrzeugs, Default-Einstellungen externe openWB korrigiert
Workaround: pymodbus-Instanzen können mit Python3.9/pymodbus2.5 nicht mehr kopiert werden.