### PR TITLE
Issue 268 - PV-Ertrag falsch

### DIFF
--- a/packages/control/algorithm.py
+++ b/packages/control/algorithm.py
@@ -40,7 +40,7 @@ class Algorithm:
             evu_counter = data.data.counter_data["all"].get_evu_counter()
             MainLogger().info(
                 "EVU-Punkt: Leistung[W] " + str(data.data.counter_data[evu_counter].data["get"]["power"]) +
-                ", Ströme[A] " + str(data.data.counter_data[evu_counter].data["get"]["currents"]))
+                ", Ströme[A] " + str(data.data.counter_data[evu_counter].data["get"].get("currents")))
             if not data.data.counter_data["all"].data["set"]["loadmanagement_available"]:
                 return
 

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -358,7 +358,7 @@ class Counter:
                 MainLogger().debug(str(self.data["set"]["consumption_left"]) +
                                    "W EVU-Leistung, die noch bezogen werden kann.")
             # Strom
-            self.data["set"]["currents_used"] = self.data["get"]["currents"]
+            self.data["set"]["currents_used"] = self.data["get"].get("currents")
         except Exception:
             MainLogger().exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
 

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -174,7 +174,7 @@ class Ev:
             if self.data["control_parameter"]["chargemode"] != self.charge_template.data["chargemode"]["selected"]:
                 mode_changed = True
 
-            # Die benötigte Stromstärke hat sich durch eine Änderung des Lademdous oder der Konfiguration geändert.
+            # Die benötigte Stromstärke hat sich durch eine Änderung des Lademodus oder der Konfiguration geändert.
             # Der Ladepunkt muss in der Regelung neu priorisiert werden.
             if self.data["control_parameter"]["required_current"] != required_current:
                 # Wenn im PV-Laden mit übrigem Überschuss geladen wird und dadurch die aktuelle Soll-Stromstärke über
@@ -774,5 +774,5 @@ class ChargeTemplate:
             Required Current, Chargemode: int, str
                 Therotisch benötigter Strom, Ladmodus
         """
-        message = "Keine Ladung, da der Lademdus Stop aktiv ist."
+        message = "Keine Ladung, da der Lademodus Stop aktiv ist."
         return 0, "stop", message

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -289,7 +289,7 @@ def _check_max_currents(counter, required_current_phases, phases, offset):
     try:
         loadmanagement = False
         counter_currents_used = data.data.counter_data[counter].data["set"].get("currents_used")
-        if counter_currents_used is None or counter_currents_used.len < 3:
+        if counter_currents_used is None or len(counter_currents_used) < 3:
             MainLogger().warning("Einzelwerte für Zähler-Phasenströme unbekannt")
             return False, 0, 0
         for phase in range(3):

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -205,7 +205,7 @@ def _loadmanagement_for_evu(required_power, required_current_phases, phases, off
                 max_current_overshoot = overshoot_one_phase
                 max_overshoot_phase = phase
         loadmanagement, overshoot_one_phase, phase = _check_unbalanced_load(
-            data.data.counter_data[evu_counter].data["set"]["currents_used"], offset)
+            data.data.counter_data[evu_counter].data["set"].get("currents_used"), offset)
         if loadmanagement:
             loadmanagement_all_conditions = True
             # Wenn phase -1 ist, wurde die maximale Gesamtleistung überschrittten und
@@ -288,10 +288,13 @@ def _check_max_currents(counter, required_current_phases, phases, offset):
         offset_current = 0
     try:
         loadmanagement = False
+        counter_currents_used = data.data.counter_data[counter].data["set"].get("currents_used")
+        if counter_currents_used is None or counter_currents_used.len < 3:
+            MainLogger().warning("Einzelwerte für Zähler-Phasenströme unbekannt")
+            return False, 0, 0
         for phase in range(3):
-            currents_used[phase] = data.data.counter_data[counter].data["set"]["currents_used"][phase] + \
-                required_current_phases[phase]
-            # Wird die maximal zulässige Stromstärke inklusive des Offsets eingehlaten?
+            currents_used[phase] = counter_currents_used[phase] + required_current_phases[phase]
+            # Wird die maximal zulässige Stromstärke inklusive des Offsets eingehalten?
             max_current_of_phase = data.data.counter_data[counter].data["config"]["max_currents"][phase]
             if (currents_used[phase] > max_current_of_phase - offset_current):
                 if ((currents_used[phase]-(max_current_of_phase - offset_current)) > max_current_overshoot):

--- a/web/themes/dark/processAllMqttMsg.js
+++ b/web/themes/dark/processAllMqttMsg.js
@@ -478,14 +478,14 @@ function processPvMessages(mqttTopic, mqttPayload) {
 		$('.pv-sum-power').text(pvWatt + ' ' + unitPrefix + unit);
 	} else if (mqttTopic == 'openWB/pv/get/daily_yield') {
 		var unit = "Wh";
-		var unitPrefix = "k";
+		var unitPrefix = "";
 		var pvDailyYield = parseFloat(mqttPayload);
 		if (isNaN(pvDailyYield)) {
 			pvDailyYield = 0;
 		}
 		if (pvDailyYield > 999) {
 			pvDailyYield = (pvDailyYield / 1000).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-			unitPrefix = "M";
+			unitPrefix = "k";
 		} else {
 			pvDailyYield = pvDailyYield.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 		}


### PR DESCRIPTION
Wie Det anmerkte, wird der PV-Ertrag in der GUI falsch (Faktor 1000) angezeigt.
Dieser Patch behebt das. MWh sind m.E. nicht nötig, Wh und kWh reicht m.E. als Tagesertrag