### PR TITLE
upgrade GitHub Actions to python 3.9

### DIFF
--- a/.github/workflows/github-actions-python.yml
+++ b/.github/workflows/github-actions-python.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.5
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: "3.5"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Wäre ein Vorschlag auch mit den GitHub-Actions auf Python 3.9 zu gehen, wenn das die neue Min-Version für Python ist. Ist es das?