### PR TITLE
Berechtigungen sinnvoll nutzen

### DIFF
--- a/data/config/openwb2.service
+++ b/data/config/openwb2.service
@@ -2,7 +2,7 @@
 Description="Regelung openWB 2.0"
 
 [Service]
-User=pi
+User=openwb
 WorkingDirectory=/var/www/html/openWB
 ExecStart=/var/www/html/openWB/packages/main.py
 Restart=always

--- a/openwb-install.sh
+++ b/openwb-install.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 OPENWBBASEDIR=/var/www/html/openWB
+OPENWB_USER=openwb
+
+if [ "$EUID" -ne 0 ]
+then
+	echo "This script must be run as root"
+	exit
+fi
 
 echo "installing openWB 2 into \"${OPENWBBASEDIR}\""
 
@@ -8,11 +15,19 @@ apt-get update
 apt-get -q -y install vim bc apache2 php php-gd php-curl php-xml php-json libapache2-mod-php jq git mosquitto mosquitto-clients socat python3-pip sshpass
 echo "done"
 
+echo "create user $OPENWB_USER"
+# Will do nothing if user already exists:
+useradd "$OPENWB_USER" --create-home
+# The user "openwb" is still new and we might need sudo in many places. Thus for now we give the user
+# unrestricted sudo. This should restricted in the future
+echo "$OPENWB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/openwb
+echo "done"
+
 echo "check for initial git clone..."
-if [ ! -d ${OPENWBBASEDIR}/web ]; then
-	cd /var/www/html/
-	git clone https://github.com/openWB/core.git --branch master ${OPENWBBASEDIR}
-	chown -R pi:pi openWB
+if [ ! -d "$OPENWBBASEDIR/web" ]; then
+	mkdir "$OPENWBBASEDIR"
+	chown "$OPENWB_USER:$OPENWB_USER" "$OPENWBBASEDIR"
+	sudo -u "$OPENWB_USER" git clone https://github.com/openWB/core.git --branch master "$OPENWBBASEDIR"
 	echo "git cloned"
 else
 	echo "ok"
@@ -30,7 +45,7 @@ fi
 
 echo -n "check for crontab... "
 if [ ! -f /etc/cron.d/openwb ]; then
-	sudo cp ${OPENWBBASEDIR}/data/config/openwb.cron /etc/cron.d/openwb
+	cp ${OPENWBBASEDIR}/data/config/openwb.cron /etc/cron.d/openwb
 	echo "installed"
 else
 	echo "ok"
@@ -40,21 +55,21 @@ fi
 echo "check mosquitto installation..."
 if [ ! -f /etc/mosquitto/conf.d/openwb.conf ] || ! sudo grep -Fq "persistent_client_expiration" /etc/mosquitto/mosquitto.conf; then
 	echo "updating mosquitto config file"
-	sudo cp ${OPENWBBASEDIR}/data/config/openwb.conf /etc/mosquitto/conf.d/openwb.conf
-	sudo service mosquitto restart
+	cp ${OPENWBBASEDIR}/data/config/openwb.conf /etc/mosquitto/conf.d/openwb.conf
+	service mosquitto restart
 fi
 
 #check for mosquitto_local instance
 if [ ! -f /etc/mosquitto/mosquitto_local.conf ]; then
 	echo "setting up mosquitto local instance"
-	sudo install -d -m 0755 -o root -g root /etc/mosquitto/conf_local.d/
-	sudo install -d -m 0755 -o mosquitto -g root /var/lib/mosquitto_local
-	sudo cp -a ${OPENWBBASEDIR}/data/config/mosquitto_local.conf /etc/mosquitto/mosquitto_local.conf
-	sudo cp -a ${OPENWBBASEDIR}/data/config/openwb_local.conf /etc/mosquitto/conf_local.d/
+	install -d -m 0755 -o root -g root /etc/mosquitto/conf_local.d/
+	install -d -m 0755 -o mosquitto -g root /var/lib/mosquitto_local
+	cp -a "$OPENWBBASEDIR/data/config/mosquitto_local.conf" /etc/mosquitto/mosquitto_local.conf
+	cp -a "$OPENWBBASEDIR/data/config/openwb_local.conf" /etc/mosquitto/conf_local.d/
 
