### PR TITLE
catch file not fount error for graph logfiles

### DIFF
--- a/packages/helpermodules/measurement_log.py
+++ b/packages/helpermodules/measurement_log.py
@@ -171,13 +171,21 @@ def save_log(folder):
 
 
 def get_daily_log(date: str):
-    with open(str(Path(__file__).resolve().parents[2] / "data"/"daily_log"/(date+".json")), "r") as jsonFile:
-        return json.load(jsonFile)
+    try:
+        with open(str(Path(__file__).resolve().parents[2] / "data"/"daily_log"/(date+".json")), "r") as jsonFile:
+            return json.load(jsonFile)
+    except FileNotFoundError:
+        pass
+    return []
 
 
 def get_monthly_log(date: str):
-    with open(str(Path(__file__).resolve().parents[2] / "data"/"monthly_log"/(date+".json")), "r") as jsonFile:
-        return json.load(jsonFile)
+    try:
+        with open(str(Path(__file__).resolve().parents[2] / "data"/"monthly_log"/(date+".json")), "r") as jsonFile:
+            return json.load(jsonFile)
+    except FileNotFoundError:
+        pass
+    return []
 
 
 def update_daily_yields():

--- a/packages/helpermodules/pub.py
+++ b/packages/helpermodules/pub.py
@@ -17,7 +17,6 @@ class PubSingleton:
         self.client.loop_start()
 
     def pub(self, topic: str, payload, qos: int = 0, retain: bool = True) -> None:
-        MainLogger().debug("publish: '%s'->'%s' qos:%d retain:%s" % (json.dumps(payload), topic, qos, retain))
         try:
             if payload == "":
                 self.client.publish(topic, payload, qos=qos, retain=retain)


### PR DESCRIPTION
Werden Diagrammdaten für einen Zeitraum abgerufen, für den keine Daten existieren, wurde im Gui bis jetzt eine unschöne Fehlermeldung angezeigt. Mit diesem PR wird ein FileNotFoundError abgefangen und stattdessen eine leere Liste zurückgegeben.