### PR TITLE
Missing phase currents

### DIFF
--- a/packages/control/algorithm.py
+++ b/packages/control/algorithm.py
@@ -40,7 +40,7 @@ class Algorithm:
             evu_counter = data.data.counter_data["all"].get_evu_counter()
             MainLogger().info(
                 "EVU-Punkt: Leistung[W] " + str(data.data.counter_data[evu_counter].data["get"]["power"]) +
-                ", Ströme[A] " + str(data.data.counter_data[evu_counter].data["get"]["currents"]))
+                ", Ströme[A] " + str(data.data.counter_data[evu_counter].data["get"].get("currents")))
             if not data.data.counter_data["all"].data["set"]["loadmanagement_available"]:
                 return
 
@@ -739,7 +739,7 @@ class Algorithm:
             if data.data.counter_data["all"].data["set"]["loadmanagement_active"] and len(overloaded_counters) != 0:
                 # Lastmanagement hat eingegriffen
                 MainLogger().debug("Aktuell kalkulierte Ströme am EVU-Punkt[A]: "+str(
-                    data.data.counter_data[evu_counter].data["set"]["currents_used"]))
+                    data.data.counter_data[evu_counter].data["set"].get("currents_used")))
                 MainLogger().warning(
                     "Für die Ladung an LP"+str(chargepoint.cp_num) +
                     " muss erst ein Ladepunkt mit gleicher/niedrigerer Priorität reduziert/gestoppt werden.")

--- a/packages/control/algorithm.py
+++ b/packages/control/algorithm.py
@@ -41,8 +41,6 @@ class Algorithm:
             MainLogger().info(
                 "EVU-Punkt: Leistung[W] " + str(data.data.counter_data[evu_counter].data["get"]["power"]) +
                 ", Ströme[A] " + str(data.data.counter_data[evu_counter].data["get"].get("currents")))
