### PR TITLE
fix fronius counter types

### DIFF
--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -335,7 +335,7 @@ class Command:
             "."+payload["data"]["deviceType"]+"."+payload["data"]["type"], "modules")
         component_default = component.get_default_config()
         component_default["id"] = new_id
-        if payload["data"]["type"] == "counter":
+        if "counter" in payload["data"]["type"]:
             try:
                 data.data.counter_data["all"].hierarchy_add_item_below(
                     "counter"+str(new_id), data.data.counter_data["all"].get_evu_counter())

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -568,15 +568,22 @@ class ProcessBrokerBranch:
                 Pub().pub(msg.topic, "")
                 if "openWB/system/device/" in msg.topic and "component" in msg.topic and "config" in msg.topic:
                     payload = json.loads(str(msg.payload.decode("utf-8")))
-                    if payload["type"] == "counter":
-                        data.data.counter_data["all"].hierarchy_remove_item("counter"+str(payload["id"]))
-                    if payload["type"] == "inverter":
-                        module_branch = "openWB/pv/"+str(payload["id"])
-                    else:
-                        module_branch = "openWB/"+payload["type"]+"/"+str(payload["id"])
-                    client.subscribe(module_branch+"/#", 2)
+                    topic = self.__type_topic_mapping(payload["type"])
+                    if topic == "counter":
+                        data.data.counter_data["all"].hierarchy_remove_item(topic+str(payload["id"]))
+                    client.subscribe("openWB/"+topic+"/"+str(payload["id"])+"/#", 2)
         except Exception:
             MainLogger().exception("Fehler im Command-Modul")
+
+    def __type_topic_mapping(self, component_type: str) -> str:
+        if "bat" in component_type:
+            return "bat"
+        elif "counter" in component_type:
+            return "counter"
+        elif "inverter" in component_type:
+            return "pv"
+        else:
+            return component_type
 
     def __on_message_max_id(self, client, userdata, msg):
         try:

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -49,8 +49,6 @@ class FaultState(Exception):
                 pub.pub_single(prefix + "aultState", self.fault_state.value)
             else:
                 topic = self.__type_topic_mapping(component_info.type)
-                if topic.startswith("counter"):
-                    topic = "counter"
                 pub.Pub().pub(
                     "openWB/set/" + topic + "/" + str(component_info.id) + "/get/fault_str", self.fault_str)
                 pub.Pub().pub(
@@ -59,7 +57,9 @@ class FaultState(Exception):
             log.MainLogger().exception("Fehler im Modul fault_state")
 
     def __type_topic_mapping(self, component_type: str) -> str:
-        if "counter" in component_type:
+        if "bat" in component_type:
+            return "bat"
+        elif "counter" in component_type:
             return "counter"
         elif "inverter" in component_type:
             return "pv"

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -49,6 +49,8 @@ class FaultState(Exception):
                 pub.pub_single(prefix + "aultState", self.fault_state.value)
             else:
                 topic = self.__type_topic_mapping(component_info.type)
+                if topic.startswith("counter"):
+                    topic = "counter"
                 pub.Pub().pub(
                     "openWB/set/" + topic + "/" + str(component_info.id) + "/get/fault_str", self.fault_str)
                 pub.Pub().pub(


### PR DESCRIPTION
Durch die Unterscheidung der Zählertypen bei Fronius gibt es in den Modulen nicht nur den Typ `counter`, sondern `counter_sm` und `counter_s0`. Bisher sind mir 2 Stellen aufgefallen, die damit nicht umgehen können:
- Beim Anlegen der Komponenten ist die Prüfung auf `type == 'counter'` zu strikt. – packages/helpermodules/command.py
- Das Veröffentlichen des Fehlerstatus auf dem MQTT-Server trifft nicht. – packages/modules/common/fault_state.py