-	sudo cp ${OPENWBBASEDIR}/data/config/mosquitto_local_init /etc/init.d/mosquitto_local
-	sudo chown root.root /etc/init.d/mosquitto_local
-	sudo chmod 755 /etc/init.d/mosquitto_local
+	cp "$OPENWBBASEDIR/data/config/mosquitto_local_init" /etc/init.d/mosquitto_local
+	chown root:root /etc/init.d/mosquitto_local
+	chmod 755 /etc/init.d/mosquitto_local
 else
 	sudo cp -a ${OPENWBBASEDIR}/data/config/openwb_local.conf /etc/mosquitto/conf_local.d/
 fi
@@ -76,33 +91,26 @@ echo -n "replacing apache default page..."
 sudo cp ${OPENWBBASEDIR}/index.html /var/www/html/index.html
 echo "done"
 echo -n "fix upload limit..."
-if [ -d "/etc/php/7.3/" ]; then
-	sudo /bin/su -c "echo 'upload_max_filesize = 300M' > /etc/php/7.3/apache2/conf.d/20-uploadlimit.ini"
-	sudo /bin/su -c "echo 'post_max_size = 300M' >> /etc/php/7.3/apache2/conf.d/20-uploadlimit.ini"
-	echo "done (OS Buster)"
-elif [ -d "/etc/php/7.4/" ]; then
-	sudo /bin/su -c "echo 'upload_max_filesize = 300M' > /etc/php/7.4/apache2/conf.d/20-uploadlimit.ini"
-	sudo /bin/su -c "echo 'post_max_size = 300M' >> /etc/php/7.4/apache2/conf.d/20-uploadlimit.ini"
-	echo "done (OS Bullseye)"
-fi
+echo "upload_max_filesize = 300M
+post_max_size = 300M" > $(echo /etc/php/*/apache2/conf.d)/20-uploadlimit.ini
+echo "done"
 
 echo "installing python requirements..."
-sudo pip install -r ${OPENWBBASEDIR}/requirements.txt
+sudo -u "$OPENWB_USER" pip install -r "$OPENWBBASEDIR/requirements.txt"
 
 # echo "www-data ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/010_pi-nopasswd
 
 # chmod 777 ${OPENWBBASEDIR}/openwb.conf
 # chmod +x ${OPENWBBASEDIR}/modules/*