-            if not data.data.counter_data["all"].data["set"]["loadmanagement_available"]:
-                return
 
             # zuerst die PV-Überschuss-Ladung zurück nehmen
             MainLogger().info(

--- a/packages/control/chargepoint.py
+++ b/packages/control/chargepoint.py
@@ -273,6 +273,7 @@ class Chargepoint:
                         "plug_time": "0",
                         "rfid": 0,
                         "manual_lock": False,
+                        "loadmanagement_available": True,
                         "log": {"counter_at_plugtime": 0,
                                 "timestamp_start_charging": "0",
                                 "counter_at_mode_switch": 0,
@@ -361,7 +362,7 @@ class Chargepoint:
             Text, dass geladen werden kann oder warum nicht geladen werden kann.
         """
         try:
-            if data.data.counter_data["all"].data["set"]["loadmanagement_available"]:
+            if self.data["set"]["loadmanagement_available"]:
                 state = True
                 message = None
             else:

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -365,7 +365,8 @@ class Counter:
                 self.data["set"]["currents_used"] = self.data["get"]["currents"]
             except KeyError:
                 MainLogger().warning(f"Zähler {self.counter_num}: Einzelwerte für Zähler-Phasenströme unbekannt")
-                self.data["set"]["state_str"] = "Das Lastmanagement regelt nur anhand der Gesamtleistung, da keine Phasenströme ermittelt werden konnten."
+                self.data["set"]["state_str"] = "Das Lastmanagement regelt nur anhand der Gesamtleistung, da keine \
+                    Phasenströme ermittelt werden konnten."
                 Pub().pub("openWB/set/counter/"+str(self.counter_num) + "/set/state_str",
                           self.data["set"]["state_str"])
         except Exception:

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -11,7 +11,6 @@ class CounterAll:
 
     def __init__(self):
         self.data = {"set": {"loadmanagement_active": False,
-                             "loadmanagement_available": True,
                              "home_consumption": 0,
                              "invalid_home_consumption": 0,
                              "daily_yield_home_consumption": 0}}
@@ -340,15 +339,19 @@ class Counter:
     def setup_counter(self):
         # Zählvariablen vor dem Start der Regelung zurücksetzen
         try:
+            # Wenn der Zähler keine Werte liefert, darf nicht geladen werden.
+            connected_cps = data.data.counter_data["all"].get_chargepoints_of_counter(f'counter{self.counter_num}')
+            for cp in connected_cps:
+                if self.data["get"]["fault_state"] > 0:
+                    data.data.cp_data[cp].data["set"]["loadmanagement_available"] = False
+                else:
+                    data.data.cp_data[cp].data["set"]["loadmanagement_available"] = True
+            if self.data["get"]["fault_state"] > 0:
+                self.data["get"]["power"] = 0
+                return
+
             # Nur beim EVU-Zähler wird auch die maximale Leistung geprüft.
             if f'counter{self.counter_num}' == data.data.counter_data["all"].get_evu_counter():
-                # Wenn der EVU-Zähler keine Werte liefert, darf nicht geladen werden.
-                if self.data["get"]["fault_state"] > 0:
-                    data.data.counter_data["all"].data["set"]["loadmanagement_available"] = False
-                    self.data["get"]["power"] = 0
-                    return
-                else:
-                    data.data.counter_data["all"].data["set"]["loadmanagement_available"] = True
                 # max Leistung
                 if self.data["get"]["power"] > 0:
                     self.data["set"]["consumption_left"] = self.data["config"]["max_total_power"] \
@@ -362,14 +365,9 @@ class Counter:
                 self.data["set"]["currents_used"] = self.data["get"]["currents"]
             except KeyError:
                 MainLogger().warning(f"Zähler {self.counter_num}: Einzelwerte für Zähler-Phasenströme unbekannt")
-                # Fehlermeldung nicht überschreiben
-                if self.data["get"]["fault_state"] < 2:
-                    self.data["get"]["fault_str"] = "Das Lastmanagement regelt nur anhand der Gesamtleistung, da keine Phasenströme ermittelt werden konnten."
-                    Pub().pub("openWB/set/counter/"+str(self.counter_num) + "/get/fault_str",
-                              self.data["get"]["fault_str"])
-                    self.data["get"]["fault_state"] = 1
-                    Pub().pub("openWB/set/counter/"+str(self.counter_num) + "/get/fault_state",
-                              self.data["get"]["fault_state"])
+                self.data["set"]["state_str"] = "Das Lastmanagement regelt nur anhand der Gesamtleistung, da keine Phasenströme ermittelt werden konnten."
+                Pub().pub("openWB/set/counter/"+str(self.counter_num) + "/set/state_str",
+                          self.data["set"]["state_str"])
         except Exception:
             MainLogger().exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
 

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -302,19 +302,21 @@ def _check_max_currents(counter, required_current_phases, phases, offset):
                 if offset:
                     MainLogger().debug("Strom "+str(currents_used))
                     MainLogger().warning(
-                        f"Benoetigte Stromstaerke {required_current_phases} ueberschreitet unter Beachtung des Offsets die"
-                        f" zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
+                        f"Benoetigte Stromstaerke {required_current_phases} ueberschreitet unter Beachtung des Offsets"
+                        f" die zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
                         f" {max_current_overshoot}A.")
                 else:
                     MainLogger().debug("Strom "+str(currents_used))
                     MainLogger().warning(
-                        f"Benoetigte Stromstaerke {required_current_phases} ueberschreitet ohne Beachtung des Offsets die"
-                        f" zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
+                        f"Benoetigte Stromstaerke {required_current_phases} ueberschreitet ohne Beachtung des Offsets"
+                        f" die zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
                         f" {max_current_overshoot}A.")
             data.data.counter_data[counter].data["set"]["currents_used"] = currents_used
-            # Wenn Zähler geprüft werden, wird ohne Offset geprüft. Beim Runterregeln soll aber das Offset berücksichtigt
-            # werden, um Schwingen zu vermeiden.
-            return loadmanagement, max_current_overshoot + (300 / 230 / phases), currents_used.index(max(currents_used))+1
+            # Wenn Zähler geprüft werden, wird ohne Offset geprüft. Beim Runterregeln soll aber das Offset
+            # berücksichtigt werden, um Schwingen zu vermeiden.
+            return (loadmanagement,
+                    max_current_overshoot + (300 / 230 / phases),
+                    currents_used.index(max(currents_used))+1)
         except Exception:
             MainLogger().exception("Fehler im Lastmanagement-Modul")
             return False, 0, 0

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -308,7 +308,7 @@ def _check_max_currents(counter, required_current_phases, phases, offset):
                 else:
                     MainLogger().debug("Strom "+str(currents_used))
                     MainLogger().warning(
-                        "'Benoetigte Stromstaerke {required_current_phases} ueberschreitet ohne Beachtung des Offsets die"
+                        f"Benoetigte Stromstaerke {required_current_phases} ueberschreitet ohne Beachtung des Offsets die"
                         f" zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
                         f" {max_current_overshoot}A.")
             data.data.counter_data[counter].data["set"]["currents_used"] = currents_used

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -205,7 +205,7 @@ def _loadmanagement_for_evu(required_power, required_current_phases, phases, off
                 max_current_overshoot = overshoot_one_phase
                 max_overshoot_phase = phase
         loadmanagement, overshoot_one_phase, phase = _check_unbalanced_load(
-            data.data.counter_data[evu_counter].data["set"]["currents_used"], offset)
+            data.data.counter_data[evu_counter].data["set"].get("currents_used"), offset)
         if loadmanagement:
             loadmanagement_all_conditions = True
             # Wenn phase -1 ist, wurde die maximale Gesamtleistung überschrittten und
@@ -280,46 +280,49 @@ def _check_max_currents(counter, required_current_phases, phases, offset):
     phase: int
         Phase, die den höchsten Strom verbraucht
     """
-    currents_used = [0, 0, 0]
-    max_current_overshoot = 0
-    if offset:
-        offset_current = 300 / 230 / phases
+    if data.data.counter_data[counter].data["set"].get("currents_used"):
+        currents_used = [0, 0, 0]
+        max_current_overshoot = 0
+        if offset:
+            offset_current = 300 / 230 / phases
+        else:
+            offset_current = 0
+        try:
+            loadmanagement = False
+            for phase in range(3):
+                currents_used[phase] = data.data.counter_data[counter].data["set"]["currents_used"][phase] + \
+                    required_current_phases[phase]
+                # Wird die maximal zulässige Stromstärke inklusive des Offsets eingehlaten?
+                max_current_of_phase = data.data.counter_data[counter].data["config"]["max_currents"][phase]
+                if (currents_used[phase] > max_current_of_phase - offset_current):
+                    if ((currents_used[phase]-(max_current_of_phase - offset_current)) > max_current_overshoot):
+                        max_current_overshoot = currents_used[phase] - max_current_of_phase
+                    loadmanagement = True
+            if max_current_overshoot > 0:
+                if offset:
+                    MainLogger().debug("Strom "+str(currents_used))
+                    MainLogger().warning(
+                        f"Benoetigte Stromstaerke {required_current_phases} ueberschreitet unter Beachtung des Offsets die"
+                        f" zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
+                        f" {max_current_overshoot}A.")
+                else:
+                    MainLogger().debug("Strom "+str(currents_used))
+                    MainLogger().warning(
+                        "'Benoetigte Stromstaerke {required_current_phases} ueberschreitet ohne Beachtung des Offsets die"
+                        f" zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
+                        f" {max_current_overshoot}A.")
+            data.data.counter_data[counter].data["set"]["currents_used"] = currents_used
+            # Wenn Zähler geprüft werden, wird ohne Offset geprüft. Beim Runterregeln soll aber das Offset berücksichtigt
+            # werden, um Schwingen zu vermeiden.
+            return loadmanagement, max_current_overshoot + (300 / 230 / phases), currents_used.index(max(currents_used))+1
+        except Exception:
+            MainLogger().exception("Fehler im Lastmanagement-Modul")
+            return False, 0, 0
     else:
-        offset_current = 0
-    try:
-        loadmanagement = False
-        for phase in range(3):
-            currents_used[phase] = data.data.counter_data[counter].data["set"]["currents_used"][phase] + \
-                required_current_phases[phase]
-            # Wird die maximal zulässige Stromstärke inklusive des Offsets eingehlaten?
-            max_current_of_phase = data.data.counter_data[counter].data["config"]["max_currents"][phase]
-            if (currents_used[phase] > max_current_of_phase - offset_current):
-                if ((currents_used[phase]-(max_current_of_phase - offset_current)) > max_current_overshoot):
-                    max_current_overshoot = currents_used[phase] - max_current_of_phase
-                loadmanagement = True
-        if max_current_overshoot > 0:
-            if offset:
-                MainLogger().debug("Strom "+str(currents_used))
-                MainLogger().warning(
-                    f"Benoetigte Stromstaerke {required_current_phases} ueberschreitet unter Beachtung des Offsets die"
-                    f" zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
-                    f" {max_current_overshoot}A.")
-            else:
-                MainLogger().debug("Strom "+str(currents_used))
-                MainLogger().warning(
-                    "'Benoetigte Stromstaerke {required_current_phases} ueberschreitet ohne Beachtung des Offsets die"
-                    f" zulaessige Stromstaerke an Phase {(currents_used.index(max(currents_used))+1)} um"
-                    f" {max_current_overshoot}A.")
-        data.data.counter_data[counter].data["set"]["currents_used"] = currents_used
-        # Wenn Zähler geprüft werden, wird ohne Offset geprüft. Beim Runterregeln soll aber das Offset berücksichtigt
-        # werden, um Schwingen zu vermeiden.
-        return loadmanagement, max_current_overshoot + (300 / 230 / phases), currents_used.index(max(currents_used))+1
-    except Exception:
-        MainLogger().exception("Fehler im Lastmanagement-Modul")
         return False, 0, 0
 
 
-def _check_unbalanced_load(currents_used, offset):
+def _check_unbalanced_load(currents_used, offset) -> Tuple[bool, float, float]:
     """ prüft, ob die Schieflastbegrenzug aktiv ist und ob diese eingehalten wird.
 
     Parameter
@@ -334,7 +337,7 @@ def _check_unbalanced_load(currents_used, offset):
     max_current_overshoot: maximale Überschreitung der Stromstärke
     int: Phase, die den höchsten Strom verbraucht
     """
-    if data.data.general_data["general"].data["chargemode_config"]["unbalanced_load"]:
+    if data.data.general_data["general"].data["chargemode_config"]["unbalanced_load"] and currents_used:
         max_current_overshoot = 0
         if offset:
             offset_current = 1
@@ -349,7 +352,7 @@ def _check_unbalanced_load(currents_used, offset):
                 max_current = 0
             if ((max_current - min_current) <= data.data.general_data["general"].data["chargemode_config"][
                     "unbalanced_load_limit"] - offset_current):
-                return False, None, 0
+                return False, 0, 0
             else:
                 max_current_overshoot = (
                     max_current - min_current) - \
@@ -360,4 +363,4 @@ def _check_unbalanced_load(currents_used, offset):
             MainLogger().exception("Fehler im Lastmanagement-Modul")
             return False, 0, 0
     else:
-        return False, None, 0
+        return False, 0, 0

--- a/packages/helpermodules/graph.py
+++ b/packages/helpermodules/graph.py
@@ -21,14 +21,15 @@ class Graph:
             dataline = {"timestamp": int(
                 time.time()), "time": datetime.datetime.today().strftime("%H:%M:%S")}
             evu_counter = data.data.counter_data["all"].get_evu_counter()
-            if data.data.counter_data["all"].data["set"]["loadmanagement_available"]:
+            if data.data.counter_data[evu_counter].data["get"]["fault_state"] == 0:
                 dataline.update({"grid": _convert_to_kW(
                     data.data.counter_data[evu_counter].data["get"]["power"])})
             for c in data.data.counter_data:
                 if "counter" in c and evu_counter not in c:
                     counter = data.data.counter_data[c]
-                    dataline.update({"counter"+str(counter.counter_num) +
-                                     "-power": _convert_to_kW(counter.data["get"]["power"])})
+                    if counter.data["get"]["fault_state"] == 0:
+                        dataline.update({"counter"+str(counter.counter_num) +
+                                         "-power": _convert_to_kW(counter.data["get"]["power"])})
             dataline.update(
                 {"house-power": _convert_to_kW(data.data.counter_data["all"].data["set"]["home_consumption"])})
             dataline.update(
@@ -40,9 +41,10 @@ class Graph:
                 for cp in data.data.cp_data:
                     if "cp" in cp:
                         chargepoint = data.data.cp_data[cp]
-                        dataline.update(
-                            {"cp" + str(chargepoint.cp_num) +
-                             "-power": _convert_to_kW(chargepoint.data["get"]["power"])})
+                        if chargepoint.data["get"]["fault_state"] == 0:
+                            dataline.update(
+                                {"cp" + str(chargepoint.cp_num) +
+                                 "-power": _convert_to_kW(chargepoint.data["get"]["power"])})
                         # if chargepoint.data["get"]["connected_vehicle"]["soc_config"]["configured"]:
                         #     dataline.update({"cp"+str(chargepoint.cp_num)+"-soc": _convert_to_kW(
                         #         chargepoint.data["get"]["connected_vehicle"]["soc"]["soc"])})

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -799,7 +799,8 @@ class SetData:
                     msg, float, [(0, float("inf")), (None, None)])
             elif "/get/fault_state" in msg.topic:
                 self._validate_value(msg, int, [(0, 2)])
-            elif "/get/fault_str" in msg.topic:
+            elif ("/get/fault_str" in msg.topic or
+                  "/set/state_str" in msg.topic):
                 self._validate_value(msg, str)
             elif "/get/power" in msg.topic:
                 self._validate_value(

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -95,6 +95,7 @@ class UpdateConfig:
                    "^openWB/counter/[0-9]+/get/imported$",
                    "^openWB/counter/[0-9]+/get/exported$",
                    "^openWB/counter/[0-9]+/set/consumption_left$",
+                   "^openWB/counter/[0-9]+/set/state_str$",
                    "^openWB/counter/[0-9]+/config/max_currents$",
                    "^openWB/counter/[0-9]+/config/max_total_power$",
 

--- a/packages/modules/alpha_ess/counter.py
+++ b/packages/modules/alpha_ess/counter.py
@@ -50,14 +50,10 @@ class AlphaEssCounter:
             0x0000, [ModbusDataType.INT_32]*3, unit=unit)]
 
         counter_state = CounterState(
-            voltages=[0, 0, 0],
             currents=currents,
-            powers=[0, 0, 0],
-            power_factors=[0, 0, 0],
             imported=imported,
             exported=exported,
-            power=power,
-            frequency=50
+            power=power
         )
         return counter_state
 

--- a/packages/modules/alpha_ess/inverter.py
+++ b/packages/modules/alpha_ess/inverter.py
@@ -45,8 +45,7 @@ class AlphaEssInverter:
             power, topic=topic_str, data=self.__simulation, prefix="pv")
         inverter_state = InverterState(
             power=power,
-            counter=counter,
-            currents=[0, 0, 0]
+            counter=counter
         )
         self.__store.set(inverter_state)
 

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -20,16 +20,14 @@ class CounterState:
                  power_factors: List[float] = None,
                  frequency: float = 50):
         if voltages is None:
-            voltages = [0]*3
+            voltages = [0.0]*3
         self.voltages = voltages
-        if currents is None:
-            currents = [0]*3
         self.currents = currents
         if powers is None:
-            powers = [0]*3
+            powers = [0.0]*3
         self.powers = powers
         if power_factors is None:
-            power_factors = [0]*3
+            power_factors = [0.0]*3
         self.power_factors = power_factors
         self.imported = imported
         self.exported = exported
@@ -45,7 +43,7 @@ class InverterState:
         currents: List[float] = None,
     ):
         if currents is None:
-            currents = [0]*3
+            currents = [0.0]*3
         self.currents = currents
         self.power = power
         self.counter = counter
@@ -68,13 +66,13 @@ class ChargepointState:
                  charge_state: bool = False,
                  plug_state: bool = False):
         if voltages is None:
-            voltages = [0]*3
+            voltages = [0.0]*3
         self.voltages = voltages
         if currents is None:
-            currents = [0]*3
+            currents = [0.0]*3
         self.currents = currents
         if power_factors is None:
-            power_factors = [0]*3
+            power_factors = [0.0]*3
         self.power_factors = power_factors
         self.imported = imported
         self.exported = exported

--- a/packages/modules/common/store/_counter.py
+++ b/packages/modules/common/store/_counter.py
@@ -10,12 +10,13 @@ class CounterValueStoreRamdisk(ValueStore[CounterState]):
     def set(self, counter_state: CounterState):
         try:
             files.evu.voltages.write(counter_state.voltages)
