### PR TITLE
Fix wrong daily PV yield in dark WebUI (kWh instead of MWh)

### DIFF
--- a/web/themes/dark/processAllMqttMsg.js
+++ b/web/themes/dark/processAllMqttMsg.js
@@ -478,14 +478,14 @@ function processPvMessages(mqttTopic, mqttPayload) {
 		$('.pv-sum-power').text(pvWatt + ' ' + unitPrefix + unit);
 	} else if (mqttTopic == 'openWB/pv/get/daily_yield') {
 		var unit = "Wh";
-		var unitPrefix = "k";
+		var unitPrefix = "";
 		var pvDailyYield = parseFloat(mqttPayload);
 		if (isNaN(pvDailyYield)) {
 			pvDailyYield = 0;
 		}
 		if (pvDailyYield > 999) {
 			pvDailyYield = (pvDailyYield / 1000).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-			unitPrefix = "M";
+			unitPrefix = "k";
 		} else {
 			pvDailyYield = pvDailyYield.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 		}


### PR DESCRIPTION
Im "Dark Theme" wird ein um Faktor 1000 zu hoher PV-Ertag angezeigt, siehe Untermeldung zu #268 

Mit korrigierter Datei:
<img width="708" alt="image" src="https://user-images.githubusercontent.com/34947968/150153303-64522b81-741e-47a2-8433-7a945abbaa38.png">