-chmod +x ${OPENWBBASEDIR}/runs/*
-chmod +x ${OPENWBBASEDIR}/*.sh
+chmod +x "$OPENWBBASEDIR"/runs/* "$OPENWBBASEDIR"/*.sh
 touch /var/log/openWB.log
-chmod 777 /var/log/openWB.log
+chown "$OPENWB_USER:$OPENWB_USER" /var/log/openWB.log
 
 echo "installing openwb2 system service..."
-sudo ln -s ${OPENWBBASEDIR}/data/config/openwb2.service /etc/systemd/system/openwb2.service
-sudo systemctl daemon-reload
-sudo systemctl enable openwb2.service
-sudo systemctl start openwb2.service
+ln -s ${OPENWBBASEDIR}/data/config/openwb2.service /etc/systemd/system/openwb2.service
+systemctl daemon-reload
+systemctl enable openwb2.service
+systemctl start openwb2.service
 
 echo "installation finished, now running atreboot.sh..."
 ${OPENWBBASEDIR}/runs/atreboot.sh

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+if [ $(id -u -n) != "openwb" ]
+then
+	echo "Re-running script ${BASH_SOURCE[0]} as user openwb"
+	exec sudo -u openwb bash "${BASH_SOURCE[0]}"
+fi
+
 OPENWBBASEDIR=$(cd `dirname $0`/../ && pwd)
 echo "atreboot.sh started"
 rm "${OPENWBBASEDIR}/ramdisk/bootdone"
@@ -64,7 +71,7 @@ echo "apt packages..."
 
 # check for other dependencies
 echo "python packages..."
-sudo pip3 install -r ${OPENWBBASEDIR}/requirements.txt
+pip3 install -r "$OPENWBBASEDIR/requirements.txt"
 
 # update version
 echo "version..."
@@ -123,11 +130,11 @@ echo "load versions..."
 # curl --connect-timeout 10 -s https://raw.githubusercontent.com/snaptec/openWB/stable/web/version > ${OPENWBBASEDIR}/ramdisk/vstable
 
 # update our local version
-sudo git -C ${OPENWBBASEDIR}/ show --pretty='format:%ci [%h]' | head -n1 > ${OPENWBBASEDIR}/web/lastcommit
+git -C "$OPENWBBASEDIR/" show --pretty='format:%ci [%h]' | head -n1 > "$OPENWBBASEDIR/web/lastcommit"
 # and record the current commit details
 commitId=`git -C ${OPENWBBASEDIR}/ log --format="%h" -n 1`
-echo $commitId > ${OPENWBBASEDIR}/ramdisk/currentCommitHash
-echo `git -C ${OPENWBBASEDIR}/ branch -a --contains $commitId | perl -nle 'm|.*origin/(.+).*|; print $1' | uniq | xargs` > ${OPENWBBASEDIR}/ramdisk/currentCommitBranches
+echo "$commitId" > ${OPENWBBASEDIR}/ramdisk/currentCommitHash
+git -C "$OPENWBBASEDIR/" branch -a --contains "$commitId" | perl -nle 'm|.*origin/(.+).*|; print $1' | uniq | xargs > "$OPENWBBASEDIR/ramdisk/currentCommitBranches"
 
 # set upload limit in php
 # echo -n "fix upload limit..."


### PR DESCRIPTION
Linux ist ein Mehrbenutzersystem und hat die Möglichkeit, dass man unterschiedliche Befehle als ein bestimmter Nutzer ausführen kann. Damit lassen sich Prozesse unterschiedlicher Nutzer voneinander isolieren.

Das System ist aus Sicherheitssicht sehr sinnvoll. So wäre es möglich, dass alle openWB-Prozesse als ein unpriviligierter Nutzer "openWB" laufen. Das bedeutet dann, dass diese Prozesse nicht (versehentlich oder mit (böser) Absicht) Systemdateien verändern können und damit das komplette Betriebssystem außer Gefecht setzen oder es ermöglichen, dass ein Angreifer das System übernimmt.

Natürlich kann man sich auch auf den Standpunkt stellen, dass das Berechtigungssystem den Aufwand nicht wert ist und einfach alles als Nutzer "root" ausführen. Dieser Sicht würde ich mich persönlich zwar nicht anschließen, aber es hätte immerhin den Vorteil, dass man sich über Berechtigungen keine Gedanken machen muss, weil immer alles geht.

Die Skripte, so wie sie aktuell laufen verbinden die Nachteile von beiden Varianten und nutzen keine Vorteile der jeweiligen Variante: Ein Teil der Skripte wird als root ausgeführt, ein Teil der Skripte als "pi". Wenn "root" was gemacht hat kann "pi" nicht darauf zugreifen, deswegen braucht es dann jede Menge `chmod 777` calls, oder `chown` oder `sudo`.

Aufrufe von `sudo` sind unmotiviert über den Code verteilt. Beispielsweise soll das Skript `openwb-install.sh` laut README als root ausgeführt werden. Trotzdem befinden sich vor jeder Menge Befehlen in diesem Skript `sudo`-Aufrufe. Warum? Es ist doch eh alles root?!

Anderes Beispiel:
In der `atreboot.sh` findet sich:
```bash
sudo git -C ${OPENWBBASEDIR}/ show --pretty='format:%ci [%h]' | head -n1 > ${OPENWBBASEDIR}/web/lastcommit
# [..]
echo `git -C ${OPENWBBASEDIR}/ branch -a --contains $commitId | perl -nle 'm|.*origin/(.+).*|; print $1' | uniq | xargs` > ${OPENWBBASEDIR}/ramdisk/currentCommitBranches
```
Der erste der beiden Git-Befehle wird mit `sudo` aufgerufen, der Zweite ohne. Es ist auch so schon merkwürdig, dass der git-Befehl mit `sudo` ist, aber noch verwunderlicher ist, dass es nichtmal einheitlich ist.

Ich finde es auch ungünstig, dass der Standardnutzer "pi" verwendet wird. Das ist nicht selbsterklärend und kann potentiell zu Konflikten führen, wenn man mit dem Nutzer noch etwas anderes machen will.

Mein Vorschlag:
Bei der Installation einen Nutzer "openwb" anlegen. Es werden grundsätzlich alle Scripte als dieser Nutzer ausgeführt, mit Ausnahme von Skripten die unbedingt etwas an der Systemkonfiguration ändern müssen.

Dieser PR könnte den Anfang machen. Für das erste erhält der Nutzer openwb uneingeschränkte sudo-Rechte. Das ist auf Dauer nicht Sinn der Sache, macht den Übergang vom aktuellen System zum openwb-Nutzer jedoch einfacher.

Das ganze ist ungetestet. Ich habe keinen Raspberry zum testen und damit das ganze in Docker funktioniert sind weitere Änderungen notwendig. Ich vermute, dass noch weitere Skripte angepasst werden müssen, aber ich blicke noch nicht ganz durch, welche Skripte alt sind und ohnehin gelöscht könnten.