-            files.evu.currents.write(counter_state.currents)
+            if counter_state.currents:
+                files.evu.currents.write(counter_state.currents)
             files.evu.powers_import.write(counter_state.powers)
             files.evu.power_factors.write(counter_state.power_factors)
             files.evu.energy_import.write(counter_state.imported)
             files.evu.energy_export.write(counter_state.exported)
-            files.evu.power_import.write(counter_state.power)
+            files.evu.power_import.write(int(counter_state.power))
             files.evu.frequency.write(counter_state.frequency)
             log.MainLogger().info('EVU Watt: ' + str(counter_state.power))
             log.MainLogger().info('EVU Bezug: ' + str(counter_state.imported))
@@ -31,7 +32,8 @@ class CounterValueStoreBroker(ValueStore[CounterState]):
     def set(self, counter_state: CounterState):
         try:
             pub_to_broker("openWB/set/counter/" + str(self.num) + "/get/voltages", counter_state.voltages, 2)
-            pub_to_broker("openWB/set/counter/" + str(self.num) + "/get/currents", counter_state.currents, 2)
+            if counter_state.currents:
+                pub_to_broker("openWB/set/counter/" + str(self.num) + "/get/currents", counter_state.currents, 2)
             pub_to_broker("openWB/set/counter/" + str(self.num) + "/get/powers", counter_state.powers, 2)
             pub_to_broker("openWB/set/counter/" + str(self.num) + "/get/power_factors", counter_state.power_factors, 2)
             pub_to_broker("openWB/set/counter/" + str(self.num) + "/get/imported", counter_state.imported)

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -75,8 +75,7 @@ class FroniusInverter:
 
         inverter_state = InverterState(
             power=power,
-            counter=counter,
-            currents=[0, 0, 0]
+            counter=counter
         )
         self.__store.set(inverter_state)
         # Rückgabe der Leistung des ersten WR ohne Vorzeichenumkehr

--- a/packages/modules/json/inverter.py
+++ b/packages/modules/json/inverter.py
@@ -45,8 +45,7 @@ class JsonInverter:
                 power, topic=topic_str, data=self.simulation, prefix="pv")
             inverter_state = InverterState(
                 power=power,
-                counter=counter,
-                currents=[0, 0, 0]
+                counter=counter
             )
         else:
             counter = jq.compile(config["jq_counter"]).input(response).first()


### PR DESCRIPTION
PR zu Issue #282 ausgehend vom PR #285:
Um zu erkennen, dass das Modul keine Phasenströme liefert, werden diese nicht mit einem Standardwert gefüllt. Das Topic existiert dann nicht. Wenn keine Phasenströme vorhanden sind, wird im jeweiligen Zähler-Status eine Statusmeldung angezeigt, dass das LM nur mit der Gesamtleistung arbeitet.
Außerdem wurde überarbeitet, dass wenn ein Zähler einen Fehler liefert, alle nachfolgenden Ladepunkte gesperrt werden.