### PR TITLE
Use built-in python logger

### DIFF
--- a/packages/control/chargelog.py
+++ b/packages/control/chargelog.py
@@ -1,9 +1,9 @@
 import json
+import logging
 import math
 import pathlib
 
 from control import data
-from helpermodules.log import MainLogger
 from helpermodules.pub import Pub
 from helpermodules import timecheck
 
@@ -14,6 +14,8 @@ from helpermodules import timecheck
 # "time": { "begin":"27.05.2021 07:43", "end": "27.05.2021 07:50", "time_charged": "1:34",
 # "data": {"range_charged": 34, "charged_since_mode_switch": 3400, "charged_since_plugged_counter": 5000,
 #          "power": 110000, "costs": 3,42} }}
+
+log = logging.getLogger(__name__)
 
 
 def collect_data(chargepoint):
@@ -32,8 +34,8 @@ def collect_data(chargepoint):
                 log_data["counter_at_plugtime"] = chargepoint.data["get"]["counter"]
                 Pub().pub("openWB/set/chargepoint/"+str(chargepoint.cp_num) +
                           "/set/log/counter_at_plugtime", log_data["counter_at_plugtime"])
-                MainLogger().debug("counter_at_plugtime " +
-                                   str(chargepoint.data["get"]["counter"]))
+                log.debug("counter_at_plugtime " +
+                          str(chargepoint.data["get"]["counter"]))
             # Bisher geladene Energie ermitteln
             log_data["charged_since_plugged_counter"] = chargepoint.data["get"]["counter"] - \
                 log_data["counter_at_plugtime"]
@@ -46,8 +48,8 @@ def collect_data(chargepoint):
                 log_data["counter_at_mode_switch"] = chargepoint.data["get"]["counter"]
                 Pub().pub("openWB/set/chargepoint/"+str(chargepoint.cp_num) +
                           "/set/log/counter_at_mode_switch", log_data["counter_at_mode_switch"])
-                MainLogger().debug("counter_at_mode_switch " +
-                                   str(chargepoint.data["get"]["counter"]))
+                log.debug("counter_at_mode_switch " +
+                          str(chargepoint.data["get"]["counter"]))
             # Bei einem Wechsel das Lademodus wird ein neuer Logeintrag erstellt.
             if chargepoint.data["get"]["charge_state"]:
                 if log_data["timestamp_start_charging"] == "0":
@@ -56,9 +58,9 @@ def collect_data(chargepoint):
                               "/set/log/timestamp_start_charging", log_data["timestamp_start_charging"])
                 log_data["charged_since_mode_switch"] = chargepoint.data["get"]["counter"] - \
                     log_data["counter_at_mode_switch"]
-                MainLogger().debug("charged_since_mode_switch " +
-                                   str(log_data["charged_since_mode_switch"])+" counter " +
-                                   str(chargepoint.data["get"]["counter"]))
+                log.debug("charged_since_mode_switch " +
+                          str(log_data["charged_since_mode_switch"])+" counter " +
+                          str(chargepoint.data["get"]["counter"]))
                 log_data["range_charged"] = log_data["charged_since_mode_switch"] / \
                     charging_ev.ev_template.data["average_consump"]*100
                 log_data["time_charged"] = timecheck.get_difference_to_now(
@@ -71,7 +73,7 @@ def collect_data(chargepoint):
                 Pub().pub("openWB/set/chargepoint/"+str(chargepoint.cp_num) +
                           "/set/log/time_charged", log_data["time_charged"])
     except Exception:
-        MainLogger().exception("Fehler im Ladelog-Modul")
+        log.exception("Fehler im Ladelog-Modul")
 
 
 def save_data(chargepoint, charging_ev, immediately=True, reset=False):
@@ -173,7 +175,7 @@ def save_data(chargepoint, charging_ev, immediately=True, reset=False):
 
         # json-Objekt in Datei einfügen
         (pathlib.Path(__file__).resolve(
-            ).parents[2] / "data"/"charge_log").mkdir(mode=0o755, parents=True, exist_ok=True)
+        ).parents[2] / "data"/"charge_log").mkdir(mode=0o755, parents=True, exist_ok=True)
         filepath = str(
             pathlib.Path(__file__).resolve().parents[2] / "data" / "charge_log" /
             (timecheck.create_timestamp_YYYYMM() + ".json"))
@@ -214,7 +216,7 @@ def save_data(chargepoint, charging_ev, immediately=True, reset=False):
         Pub().pub("openWB/set/chargepoint/"+str(chargepoint.cp_num) +
                   "/set/log/time_charged", log_data["time_charged"])
     except Exception:
-        MainLogger().exception("Fehler im Ladelog-Modul")
+        log.exception("Fehler im Ladelog-Modul")
 
 
 def get_log_data(request):
@@ -235,7 +237,7 @@ def get_log_data(request):
             with open(filepath, "r", encoding="utf-8") as json_file:
                 chargelog = json.load(json_file)
         except FileNotFoundError:
-            MainLogger().debug("Kein Ladelog für %s gefunden!" % (str(request)))
+            log.debug("Kein Ladelog für %s gefunden!" % (str(request)))
             return log_data
         # Liste mit gefilterten Einträgen erstellen
         for entry in chargelog:
@@ -319,7 +321,7 @@ def get_log_data(request):
                 "costs": costs,
             }
     except Exception:
-        MainLogger().exception("Fehler im Ladelog-Modul")
+        log.exception("Fehler im Ladelog-Modul")
     return log_data
 
 
@@ -354,7 +356,7 @@ def reset_data(chargepoint, charging_ev, immediately=True):
                   "/set/log/charged_since_plugged_counter", log_data["charged_since_plugged_counter"])
 
     except Exception:
-        MainLogger().exception("Fehler im Ladelog-Modul")
+        log.exception("Fehler im Ladelog-Modul")
 
 
 def truncate(number, decimals=0):
@@ -372,4 +374,4 @@ def truncate(number, decimals=0):
         factor = 10.0 ** decimals
         return math.trunc(number * factor) / factor
     except Exception:
-        MainLogger().exception("Fehler im Ladelog-Modul")
+        log.exception("Fehler im Ladelog-Modul")

--- a/packages/control/chargelog.py
+++ b/packages/control/chargelog.py
@@ -247,7 +247,7 @@ def get_log_data(request):
                     len(request["filter"]["chargepoint"]["id"]) > 0 and
                     entry["chargepoint"]["id"] not in request["filter"]["chargepoint"]["id"]
                 ):
-                    MainLogger().debug(
+                    log.debug(
                         "Verwerfe Eintrag wegen Ladepunkt ID: %s != %s" %
                         (str(entry["chargepoint"]["id"]), str(request["filter"]["chargepoint"]["id"]))
                     )
@@ -257,7 +257,7 @@ def get_log_data(request):
                     len(request["filter"]["vehicle"]["id"]) > 0 and
                     entry["vehicle"]["id"] not in request["filter"]["vehicle"]["id"]
                 ):
-                    MainLogger().debug(
+                    log.debug(
                         "Verwerfe Eintrag wegen Fahrzeug ID: %s != %s" %
                         (str(entry["vehicle"]["id"]), str(request["filter"]["vehicle"]["id"]))
                     )
@@ -267,7 +267,7 @@ def get_log_data(request):
                     len(request["filter"]["vehicle"]["rfid"]) > 0 and
                     entry["vehicle"]["rfid"] not in request["filter"]["vehicle"]["rfid"]
                 ):
-                    MainLogger().debug(
+                    log.debug(
                         "Verwerfe Eintrag wegen RFID Tag: %s != %s" %
                         (str(entry["vehicle"]["rfid"]), str(request["filter"]["vehicle"]["rfid"]))
                     )
@@ -277,7 +277,7 @@ def get_log_data(request):
                     len(request["filter"]["vehicle"]["chargemode"]) > 0 and
                     entry["vehicle"]["chargemode"] not in request["filter"]["vehicle"]["chargemode"]
                 ):
-                    MainLogger().debug(
+                    log.debug(
                         "Verwerfe Eintrag wegen Lademodus: %s != %s" %
                         (str(entry["vehicle"]["chargemode"]), str(request["filter"]["vehicle"]["chargemode"]))
                     )
@@ -286,7 +286,7 @@ def get_log_data(request):
                     "prio" in request["filter"]["vehicle"] and
                     request["filter"]["vehicle"]["prio"] is not entry["vehicle"]["prio"]
                 ):
-                    MainLogger().debug(
+                    log.debug(
                         "Verwerfe Eintrag wegen Priorität: %s != %s" %
                         (str(entry["vehicle"]["prio"]), str(request["filter"]["vehicle"]["prio"]))
                     )

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -1,10 +1,13 @@
 """Zähler-Logik
 """
+import logging
 from typing import Callable, Dict, List
+
 from control import data
-from helpermodules.log import MainLogger
 from helpermodules.pub import Pub
 from modules.common.component_type import ComponentType
+
+log = logging.getLogger(__name__)
 
 
 class CounterAll:
@@ -31,7 +34,7 @@ class CounterAll:
             else:
                 raise TypeError
         except Exception:
-            MainLogger().error(
+            log.error(
                 "Ohne Konfiguration eines EVU-Zählers an der Spitze der Hierarchie ist keine Regelung möglich.")
             raise
 
@@ -39,7 +42,7 @@ class CounterAll:
         try:
             Pub().pub("openWB/set/counter/set/loadmanagement_active", self.data["set"]["loadmanagement_active"])
         except Exception:
-            MainLogger().exception("Fehler in der allgemeinen Zähler-Klasse")
+            log.exception("Fehler in der allgemeinen Zähler-Klasse")
 
     def calc_home_consumption(self) -> None:
         try:
@@ -71,7 +74,7 @@ class CounterAll:
             Pub().pub("openWB/set/counter/set/invalid_home_consumption",  self.data["set"]["invalid_home_consumption"])
             Pub().pub("openWB/set/counter/set/home_consumption", self.data["set"]["home_consumption"])
         except Exception:
-            MainLogger().exception("Fehler in der allgemeinen Zähler-Klasse")
+            log.exception("Fehler in der allgemeinen Zähler-Klasse")
 
     def calc_daily_yield_home_consumption(self):
         """ berechnet die heute im Haus verbrauchte Energie.
@@ -97,7 +100,7 @@ class CounterAll:
             Pub().pub("openWB/set/counter/set/daily_yield_home_consumption", daily_yield_home_consumption)
             self.data["set"]["daily_yield_home_consumption"] = daily_yield_home_consumption
         except Exception:
-            MainLogger().exception("Fehler in der allgemeinen Zähler-Klasse")
+            log.exception("Fehler in der allgemeinen Zähler-Klasse")
 
     # Hierarchie analysieren
 
@@ -125,7 +128,7 @@ class CounterAll:
             self._get_all_cp_connected_to_counter(counter_object)
             return self.connected_chargepoints
         except Exception:
-            MainLogger().exception("Fehler in der allgemeinen Zähler-Klasse")
+            log.exception("Fehler in der allgemeinen Zähler-Klasse")
             return None
 
     def _get_all_cp_connected_to_counter(self, child):
@@ -145,7 +148,7 @@ class CounterAll:
                 elif len(child["children"]) != 0:
                     self._get_all_cp_connected_to_counter(child)
             except Exception:
-                MainLogger().exception("Fehler in der allgemeinen Zähler-Klasse")
+                log.exception("Fehler in der allgemeinen Zähler-Klasse")
 
     def get_counters_to_check(self, cp_num: int):
         """ ermittelt alle Zähler im Zweig des Ladepunkts.
@@ -160,7 +163,7 @@ class CounterAll:
             self.__get_all_counter_in_branch(self.data["get"]["hierarchy"][0], cp_num)
             return self.connected_counters
         except Exception:
-            MainLogger().exception("Fehler in der allgemeinen Zähler-Klasse")
+            log.exception("Fehler in der allgemeinen Zähler-Klasse")
             return None
 
     def get_entry_of_element(self, id_to_find: int) -> Dict:
@@ -321,7 +324,7 @@ class Counter:
                 "daily_yield_import": 0}}
             self.counter_num = index
         except Exception:
-            MainLogger().exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
+            log.exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
 
     def setup_counter(self):
         # Zählvariablen vor dem Start der Regelung zurücksetzen
@@ -345,31 +348,31 @@ class Counter:
                         - self.data["get"]["power"]
                 else:
                     self.data["set"]["consumption_left"] = self.data["config"]["max_total_power"]
-                MainLogger().debug(str(self.data["set"]["consumption_left"]) +
-                                   "W EVU-Leistung, die noch bezogen werden kann.")
+                log.debug(str(self.data["set"]["consumption_left"]) +
+                          "W EVU-Leistung, die noch bezogen werden kann.")
             # Strom
             try:
                 self.data["set"]["currents_used"] = self.data["get"]["currents"]
             except KeyError:
-                MainLogger().warning(f"Zähler {self.counter_num}: Einzelwerte für Zähler-Phasenströme unbekannt")
+                log.warning(f"Zähler {self.counter_num}: Einzelwerte für Zähler-Phasenströme unbekannt")
                 self.data["set"]["state_str"] = "Das Lastmanagement regelt nur anhand der Gesamtleistung, da keine \
                     Phasenströme ermittelt werden konnten."
                 Pub().pub("openWB/set/counter/"+str(self.counter_num) + "/set/state_str",
                           self.data["set"]["state_str"])
         except Exception:
-            MainLogger().exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
+            log.exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
 
     def put_stats(self):
         try:
             if f'counter{self.counter_num}' == data.data.counter_data["all"].get_evu_counter():
                 Pub().pub("openWB/set/counter/"+str(self.counter_num)+"/set/consumption_left",
                           self.data["set"]["consumption_left"])
-                MainLogger().debug(str(self.data["set"]["consumption_left"])+"W verbleibende EVU-Bezugs-Leistung")
+                log.debug(str(self.data["set"]["consumption_left"])+"W verbleibende EVU-Bezugs-Leistung")
         except Exception:
-            MainLogger().exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
+            log.exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
 
     def print_stats(self):
         try:
-            MainLogger().debug(str(self.data["set"]["consumption_left"])+"W verbleibende EVU-Bezugs-Leistung")
+            log.debug(str(self.data["set"]["consumption_left"])+"W verbleibende EVU-Bezugs-Leistung")
         except Exception:
-            MainLogger().exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))
+            log.exception("Fehler in der Zähler-Klasse von "+str(self.counter_num))

--- a/packages/control/cp_interruption.py
+++ b/packages/control/cp_interruption.py
@@ -1,11 +1,13 @@
 """ Modul, das die CP-Unterbrechung durchführt.
 """
+import logging
 import threading
 import time
 
-from helpermodules.log import MainLogger
 from helpermodules import pub
 from modules.cp import ip_evse
+
+log = logging.getLogger(__name__)
 
 cp_interruption_threads = {}
 
@@ -38,9 +40,9 @@ def thread_cp_interruption(cp_num, selected, config, duration):
             cp_interruption_threads["thread_cp"+str(cp_num)] = threading.Thread(
                 target=_perform_cp_interruption, args=(selected, config, duration))
             cp_interruption_threads["thread_cp"+str(cp_num)].start()
-            MainLogger().debug("Thread zur CP-Unterbrechung an LP"+str(cp_num)+" gestartet.")
+            log.debug("Thread zur CP-Unterbrechung an LP"+str(cp_num)+" gestartet.")
     except Exception:
-        MainLogger().exception("Fehler im Modul fuer die CP-Unterbrechung")
+        log.exception("Fehler im Modul fuer die CP-Unterbrechung")
 
 
 def _perform_cp_interruption(selected, config, duration):
@@ -57,4 +59,4 @@ def _perform_cp_interruption(selected, config, duration):
             id = config["id"]
             ip_evse.perform_cp_interruption(ip_address, id, duration)
     except Exception:
-        MainLogger().exception("Fehler im Modul fuer die CP-Unterbrechung")
+        log.exception("Fehler im Modul fuer die CP-Unterbrechung")

--- a/packages/control/data.py
+++ b/packages/control/data.py
@@ -2,10 +2,10 @@
 Dictionary: Zugriff erfolgt bei Dictionary über Keys, nicht über Indizes wie bei Listen. Das hat den Vorteil, dass
 Instanzen gelöscht werden können, der Zugriff aber nicht verändert werden musss.
 """
-
+import logging
 import threading
 
-from helpermodules.log import MainLogger
+log = logging.getLogger(__name__)
 
 data = None
 
@@ -252,7 +252,7 @@ class Data:
         self._print_dictionaries(self._optional_data)
         self._print_dictionaries(self._pv_data)
         self._print_dictionaries(self._system_data)
-        MainLogger().debug("\n")
+        log.debug("\n")
 
     def _print_dictionaries(self, data):
         """ gibt zu Debug-Zwecken für jeden Key im übergebenen Dictionary das Dictionary aus.
@@ -265,14 +265,14 @@ class Data:
             try:
                 if not isinstance(data[key], dict):
                     try:
-                        MainLogger().debug(key+"\n"+str(data[key].data))
+                        log.debug(key+"\n"+str(data[key].data))
                     except AttributeError:
                         # Devices haben kein data-Dict
                         pass
                 else:
-                    MainLogger().debug(key+"\n"+"Klasse fehlt")
+                    log.debug(key+"\n"+"Klasse fehlt")
             except Exception:
-                MainLogger().exception("Fehler im Data-Modul")
+                log.exception("Fehler im Data-Modul")
 
 
 def data_init():

--- a/packages/control/general.py
+++ b/packages/control/general.py
@@ -1,12 +1,13 @@
 """Allgemeine Einstellungen
 """
-
+import logging
 import random
 
 from control import data
-from helpermodules.log import MainLogger
 from helpermodules.pub import Pub
 from helpermodules import timecheck
+
+log = logging.getLogger(__name__)
 
 
 class General:
@@ -36,7 +37,7 @@ class General:
             else:
                 return self.data["chargemode_config"][chargemode]["phases_to_use"]
         except Exception:
-            MainLogger().exception("Fehler im General-Modul")
+            log.exception("Fehler im General-Modul")
             return 1
 
     def grid_protection(self):
@@ -62,8 +63,8 @@ class General:
                                   self.data["grid_protection_random_stop"])
                         Pub().pub("openWB/set/general/grid_protection_active",
                                   self.data["grid_protection_active"])
-                        MainLogger().info("Netzschutz aktiv! Frequenz: " +
-                                          str(data.data.counter_data[evu_counter].data["get"]["frequency"])+"Hz")
+                        log.info("Netzschutz aktiv! Frequenz: " +
+                                 str(data.data.counter_data[evu_counter].data["get"]["frequency"])+"Hz")
                     if 5180 < frequency < 5300:
                         self.data["grid_protection_random_stop"] = 0
                         self.data["grid_protection_timestamp"] = "0"
@@ -74,18 +75,18 @@ class General:
                                   self.data["grid_protection_random_stop"])
                         Pub().pub("openWB/set/general/grid_protection_active",
                                   self.data["grid_protection_active"])
-                        MainLogger().info("Netzschutz aktiv! Frequenz: " +
-                                          str(data.data.counter_data[evu_counter].data["get"]["frequency"])+"Hz")
+                        log.info("Netzschutz aktiv! Frequenz: " +
+                                 str(data.data.counter_data[evu_counter].data["get"]["frequency"])+"Hz")
                 else:
                     if 4962 < frequency < 5100:
                         self.data["grid_protection_active"] = False
                         Pub().pub("openWB/set/general/grid_protection_active",
                                   self.data["grid_protection_active"])
-                        MainLogger().info("Netzfrequenz wieder im normalen Bereich. Frequenz: " +
-                                          str(data.data.counter_data[evu_counter].data["get"]["frequency"])+"Hz")
+                        log.info("Netzfrequenz wieder im normalen Bereich. Frequenz: " +
+                                 str(data.data.counter_data[evu_counter].data["get"]["frequency"])+"Hz")
                         Pub().pub(
                             "openWB/set/general/grid_protection_timestamp", "0")
                         Pub().pub(
                             "openWB/set/general/grid_protection_random_stop", 0)
         except Exception:
-            MainLogger().exception("Fehler im General-Modul")
+            log.exception("Fehler im General-Modul")

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -1,9 +1,9 @@
 """Optionale Module
 """
-
+import logging
 from math import ceil  # Aufrunden
 
-from helpermodules.log import MainLogger
+log = logging.getLogger(__name__)
 
 
 class Optional:
@@ -11,7 +11,7 @@ class Optional:
         try:
             self.data = {"et": {"get": {}}}
         except Exception:
-            MainLogger().exception("Fehler im Optional-Modul")
+            log.exception("Fehler im Optional-Modul")
 
     def et_price_lower_than_limit(self):
         """ prüft, ob der aktuelle Strompreis unter der festgelegten Preisgrenze liegt.
@@ -29,7 +29,7 @@ class Optional:
                 return False
         except Exception:
             self.et_get_prices()
-            MainLogger().exception("Fehler im Optional-Modul")
+            log.exception("Fehler im Optional-Modul")
             return False
 
     def et_get_loading_hours(self, duration):
@@ -52,7 +52,7 @@ class Optional:
             ]
         except Exception:
             self.et_get_prices()
-            MainLogger().exception("Fehler im Optional-Modul")
+            log.exception("Fehler im Optional-Modul")
             return []
 
     def et_get_prices(self):
@@ -65,6 +65,6 @@ class Optional:
                 #     tibbergetprices.update_pricedata(
                 #         self.data["et"]["config"]["provider"]["token"], self.data["et"]["config"]["provider"]["id"])
                 # else:
-                MainLogger().error("Unbekannter Et-Provider.")
+                log.error("Unbekannter Et-Provider.")
         except Exception:
-            MainLogger().exception("Fehler im Optional-Modul")
+            log.exception("Fehler im Optional-Modul")

--- a/packages/control/phase_switch.py
+++ b/packages/control/phase_switch.py
@@ -1,12 +1,12 @@
 """ Modul, das die Phasenumschaltung durchführt.
 """
+import logging
 import threading
 import time
 
-from helpermodules.log import MainLogger
 from modules.common.abstract_chargepoint import AbstractChargepoint
 
-
+log = logging.getLogger(__name__)
 phase_switch_threads = {}
 
 
@@ -32,9 +32,9 @@ def thread_phase_switch(
             phase_switch_threads["thread_cp"+str(cp_num)] = threading.Thread(
                 target=_perform_phase_switch, args=(chargepoint_module, phases_to_use, duration, charge_state))
             phase_switch_threads["thread_cp"+str(cp_num)].start()
-            MainLogger().debug("Thread zur Phasenumschaltung an LP"+str(cp_num)+" gestartet.")
+            log.debug("Thread zur Phasenumschaltung an LP"+str(cp_num)+" gestartet.")
     except Exception:
-        MainLogger().exception("Fehler im Phasenumschaltungs-Modul")
+        log.exception("Fehler im Phasenumschaltungs-Modul")
 
 
 def _perform_phase_switch(
@@ -53,4 +53,4 @@ def _perform_phase_switch(
         if charge_state:
             time.sleep(1)
     except Exception:
-        MainLogger().exception("Fehler im Phasenumschaltungs-Modul")
+        log.exception("Fehler im Phasenumschaltungs-Modul")

--- a/packages/control/process.py
+++ b/packages/control/process.py
@@ -1,13 +1,15 @@
 """ Starten des Lade-Vorgangs
 """
+import logging
 import threading
 from typing import List
 
 from control import chargelog
 from control import chargepoint
 from control import data
-from helpermodules.log import MainLogger
 from helpermodules.pub import Pub
+
+log = logging.getLogger(__name__)
 
 
 class Process:
@@ -17,7 +19,7 @@ class Process:
     def process_algorithm_results(self) -> None:
         try:
             modules_threads = []  # type: List[threading.Thread]
-            MainLogger().debug("# Ladung starten.")
+            log.debug("# Ladung starten.")
             for cp in data.data.cp_data:
                 try:
                     if "cp" in cp:
@@ -47,7 +49,7 @@ class Process:
                                 "Ladevorgang läuft...")
                         modules_threads.append(self._start_charging(chargepoint))
                 except Exception:
-                    MainLogger().exception("Fehler im Process-Modul fuer Ladepunkt "+str(cp))
+                    log.exception("Fehler im Process-Modul fuer Ladepunkt "+str(cp))
 
             if modules_threads:
                 for thread in modules_threads:
@@ -59,7 +61,7 @@ class Process:
 
                 for thread in modules_threads:
                     if thread.is_alive():
-                        MainLogger().error(
+                        log.error(
                             thread.name +
                             " konnte nicht innerhalb des Timeouts die Werte senden.")
 
@@ -67,7 +69,7 @@ class Process:
             data.data.pv_data["all"].print_stats()
             data.data.counter_data[data.data.counter_data["all"].get_evu_counter()].put_stats()
         except Exception:
-            MainLogger().exception("Fehler im Process-Modul")
+            log.exception("Fehler im Process-Modul")
 
     def _update_state(self, chargepoint) -> None:
         """aktualisiert den Zustand des Ladepunkts.
@@ -90,11 +92,11 @@ class Process:
         if (charging_ev.data["control_parameter"]["timestamp_switch_on_off"] != "0" and
                 not chargepoint.data["get"]["charge_state"] and
                 data.data.pv_data["all"].data["set"]["reserved_evu_overhang"] == 0):
-            MainLogger().error("Reservierte Leistung kann am Algorithmus-Ende nicht 0 sein.")
+            log.error("Reservierte Leistung kann am Algorithmus-Ende nicht 0 sein.")
         if (chargepoint.data["set"]["charging_ev_data"].ev_template.data["prevent_switch_stop"] and
                 chargepoint.data["get"]["charge_state"] and
                 chargepoint.data["set"]["current"] == 0):
-            MainLogger().error(
+            log.error(
                 "LP"+str(chargepoint.cp_num)+": Ladung wurde trotz verhinderter Unterbrechung gestoppt.")
 
         # Wenn ein EV zugeordnet ist und die Phasenumschaltung aktiv ist, darf kein Strom gesetzt werden.
@@ -103,7 +105,7 @@ class Process:
 
         chargepoint.data["set"]["current"] = current
         Pub().pub("openWB/set/chargepoint/"+str(chargepoint.cp_num)+"/set/current", current)
-        MainLogger().info("LP"+str(chargepoint.cp_num)+": set current "+str(current)+" A")
+        log.info("LP"+str(chargepoint.cp_num)+": set current "+str(current)+" A")
 
     def _start_charging(self, chargepoint: chargepoint.Chargepoint) -> threading.Thread:
         return threading.Thread(target=chargepoint.chargepoint_module.set_current,

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -503,17 +503,17 @@ class Command:
             pub_error(payload, connection_id, "Die ID ist größer als die maximal vergebene ID.")
 
     def systemReboot(self, connection_id: str, payload: dict) -> None:
-        MainLogger().info("Reboot requested")
+        log.info("Reboot requested")
         parent_file = Path(__file__).resolve().parents[2]
         subprocess.run([str(parent_file / "runs" / "reboot.sh")])
 
     def systemShutdown(self, connection_id: str, payload: dict) -> None:
-        MainLogger().info("Shutdown requested")
+        log.info("Shutdown requested")
         parent_file = Path(__file__).resolve().parents[2]
         subprocess.run([str(parent_file / "runs" / "shutdown.sh")])
 
     def systemUpdate(self, connection_id: str, payload: dict) -> None:
-        MainLogger().info("Shutdown requested")
+        log.info("Shutdown requested")
         parent_file = Path(__file__).resolve().parents[2]
         subprocess.run([str(parent_file / "runs" / "update_self.sh")])
 

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -3,6 +3,7 @@
 
 import importlib
 import json
+import logging
 import subprocess
 from typing import Dict
 import paho.mqtt.client as mqtt
@@ -11,7 +12,6 @@ import time
 import traceback
 from pathlib import Path
 
-from helpermodules.log import MainLogger
 from helpermodules import measurement_log
 from helpermodules.pub import Pub
 from control import bridge
@@ -21,6 +21,8 @@ from control import data
 from control import ev
 from control import counter
 from modules.common.component_type import ComponentType, special_to_general_type_mapping, type_to_topic_mapping
+
+log = logging.getLogger(__name__)
 
 
 class Command:
@@ -44,7 +46,7 @@ class Command:
             self.__get_max_id_by_topic_id("ev_template", "vehicle/template/ev_template", 0)
             self.__get_max_id_by_topic_id("vehicle", "vehicle", 0)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __get_max_id_by_topic_id(self, id_topic: str, topic: str, default: int) -> None:
         """ ermittelt die maximale ID vom Broker """
@@ -52,7 +54,7 @@ class Command:
             max_id = ProcessBrokerBranch(topic).get_max_id(default)
             Pub().pub("openWB/set/command/max_id/"+id_topic, max_id)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __get_max_id_by_json_object(self, id_topic: str, topic: str, default: int) -> None:
         """ ermittelt die maximale ID vom Broker """
@@ -61,7 +63,7 @@ class Command:
             max_id = counter.get_max_id_in_hierarchy(hierarchy, default)
             Pub().pub("openWB/set/command/max_id/"+id_topic, max_id)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def sub_commands(self):
         """ abonniert alle Topics.
@@ -80,7 +82,7 @@ class Command:
             client.loop_forever()
             client.disconnect()
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def getserial(self):
         """ Extract serial from cpuinfo file
@@ -92,7 +94,7 @@ class Command:
                         return line[10:26]
                 return "0000000000000000"
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def on_connect(self, client, userdata, flags, rc):
         """ connect to broker and subscribe to set topics
@@ -100,7 +102,7 @@ class Command:
         try:
             client.subscribe("openWB/command/#", 2)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def on_message(self, client, userdata, msg):
         """ wartet auf eingehende Topics.
@@ -110,20 +112,20 @@ class Command:
                 if "todo" in msg.topic:
                     payload = json.loads(str(msg.payload.decode("utf-8")))
                     connection_id = msg.topic.split("/")[2]
-                    MainLogger().debug("Befehl: "+str(payload)+", Connection-ID: "+str(connection_id))
+                    log.debug("Befehl: "+str(payload)+", Connection-ID: "+str(connection_id))
                     # Methoden-Name = Befehl
                     try:
                         func = getattr(self, payload["command"])
                         with ErrorHandlingContext(payload, connection_id):
                             func(connection_id, payload)
                     except Exception:
-                        MainLogger().error("Zu dem Befehl wurde keine Methode gefunden.")
+                        log.error("Zu dem Befehl wurde keine Methode gefunden.")
                         pub_error(payload, connection_id, "Zu dem Befehl wurde keine Methode gefunden.")
                     Pub().pub(msg.topic, "")
                 elif "max_id" in msg.topic:
                     self.__process_max_id_topic(msg)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __process_max_id_topic(self, msg, no_log: bool = False) -> None:
         try:
@@ -134,15 +136,15 @@ class Command:
                 # Der Variablen-Name für die maximale ID setzt sich aus "max_id_" und dem Topic-Namen nach dem letzten /
                 # zusammen.
                 setattr(self, "max_id_"+var, payload)
-                MainLogger().debug("Max ID "+var+" "+str(payload))
+                log.debug("Max ID "+var+" "+str(payload))
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def addDevice(self, connection_id: str, payload: dict) -> None:
         """ sendet das Topic, zu dem ein neues Device erstellt werden soll.
         """
         new_id = self.max_id_device + 1
-        MainLogger().info(
+        log.info(
             "Neues Device vom Typ "+str(payload["data"]["type"])+" mit ID "+str(new_id)+" hinzugefügt.")
         dev = importlib.import_module("."+payload["data"]["type"]+".device", "modules")
         device_default = dev.get_default_config()
@@ -156,8 +158,8 @@ class Command:
         """ löscht ein Device.
         """
         if self.max_id_device >= payload["data"]["id"]:
-            MainLogger().info("Device mit ID " +
-                              str(payload["data"]["id"])+" gelöscht.")
+            log.info("Device mit ID " +
+                     str(payload["data"]["id"])+" gelöscht.")
             ProcessBrokerBranch(
                 "system/device/"+str(payload["data"]["id"])).remove_topics()
         else:
@@ -167,7 +169,7 @@ class Command:
         """ sendet das Topic, zu dem ein neuer Chargepoint erstellt werden soll.
         """
         new_id = self.max_id_hierarchy + 1
-        MainLogger().info(
+        log.info(
             "Neuer Ladepunkt mit ID "+str(new_id)+" wird hinzugefügt.")
         chargepoint_default = chargepoint.get_chargepoint_default()
         # chargepoint_default["id"] = new_id
@@ -195,7 +197,7 @@ class Command:
         """
         if self.max_id_hierarchy >= payload["data"]["id"]:
             data.data.counter_data["all"].hierarchy_remove_item(payload["data"]["id"])
-            MainLogger().info("Ladepunkt mit ID " + str(payload["data"]["id"])+" gelöscht.")
+            log.info("Ladepunkt mit ID " + str(payload["data"]["id"])+" gelöscht.")
             ProcessBrokerBranch("chargepoint/"+str(payload["data"]["id"])).remove_topics()
         else:
             pub_error(payload, connection_id, "Die ID ist größer als die maximal vergebene ID.")
@@ -204,7 +206,7 @@ class Command:
         """ sendet das Topic, zu dem eine neue Ladepunkt-Vorlage erstellt werden soll.
         """
         new_id = self.max_id_chargepoint_template + 1
-        MainLogger().info("Neue Ladepunkt-Vorlage mit ID "+str(new_id)+" hinzugefügt.")
+        log.info("Neue Ladepunkt-Vorlage mit ID "+str(new_id)+" hinzugefügt.")
         default = chargepoint.get_chargepoint_template_default()
         default["id"] = new_id
         Pub().pub("openWB/set/chargepoint/template/"+str(new_id), default)
@@ -217,8 +219,8 @@ class Command:
         """
         if self.max_id_chargepoint_template >= payload["data"]["id"]:
             if payload["data"]["id"] > 0:
-                MainLogger().info("Ladepunkt-Vorlage mit ID " +
-                                  str(payload["data"]["id"])+" gelöscht.")
+                log.info("Ladepunkt-Vorlage mit ID " +
+                         str(payload["data"]["id"])+" gelöscht.")
                 ProcessBrokerBranch("chargepoint/template/" +
                                     str(payload["data"]["id"])).remove_topics()
             else:
@@ -230,8 +232,8 @@ class Command:
         """ sendet das Topic, zu dem ein neuer Zielladen-Plan erstellt werden soll.
         """
         new_id = self.max_id_autolock_plan + 1
-        MainLogger().info("Neuer Autolock-Plan mit ID " + str(new_id) + " zu Template " +
-                          str(payload["data"]["template"]) + " hinzugefügt.")
+        log.info("Neuer Autolock-Plan mit ID " + str(new_id) + " zu Template " +
+                 str(payload["data"]["template"]) + " hinzugefügt.")
         default = chargepoint.get_autolock_plan_default()
         Pub().pub("openWB/set/chargepoint/template/"+str(payload["data"]
                                                          ["template"])+"/autolock/"+str(new_id), default)
@@ -242,7 +244,7 @@ class Command:
         """ löscht einen Zielladen-Plan.
         """
         if self.max_id_autolock_plan >= payload["data"]["plan"]:
-            MainLogger().info(
+            log.info(
                 "Autolock-Plan mit ID " + str(payload["data"]["plan"]) + " zu Template " +
                 str(payload["data"]["template"]) + " gelöscht.")
             Pub().pub(
@@ -256,7 +258,7 @@ class Command:
         """ sendet das Topic, zu dem eine neue Lade-Vorlage erstellt werden soll.
         """
         new_id = self.max_id_charge_template + 1
-        MainLogger().info("Neues Lade-Template mit ID "+str(new_id)+" hinzugefügt.")
+        log.info("Neues Lade-Template mit ID "+str(new_id)+" hinzugefügt.")
         charge_template_default = ev.get_charge_template_default()
         Pub().pub("openWB/set/vehicle/template/charge_template/" +
                   str(new_id), charge_template_default)
@@ -268,8 +270,8 @@ class Command:
         """
         if self.max_id_charge_template >= payload["data"]["id"]:
             if payload["data"]["id"] > 0:
-                MainLogger().info("Lade-Template mit ID " +
-                                  str(payload["data"]["id"])+" gelöscht.")
+                log.info("Lade-Template mit ID " +
+                         str(payload["data"]["id"])+" gelöscht.")
                 Pub().pub("openWB/vehicle/template/charge_template/" +
                           str(payload["data"]["id"]), "")
             else:
@@ -281,8 +283,8 @@ class Command:
         """ sendet das Topic, zu dem ein neuer Zielladen-Plan erstellt werden soll.
         """
         new_id = self.max_id_charge_template_scheduled_plan + 1
-        MainLogger().info("Neues Zielladen-Template mit ID " + str(new_id) + " zu Template " +
-                          str(payload["data"]["template"]) + " hinzugefügt.")
+        log.info("Neues Zielladen-Template mit ID " + str(new_id) + " zu Template " +
+                 str(payload["data"]["template"]) + " hinzugefügt.")
         charge_template_default = ev.get_charge_template_scheduled_plan_default()
         Pub().pub(
             "openWB/set/vehicle/template/charge_template/" + str(payload["data"]["template"]) +
@@ -296,7 +298,7 @@ class Command:
         """ löscht einen Zielladen-Plan.
         """
         if self.max_id_charge_template_scheduled_plan >= payload["data"]["plan"]:
-            MainLogger().info(
+            log.info(
                 "Zielladen-Template mit ID " + str(payload["data"]["plan"]) + " zu Template " +
                 str(payload["data"]["template"]) + " gelöscht.")
             Pub().pub(
@@ -310,8 +312,8 @@ class Command:
         """ sendet das Topic, zu dem ein neuer Zeitladen-Plan erstellt werden soll.
         """
         new_id = self.max_id_charge_template_time_charging_plan + 1
-        MainLogger().info("Neues Zeitladen-Template mit ID " + str(new_id) + " zu Template " +
-                          str(payload["data"]["template"]) + " hinzugefügt.")
+        log.info("Neues Zeitladen-Template mit ID " + str(new_id) + " zu Template " +
+                 str(payload["data"]["template"]) + " hinzugefügt.")
         time_charging_plan_default = ev.get_charge_template_time_charging_plan_default()
         Pub().pub(
             "openWB/set/vehicle/template/charge_template/" + str(payload["data"]["template"]) +
@@ -325,7 +327,7 @@ class Command:
         """ löscht einen Zeitladen-Plan.
         """
         if self.max_id_charge_template_time_charging_plan >= payload["data"]["plan"]:
-            MainLogger().info(
+            log.info(
                 "Zeitladen-Template mit ID " + str(payload["data"]["plan"]) + " zu Template " +
                 str(payload["data"]["template"]) + " gelöscht.")
             Pub().pub(
@@ -339,7 +341,7 @@ class Command:
         """ sendet das Topic, zu dem eine neue Komponente erstellt werden soll.
         """
         new_id = self.max_id_hierarchy + 1
-        MainLogger().info(
+        log.info(
             "Neue Komponente vom Typ"+str(payload["data"]["type"])+" mit ID "+str(new_id)+" hinzugefügt.")
         component = importlib.import_module(
             "."+payload["data"]["deviceType"]+"."+payload["data"]["type"], "modules")
@@ -373,7 +375,7 @@ class Command:
         """ löscht eine Komponente.
         """
         if self.max_id_hierarchy >= payload["data"]["id"]:
-            MainLogger().info("Komponente mit ID "+str(payload["data"]["id"])+" gelöscht.")
+            log.info("Komponente mit ID "+str(payload["data"]["id"])+" gelöscht.")
             branch = "system/device/"+str(payload["data"]["deviceId"])+"/component/"+str(payload["data"]["id"])
             ProcessBrokerBranch(branch).remove_topics()
         else:
@@ -383,7 +385,7 @@ class Command:
         """ sendet das Topic, zu dem ein neues EV-Template erstellt werden soll.
         """
         new_id = self.max_id_ev_template + 1
-        MainLogger().info("Neues EV-Template mit ID "+str(new_id)+" hinzugefügt.")
+        log.info("Neues EV-Template mit ID "+str(new_id)+" hinzugefügt.")
         ev_template_default = ev.get_ev_template_default()
         Pub().pub("openWB/set/vehicle/template/ev_template/" +
                   str(new_id), ev_template_default)
@@ -395,8 +397,8 @@ class Command:
         """
         if self.max_id_ev_template >= payload["data"]["id"]:
             if payload["data"]["id"] > 0:
-                MainLogger().info("EV-Template mit ID " +
-                                  str(payload["data"]["id"])+" gelöscht.")
+                log.info("EV-Template mit ID " +
+                         str(payload["data"]["id"])+" gelöscht.")
                 Pub().pub("openWB/vehicle/template/ev_template/" +
                           str(payload["data"]["id"]), "")
             else:
@@ -408,7 +410,7 @@ class Command:
         """ sendet das Topic, zu dem ein neues Vehicle erstellt werden soll.
         """
         new_id = self.max_id_vehicle + 1
-        MainLogger().info("Neues EV mit ID "+str(new_id)+" hinzugefügt.")
+        log.info("Neues EV mit ID "+str(new_id)+" hinzugefügt.")
         vehicle_default = ev.get_vehicle_default()
         for default in vehicle_default:
             Pub().pub("openWB/set/vehicle/"+str(new_id)+"/" +
@@ -426,7 +428,7 @@ class Command:
         """
         if self.max_id_vehicle >= payload["data"]["id"]:
             if payload["data"]["id"] > 0:
-                MainLogger().info(
+                log.info(
                     "EV mit ID "+str(payload["data"]["id"])+" gelöscht.")
                 Pub().pub("openWB/vehicle/"+str(payload["data"]["id"]), "")
                 ProcessBrokerBranch(
@@ -488,14 +490,14 @@ class Command:
     def addMqttBridge(self, connection_id: str, payload: dict,
                       bridge_default: dict = bridge.get_default_config()) -> None:
         new_id = self.max_id_mqtt_bridge + 1
-        MainLogger().info("Neue Bridge mit ID "+str(new_id)+" hinzugefügt.")
+        log.info("Neue Bridge mit ID "+str(new_id)+" hinzugefügt.")
         Pub().pub("openWB/set/system/mqtt/bridge/"+str(new_id), bridge_default)
         self.max_id_mqtt_bridge = self.max_id_mqtt_bridge + 1
         Pub().pub("openWB/set/command/max_id/mqtt_bridge", self.max_id_mqtt_bridge)
 
     def removeMqttBridge(self, connection_id: str, payload: dict) -> None:
         if self.max_id_mqtt_bridge >= payload["data"]["bridge"]:
-            MainLogger().info("Bridge mit ID "+str(payload["data"]["bridge"])+" gelöscht.")
+            log.info("Bridge mit ID "+str(payload["data"]["bridge"])+" gelöscht.")
             Pub().pub("openWB/system/mqtt/bridge/"+str(payload["data"]["bridge"]), "")
         else:
             pub_error(payload, connection_id, "Die ID ist größer als die maximal vergebene ID.")
@@ -544,9 +546,9 @@ def pub_error(payload: dict, connection_id: str, error_str: str) -> None:
         }
         Pub().pub("openWB/set/command/" +
                   str(connection_id)+"/error", error_payload)
-        MainLogger().error("Befehl konnte nicht ausgeführt werden: "+str(error_payload))
+        log.error("Befehl konnte nicht ausgeführt werden: "+str(error_payload))
     except Exception:
-        MainLogger().exception("Fehler im Command-Modul")
+        log.exception("Fehler im Command-Modul")
 
 
 class ProcessBrokerBranch:
@@ -564,7 +566,7 @@ class ProcessBrokerBranch:
         try:
             self.__connect_to_broker(self.__on_message_rm)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def get_max_id(self, default: int):
         try:
@@ -573,7 +575,7 @@ class ProcessBrokerBranch:
             self.__connect_to_broker(self.__on_message_max_id)
             return self.max_id
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __connect_to_broker(self, on_message):
         """ abonniert alle Topics.
@@ -592,7 +594,7 @@ class ProcessBrokerBranch:
             client.loop_stop()
 
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __on_connect(self, client, userdata, flags, rc):
         """ connect to broker and subscribe to set topics
@@ -601,14 +603,14 @@ class ProcessBrokerBranch:
             client.subscribe("openWB/"+self.topic_str+"/#", 2)
             client.subscribe("openWB/set/"+self.topic_str+"/#", 2)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __on_message_rm(self, client, userdata, msg):
         """ wartet auf eingehende Topics.
         """
         try:
             if str(msg.payload.decode("utf-8")) != '':
-                MainLogger().debug("Gelöschtes Topic: "+str(msg.topic))
+                log.debug("Gelöschtes Topic: "+str(msg.topic))
                 Pub().pub(msg.topic, "")
                 if "openWB/system/device/" in msg.topic and "component" in msg.topic and "config" in msg.topic:
                     payload = json.loads(str(msg.payload.decode("utf-8")))
@@ -616,7 +618,7 @@ class ProcessBrokerBranch:
                     data.data.counter_data["all"].hierarchy_remove_item(payload["id"])
                     client.subscribe("openWB/"+topic+"/"+str(payload["id"])+"/#", 2)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __on_message_max_id(self, client, userdata, msg):
         try:
@@ -629,13 +631,13 @@ class ProcessBrokerBranch:
                     current_id = int(current_id_regex.group(1))
                     self.max_id = max(current_id, self.max_id)
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __get_payload(self, client, userdata, msg):
         try:
             self.payload = msg.payload
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")
 
     def __getserial(self):
         """ Extract serial from cpuinfo file
@@ -647,4 +649,4 @@ class ProcessBrokerBranch:
                         return line[10:26]
                 return "0000000000000000"
         except Exception:
-            MainLogger().exception("Fehler im Command-Modul")
+            log.exception("Fehler im Command-Modul")

--- a/packages/helpermodules/graph.py
+++ b/packages/helpermodules/graph.py
@@ -2,10 +2,12 @@ from pathlib import Path
 import subprocess
 import time
 import datetime
+import logging
 
 from control import data
-from helpermodules.log import MainLogger
 from helpermodules.pub import Pub
+
+log = logging.getLogger(__name__)
 
 
 class Graph:
@@ -69,4 +71,4 @@ class Graph:
             subprocess.run([str(Path(__file__).resolve().parents[2] / "runs"/"graphing.sh"),
                             str(self.data["config"]["duration"]*6)])
         except Exception:
-            MainLogger().exception("Fehler im Graph-Modul")
+            log.exception("Fehler im Graph-Modul")

--- a/packages/helpermodules/log.py
+++ b/packages/helpermodules/log.py
@@ -5,58 +5,13 @@ import logging
 from pathlib import Path
 import subprocess
 
-
-class PathTruncatingFormatter(logging.Formatter):
-    def format(self, record):
-        if 'pathname' in record.__dict__.keys():
-            record.pathname = '{}'.format(record.pathname[20:])
-        return super(PathTruncatingFormatter, self).format(record)
-
-
-def setup_logging(name):
-    root_logger = logging.getLogger(name)
-    # Only do something if logging is not yet initialized.
-    # It may not be initialized if this function is called multiple times or of logging is set up while unit testing
-    if not root_logger.hasHandlers():
-        handler = logging.FileHandler(str(Path(__file__).resolve().parents[2] / 'ramdisk' / (name+'.log')))
-        handler.setFormatter(
-            PathTruncatingFormatter(
-                '%(asctime)s - {%(pathname)s:%(lineno)s} - %(levelname)s - %(message)s')
-        )
-        root_logger.addHandler(handler)
-        root_logger.setLevel(logging.DEBUG)
-    return root_logger
-
-
-class MainLogger:
-
-    instance: logging.Logger = None
-
-    def __new__(cls):
-        if not MainLogger.instance:
-            MainLogger.instance = setup_logging("main")
-        return MainLogger.instance
-
-    def setLevel(self, level):
-        MainLogger.instance.setLevel(level)
-
-
-class MqttLogger:
-    instance: logging.Logger = None
-
-    def __new__(cls):
-        if not MqttLogger.instance:
-            MqttLogger.instance = setup_logging("mqtt")
-        return MqttLogger.instance
-
-    def setLevel(self, level):
-        MainLogger.instance.setLevel(level)
+log = logging.getLogger(__name__)
 
 
 def cleanup_logfiles():
     """ ruft das Skript zum Kürzen der Logfiles auf.
     """
-    MainLogger().debug("Logdateien kuerzen")
+    log.debug("Logdateien kuerzen")
     parent_file = Path(__file__).resolve().parents[2]
     subprocess.run([str(parent_file / "runs" / "cleanup_log.sh"), str(parent_file / "ramdisk" / "main.log")])
     subprocess.run([str(parent_file / "runs" / "cleanup_log.sh"), str(parent_file / "ramdisk" / "mqtt.log")])

--- a/packages/helpermodules/measurement_log.py
+++ b/packages/helpermodules/measurement_log.py
@@ -1,13 +1,15 @@
 
 
 import json
+import logging
 import pathlib
 from pathlib import Path
 
 from control import data
-from helpermodules.log import MainLogger
 from helpermodules.pub import Pub
 from helpermodules import timecheck
+
+log = logging.getLogger(__name__)
 
 
 def save_log(folder):
@@ -88,12 +90,12 @@ def save_log(folder):
                     cp_dict.update(
                         {cp: {"counter": data.data.cp_data[cp].data["get"]["counter"]}})
             except Exception:
-                MainLogger().exception("Fehler im Werte-Logging-Modul für Ladepunkt "+str(cp))
+                log.exception("Fehler im Werte-Logging-Modul für Ladepunkt "+str(cp))
         try:
             cp_dict.update(
                 {"all": {"counter": data.data.cp_data["all"].data["get"]["counter"]}})
         except Exception:
-            MainLogger().exception("Fehler im Werte-Logging-Modul")
+            log.exception("Fehler im Werte-Logging-Modul")
 
         ev_dict = {}
         for ev in data.data.ev_data:
@@ -102,7 +104,7 @@ def save_log(folder):
                     ev_dict.update(
                         {ev: {"soc": data.data.ev_data[ev].data["get"]["soc"]}})
             except Exception:
-                MainLogger().exception("Fehler im Werte-Logging-Modul für EV "+str(ev))
+                log.exception("Fehler im Werte-Logging-Modul für EV "+str(ev))
 
         counter_dict = {}
         for counter in data.data.counter_data:
@@ -112,7 +114,7 @@ def save_log(folder):
                                          {"imported": data.data.counter_data[counter].data["get"]["imported"],
                                           "exported": data.data.counter_data[counter].data["get"]["exported"]}})
             except Exception:
-                MainLogger().exception("Fehler im Werte-Logging-Modul für Zähler "+str(counter))
+                log.exception("Fehler im Werte-Logging-Modul für Zähler "+str(counter))
 
         pv_dict = {}
         if data.data.pv_data["all"].data["config"]["configured"]:
@@ -121,7 +123,7 @@ def save_log(folder):
                     pv_dict.update(
                         {pv: {"imported": data.data.pv_data[pv].data["get"]["counter"]}})
                 except Exception:
-                    MainLogger().exception("Fehler im Werte-Logging-Modul für Wechselrichter "+str(pv))
+                    log.exception("Fehler im Werte-Logging-Modul für Wechselrichter "+str(pv))
 
         bat_dict = {}
         if data.data.bat_data["all"].data["config"]["configured"]:
@@ -131,7 +133,7 @@ def save_log(folder):
                                            "exported": data.data.bat_data[bat].data["get"]["exported"],
                                            "soc": data.data.bat_data[bat].data["get"]["soc"]}})
                 except Exception:
-                    MainLogger().exception("Fehler im Werte-Logging-Modul für Speicher "+str(bat))
+                    log.exception("Fehler im Werte-Logging-Modul für Speicher "+str(bat))
 
         new_entry = {
             "date": date,
@@ -167,7 +169,7 @@ def save_log(folder):
         with open(filepath, "w") as jsonFile:
             json.dump(content, jsonFile)
     except Exception:
-        MainLogger().exception("Fehler im Werte-Logging-Modul")
+        log.exception("Fehler im Werte-Logging-Modul")
 
 
 def get_daily_log(date: str):
@@ -216,8 +218,8 @@ def update_daily_yields():
                 Pub().pub("openWB/set/counter/"+str(
                     data.data.counter_data[counter].counter_num)+"/get/daily_yield_export", daily_yield_export)
             else:
-                MainLogger().info("Zähler "+str(counter) +
-                                  " wurde zwischenzeitlich gelöscht und wird daher nicht mehr aufgeführt.")
+                log.info("Zähler "+str(counter) +
+                         " wurde zwischenzeitlich gelöscht und wird daher nicht mehr aufgeführt.")
         # Tagesertrag Ladepunkte
         for cp in daily_log[0]["cp"]:
             if cp in data.data.cp_data:
@@ -230,8 +232,8 @@ def update_daily_yields():
                 else:
                     Pub().pub("openWB/set/chargepoint/get/daily_yield", daily_yield)
             else:
-                MainLogger().info("Ladepunkt "+str(cp) +
-                                  " wurde zwischenzeitlich gelöscht und wird daher nicht mehr aufgeführt.")
+                log.info("Ladepunkt "+str(cp) +
+                         " wurde zwischenzeitlich gelöscht und wird daher nicht mehr aufgeführt.")
         # Tagesertrag PV
         for pv in daily_log[0]["pv"]:
             if pv in data.data.pv_data:
@@ -244,8 +246,8 @@ def update_daily_yields():
                 else:
                     Pub().pub("openWB/set/pv/get/daily_yield", daily_yield)
             else:
-                MainLogger().info("Wechselrichter "+str(pv) +
-                                  " wurde zwischenzeitlich gelöscht und wird daher nicht mehr aufgeführt.")
+                log.info("Wechselrichter "+str(pv) +
+                         " wurde zwischenzeitlich gelöscht und wird daher nicht mehr aufgeführt.")
         # Tagesertrag Speicher
         for bat in daily_log[0]["bat"]:
             if bat in data.data.bat_data:
@@ -266,8 +268,8 @@ def update_daily_yields():
                     Pub().pub("openWB/set/bat/get/daily_yield_export",
                               daily_yield_exported)
             else:
-                MainLogger().info("Speicher "+str(bat) +
-                                  " wurde zwischenzeitlich gelöscht und wird daher nicht mehr aufgeführt.")
+                log.info("Speicher "+str(bat) +
+                         " wurde zwischenzeitlich gelöscht und wird daher nicht mehr aufgeführt.")
         data.data.counter_data["all"].calc_daily_yield_home_consumption()
     except Exception:
-        MainLogger().exception("Fehler im Werte-Logging-Modul")
+        log.exception("Fehler im Werte-Logging-Modul")

--- a/packages/helpermodules/pub.py
+++ b/packages/helpermodules/pub.py
@@ -2,12 +2,13 @@
 """
 
 import json
+import logging
 import os
 
 import paho.mqtt.client as mqtt
 import paho.mqtt.publish as publish
 
-from helpermodules.log import MainLogger
+log = logging.getLogger(__name__)
 
 
 class PubSingleton:
@@ -23,7 +24,7 @@ class PubSingleton:
             else:
                 self.client.publish(topic, payload=json.dumps(payload), qos=qos, retain=retain)
         except Exception:
-            MainLogger().exception("Fehler im pub-Modul")
+            log.exception("Fehler im pub-Modul")
 
 
 class Pub:
@@ -57,4 +58,4 @@ def pub_single(topic, payload, hostname="localhost", no_json=False):
         else:
             publish.single(topic, json.dumps(payload), hostname=hostname, retain=True)
     except Exception:
-        MainLogger().exception("Fehler im pub-Modul")
+        log.exception("Fehler im pub-Modul")

--- a/packages/helpermodules/system.py
+++ b/packages/helpermodules/system.py
@@ -1,15 +1,17 @@
 """ Modul zum Updaten der Steuerung und Triggern der externen Wbs, zu updaten."""
 
 from pathlib import Path
+import logging
 import subprocess
 import time
 import _thread as thread
 import threading
 import sys
 
-from helpermodules.log import MainLogger
 from helpermodules import pub
 from control import data
+
+log = logging.getLogger(__name__)
 
 
 class System:
@@ -38,7 +40,7 @@ class System:
             # subprocess.run([str(Path(__file__).resolve().parents[2]/"runs"/"update_self.sh"), train])
             subprocess.run(str(Path(__file__).resolve().parents[2]/"runs"/"atreboot.sh"))
         except Exception:
-            MainLogger().exception("Fehler im System-Modul")
+            log.exception("Fehler im System-Modul")
 
     def _trigger_ext_update(self, train):
         """ triggert das Update auf den externen WBs.
@@ -54,15 +56,15 @@ class System:
                     if "cp" in cp:
                         chargepoint = data.data.cp_data[cp]
                         if chargepoint.chargepoint_module.connection_module["type"] == "external_openwb":
-                            MainLogger().info("Update an LP "+str(chargepoint.cp_num)+" angestossen.")
+                            log.info("Update an LP "+str(chargepoint.cp_num)+" angestossen.")
                             ip_address = chargepoint.chargepoint_module.connection_module["configuration"][
                                 "ip_address"]
                             pub.pub_single("openWB/config/set/releaseTrain", train, ip_address, no_json=True)
                             pub.pub_single("openWB/set/system/PerformUpdate", "1", ip_address, no_json=True)
                 except Exception:
-                    MainLogger().exception("Fehler im System-Modul")
+                    log.exception("Fehler im System-Modul")
         except Exception:
-            MainLogger().exception("Fehler im System-Modul")
+            log.exception("Fehler im System-Modul")
 
 
 def quit_function(fn_name):

--- a/packages/helpermodules/timecheck.py
+++ b/packages/helpermodules/timecheck.py
@@ -1,9 +1,9 @@
 """prüft, ob Zeitfenster aktuell sind
 """
-
+import logging
 from datetime import datetime, timedelta
 
-from helpermodules.log import MainLogger
+log = logging.getLogger(__name__)
 
 
 def set_date(now, begin, end):
@@ -31,7 +31,7 @@ def set_date(now, begin, end):
             end = end + timedelta(days=1)
         return begin, end
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return None, None
 
 
@@ -58,7 +58,7 @@ def is_timeframe_valid(now, begin, end):
         else:
             return False
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return False
 
 
@@ -150,7 +150,7 @@ def check_plans_timeframe(plans, hours=None):
         else:
             return None
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return None
 
 
@@ -232,7 +232,7 @@ def check_timeframe(plan, hours):
                     else:
                         state = False
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return None
     return state
 
@@ -255,7 +255,7 @@ def _calc_begin(end, hours):
         prev = timedelta(hours)
         return end - prev
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return None
 
 
@@ -332,7 +332,7 @@ def check_duration(plan, duration):
             else:
                 return False, 0
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return False
 
 
@@ -369,7 +369,7 @@ def _is_duration_valid(now, duration, end):
         else:
             return 0, 0
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return 1, 0
 
 
@@ -395,7 +395,7 @@ def is_list_valid(hourlist):
             else:
                 return False
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return False
 
 
@@ -423,7 +423,7 @@ def check_timestamp(timestamp, duration):
         else:
             return True
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return True
 
 
@@ -502,7 +502,7 @@ def get_difference_to_now(timestamp_begin: str) -> str:
         diff = (now - begin)
         return __convert_timedelta_to_HHMM(diff)
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return "00:00"
 
 
@@ -527,7 +527,7 @@ def get_difference(timestamp_begin: str, timestamp_end: str) -> str:
         diff = (begin - end)
         return f"{int(diff.total_seconds())}"
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return "0"
 
 
@@ -547,7 +547,7 @@ def duration_sum(first: str, second: str) -> str:
         sum = __get_timedelta_obj(first) + __get_timedelta_obj(second)
         return __convert_timedelta_to_HHMM(sum)
     except Exception:
-        MainLogger().exception("Fehler im System-Modul")
+        log.exception("Fehler im System-Modul")
         return "00:00"
 
 

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -1,13 +1,13 @@
+import logging
 import re
 import time
-
 import paho.mqtt.client as mqtt
 
-
-from helpermodules.log import MainLogger
 from helpermodules.pub import Pub
 from control import chargepoint
 from control import ev
+
+log = logging.getLogger(__name__)
 
 
 class UpdateConfig:
@@ -294,7 +294,7 @@ class UpdateConfig:
         self.all_received_topics = []
 
     def update(self):
-        MainLogger().debug("Broker-Konfiguration aktualisieren")
+        log.debug("Broker-Konfiguration aktualisieren")
         mqtt_broker_ip = "localhost"
         client = mqtt.Client("openWB-updateconfig-" + self.getserial())
         client.on_connect = self.on_connect
@@ -333,11 +333,11 @@ class UpdateConfig:
                     break
             else:
                 Pub().pub(topic, "")
-                MainLogger().debug("Ungültiges Topic zum Startzeitpunkt: "+str(topic))
+                log.debug("Ungültiges Topic zum Startzeitpunkt: "+str(topic))
 
     def __pub_missing_defaults(self):
         # zwingend erforderliche Standardwerte setzen
         for topic in self.default_topic:
             if topic[0] not in self.all_received_topics:
-                MainLogger().debug("Setzte Topic '%s' auf Standardwert '%s'" % (topic[0], str(topic[1])))
+                log.debug("Setzte Topic '%s' auf Standardwert '%s'" % (topic[0], str(topic[1])))
                 Pub().pub(topic[0].replace("openWB/", "openWB/set/"), topic[1])

--- a/packages/modules/alpha_ess/bat.py
+++ b/packages/modules/alpha_ess/bat.py
@@ -32,7 +32,6 @@ class AlphaEssBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self, unit_id: int) -> None:
-        MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         # keine Unterschiede zwischen den Versionen
 
         with self.__tcp_client:

--- a/packages/modules/alpha_ess/bat.py
+++ b/packages/modules/alpha_ess/bat.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
+import logging
 import time
 
-from helpermodules.log import MainLogger
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import BatState
 from modules.common.modbus import ModbusDataType
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_bat_value_store
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -41,7 +43,7 @@ class AlphaEssBat:
             current = self.__tcp_client.read_holding_registers(0x0101, ModbusDataType.INT_16, unit=unit_id)
 
             power = voltage * current * -1 / 100
-            MainLogger().debug(
+            log.debug(
                 "Alpha Ess Leistung[W]: %f, Speicher-Register: Spannung[V]: %f, Strom[A]: %f" %
                 (power, voltage, current)
             )

--- a/packages/modules/alpha_ess/counter.py
+++ b/packages/modules/alpha_ess/counter.py
@@ -2,7 +2,6 @@
 import time
 from typing import Callable
 
-from helpermodules.log import MainLogger
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.fault_state import ComponentInfo
@@ -29,8 +28,6 @@ class AlphaEssCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self, unit_id: int):
-        MainLogger().debug(
-            "Komponente "+self.component_config["name"]+" auslesen.")
         time.sleep(0.1)
         factory_method = self.__get_values_factory(
             self.component_config["configuration"]["version"])

--- a/packages/modules/alpha_ess/device.py
+++ b/packages/modules/alpha_ess/device.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """ Modul zum Auslesen von Alpha Ess Speichern, Zählern und Wechselrichtern.
 """
+import logging
 from typing import Dict, Union, Optional, List
 
-from helpermodules.log import MainLogger
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
@@ -11,6 +11,8 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.alpha_ess import bat
 from modules.alpha_ess import counter
 from modules.alpha_ess import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -39,7 +41,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient("192.168.193.125", 8899)
             self.device_config = device_config
         except Exception:
-            MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -53,14 +55,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update(unit_id=default_unit_id)
         else:
-            MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -85,7 +87,7 @@ def read_legacy(component_type: str, version: int, num: Optional[int] = None) ->
     component_config["configuration"]["version"] = version
     dev.add_component(component_config)
 
-    MainLogger().debug('alpha_ess Version: ' + str(version))
+    log.debug('alpha_ess Version: ' + str(version))
 
     dev.update()
 

--- a/packages/modules/alpha_ess/inverter.py
+++ b/packages/modules/alpha_ess/inverter.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-
-from helpermodules.log import MainLogger
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import InverterState
@@ -31,8 +29,6 @@ class AlphaEssInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self, unit_id: int) -> None:
-        MainLogger().debug(
-            "Komponente "+self.component_config["name"]+" auslesen.")
         reg_p = self.__version_factory(
             self.component_config["configuration"]["version"])
         power = self.__get_power(unit_id, reg_p)
@@ -59,5 +55,4 @@ class AlphaEssInverter:
             ]
         powers[0] = abs(powers[0])
         power = sum(powers) * -1
-        MainLogger().debug("Alpha Ess Leistung: "+str(power)+", WR-Register: " + str(powers))
         return power

--- a/packages/modules/carlo_gavazzi/counter.py
+++ b/packages/modules/carlo_gavazzi/counter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from pymodbus.constants import Endian
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import CounterState
@@ -31,8 +30,6 @@ class CarloGavazziCounter:
 
     def update(self):
         unit = 1
-        log.MainLogger().debug(
-            "Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             voltages = [val / 10 for val in self.__tcp_client.read_input_registers(
                 0x00, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=unit)]
@@ -62,5 +59,4 @@ class CarloGavazziCounter:
             power=power,
             frequency=frequency
         )
-        log.MainLogger().debug("Carlo Gavazzi Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/carlo_gavazzi/device.py
+++ b/packages/modules/carlo_gavazzi/device.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Optional, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.carlo_gavazzi import counter
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -32,7 +34,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 502)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -46,14 +48,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -76,7 +78,7 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None)
     component_config["id"] = num
     dev.add_component(component_config)
 
-    log.MainLogger().debug('carlo gavazzi IP-Adresse: ' + str(ip_address))
+    log.debug('carlo gavazzi IP-Adresse: ' + str(ip_address))
 
     dev.update()
 

--- a/packages/modules/common/component_context.py
+++ b/packages/modules/common/component_context.py
@@ -1,7 +1,9 @@
+import logging
 import threading
 from typing import Optional, List, Union, Any, Dict
 
 from modules.common.fault_state import ComponentInfo, FaultState
+from helpermodules import log
 
 
 class SingleComponentUpdateContext:
@@ -17,6 +19,7 @@ class SingleComponentUpdateContext:
         self.__component_info = component_info
 
     def __enter__(self):
+        log.MainLogger().debug("Update Komponente ['"+self.__component_info.name+"']")
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
@@ -43,6 +46,8 @@ class MultiComponentUpdateContext:
         if hasattr(self.__thread_local, "active_context"):
             raise Exception("Nesting MultiComponentUpdateContext is not supported")
         MultiComponentUpdateContext.__thread_local.active_context = self
+        log.MainLogger().debug("Update Komponenten " +
+                               str([component.component_info.name for component in self.__device_components]))
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:

--- a/packages/modules/common/component_context.py
+++ b/packages/modules/common/component_context.py
@@ -3,7 +3,8 @@ import threading
 from typing import Optional, List, Union, Any, Dict
 
 from modules.common.fault_state import ComponentInfo, FaultState
-from helpermodules import log
+
+log = logging.getLogger(__name__)
 
 
 class SingleComponentUpdateContext:
@@ -19,7 +20,7 @@ class SingleComponentUpdateContext:
         self.__component_info = component_info
 
     def __enter__(self):
-        log.MainLogger().debug("Update Komponente ['"+self.__component_info.name+"']")
+        log.debug("Update Komponente ['"+self.__component_info.name+"']")
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
@@ -46,8 +47,8 @@ class MultiComponentUpdateContext:
         if hasattr(self.__thread_local, "active_context"):
             raise Exception("Nesting MultiComponentUpdateContext is not supported")
         MultiComponentUpdateContext.__thread_local.active_context = self
-        log.MainLogger().debug("Update Komponenten " +
-                               str([component.component_info.name for component in self.__device_components]))
+        log.debug("Update Komponenten " +
+                  str([component.component_info.name for component in self.__device_components]))
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -1,9 +1,12 @@
 from enum import Enum
+import logging
 import traceback
 from typing import Optional
 
-from helpermodules import compatibility, exceptions, log, pub
+from helpermodules import compatibility, exceptions, pub
 from modules.common import component_type
+
+log = logging.getLogger(__name__)
 
 
 class FaultStateLevel(Enum):
@@ -31,10 +34,10 @@ class FaultState(Exception):
     def store_error(self, component_info: ComponentInfo) -> None:
         try:
             if self.fault_state is not FaultStateLevel.NO_ERROR:
-                log.MainLogger().error(component_info.name + ": FaultState " +
-                                       str(self.fault_state) + ", FaultStr " +
-                                       self.fault_str + ", Traceback: \n" +
-                                       traceback.format_exc())
+                log.error(component_info.name + ": FaultState " +
+                          str(self.fault_state) + ", FaultStr " +
+                          self.fault_str + ", Traceback: \n" +
+                          traceback.format_exc())
             ramdisk = compatibility.is_ramdisk_in_use()
             if ramdisk:
                 topic = component_type.type_to_topic_mapping(component_info.type)
@@ -55,7 +58,7 @@ class FaultState(Exception):
                 pub.Pub().pub(
                     "openWB/set/" + topic + "/" + str(component_info.id) + "/get/fault_state", self.fault_state.value)
         except Exception:
-            log.MainLogger().exception("Fehler im Modul fault_state")
+            log.exception("Fehler im Modul fault_state")
 
     def __type_topic_mapping_comp(self, component_type: str) -> str:
         if "bat" in component_type:

--- a/packages/modules/common/modbus.py
+++ b/packages/modules/common/modbus.py
@@ -4,6 +4,7 @@
 Das Modul baut eine Modbus-TCP-Verbindung auf. Es gibt verschiedene Funktionen, um die gelesenen Register zu
 formatieren.
 """
+import logging
 import struct
 from enum import Enum
 from typing import Callable, Iterable, Union, overload, List
@@ -14,8 +15,9 @@ from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 from urllib3.util import parse_url
 
-from helpermodules.log import MainLogger
 from modules.common.fault_state import FaultState
+
+log = logging.getLogger(__name__)
 
 
 class ModbusDataType(Enum):
@@ -59,7 +61,7 @@ class ModbusClient:
 
     def close_connection(self) -> None:
         try:
-            MainLogger().debug("Close Modbus TCP connection")
+            log.debug("Close Modbus TCP connection")
             self.delegate.close()
         except Exception as e:
             raise FaultState.error(__name__+" "+str(type(e))+" " +

--- a/packages/modules/common/powerwall.py
+++ b/packages/modules/common/powerwall.py
@@ -10,7 +10,7 @@ from modules.common.req import get_http_session
 from modules.common.store import RAMDISK_PATH
 
 COOKIE_FILE = RAMDISK_PATH / "powerwall_cookie.txt"
-log = logging.getLogger("Powerwall")
+log = logging.getLogger(__name__)
 
 
 class PowerwallHttpClient:

--- a/packages/modules/common/req.py
+++ b/packages/modules/common/req.py
@@ -1,11 +1,12 @@
 
+import logging
 from requests import Session
 
-from helpermodules import log
+log = logging.getLogger(__name__)
 
 
 def get_http_session() -> Session:
     session = Session()
     session.hooks['response'].append(lambda r, *args, **kwargs: r.raise_for_status())
-    session.hooks['response'].append(lambda r, *args, **kwargs: log.MainLogger().debug("Get-Response: " + r.text))
+    session.hooks['response'].append(lambda r, *args, **kwargs: log.debug("Get-Response: " + r.text))
     return session

--- a/packages/modules/common/simcount.py
+++ b/packages/modules/common/simcount.py
@@ -1,16 +1,18 @@
 """ Sim Count
 Berechnet die importierte und exportierte Leistung, wenn der Zähler / PV-Modul / Speicher diese nicht liefert.
 """
+import logging
 import os
 import paho.mqtt.client as mqtt
 import time
 import typing
 
 from helpermodules import compatibility
-from helpermodules.log import MainLogger
 from helpermodules import pub
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.fault_state import FaultState
+
+log = logging.getLogger(__name__)
 
 
 def process_error(e):
@@ -97,15 +99,15 @@ class SimCountLegacy:
                     # runs/simcount.py speichert das Zwischenergebnis des Exports negativ ab.
                     counter_export_present = counter_export_present * -1
                 counter_export_previous = counter_export_present
-                MainLogger().debug("simcount Zwischenergebnisse letzte Berechnung: Import: " +
-                                   str(counter_import_previous) + " Export: " + str(counter_export_previous) +
-                                   " Leistung: " + str(power_previous))
+                log.debug("simcount Zwischenergebnisse letzte Berechnung: Import: " +
+                          str(counter_import_previous) + " Export: " + str(counter_export_previous) +
+                          " Leistung: " + str(power_previous))
                 start_new = False
             write_ramdisk_file(prefix+'sec0', "%22.6f" % timestamp_present)
             write_ramdisk_file(prefix+'wh0', int(power_present))
 
             if start_new:
-                MainLogger().debug("Neue Simulation starten.")
+                log.debug("Neue Simulation starten.")
                 if prefix == "bezug":
                     imported = get_existing_imports_exports('bezugkwh')
                     exported = get_existing_imports_exports('einspeisungkwh')
@@ -123,19 +125,19 @@ class SimCountLegacy:
                     seconds_since_previous, power_previous, power_present)
                 counter_export_present = counter_export_present + imp_exp[1]
                 counter_import_present = counter_import_present + imp_exp[0]
-                MainLogger().debug(
+                log.debug(
                     "simcount aufsummierte Energie: Bezug[Ws]: " + str(counter_import_present) + ", Einspeisung[Ws]: " +
                     str(counter_export_present)
                 )
                 energy_positive_kWh = counter_import_present / 3600
                 energy_negative_kWh = counter_export_present / 3600
-                MainLogger().info(
+                log.info(
                     "simcount Ergebnis: Bezug[Wh]: " + str(energy_positive_kWh) +
                     ", Einspeisung[Wh]: " + str(energy_negative_kWh)
                 )
 
                 topic = get_topic(prefix)
-                MainLogger().debug(
+                log.debug(
                     "simcount Zwischenergebnisse aktuelle Berechnung: Import: " + str(counter_import_present) +
                     " Export: " + str(counter_export_present) + " Leistung: " + str(power_present)
                 )
@@ -154,7 +156,7 @@ class SimCountLegacy:
 def get_existing_imports_exports(file: str) -> float:
     if os.path.isfile('/var/www/html/openWB/ramdisk/'+file):
         value = float(read_ramdisk_file(file))
-        MainLogger().info("Es wurde ein vorhandener Zählerstand in "+file+" gefunden: "+str(value)+"Wh")
+        log.info("Es wurde ein vorhandener Zählerstand in "+file+" gefunden: "+str(value)+"Wh")
     else:
         value = 0
     return value
@@ -179,13 +181,13 @@ class Restore():
             try:
                 result = float(self.temp)
                 if value == "watt0pos":
-                    MainLogger().info(
+                    log.info(
                         "loadvars read openWB/"+get_topic(self.prefix)+"/WHImported_temp from mosquito "+str(self.temp))
                 else:
-                    MainLogger().info(
+                    log.info(
                         "loadvars read openWB/"+get_topic(self.prefix)+"/WHExport_temp from mosquito "+str(self.temp))
             except ValueError:
-                MainLogger().info("Keine Werte auf dem Broker gefunden.")
+                log.info("Keine Werte auf dem Broker gefunden.")
                 if prefix == "bezug":
                     file = "bezugkwh" if value == "watt0pos" else "einspeisungkwh"
                 elif prefix == "pv":
@@ -197,7 +199,7 @@ class Restore():
                     self.temp = str(result)
             write_ramdisk_file(prefix+value, self.temp)
         except Exception:
-            MainLogger().exception("Fehler in der Restore-Klasse")
+            log.exception("Fehler in der Restore-Klasse")
         finally:
             return result
 
@@ -211,7 +213,7 @@ class Restore():
             else:
                 client.subscribe("openWB/"+topic+"/WHExport_temp", 2)
         except Exception:
-            MainLogger().exception("Fehler in der Restore-Klasse")
+            log.exception("Fehler in der Restore-Klasse")
 
     def __on_message(self, client, userdata, msg):
         """ wartet auf eingehende Topics.
@@ -228,7 +230,7 @@ class Restore():
                         return line[10:26]
                 return "0000000000000000"
         except Exception:
-            MainLogger().exception("Fehler in der Restore-Klasse")
+            log.exception("Fehler in der Restore-Klasse")
 
 
 class SimCount:
@@ -263,7 +265,7 @@ class SimCount:
                     counter_export_present = int(data["present_exported"])
                 else:
                     counter_export_present = 0
-                MainLogger().debug(
+                log.debug(
                     "Fortsetzen der Simulation: Importzähler: " + str(counter_import_present)+"Ws, Export-Zähler: " +
                     str(counter_export_present) + "Ws"
                 )
@@ -272,7 +274,7 @@ class SimCount:
             pub.Pub().pub(topic+"simulation/power_present", power_present)
 
             if start_new:
-                MainLogger().debug("Neue Simulation")
+                log.debug("Neue Simulation")
                 pub.Pub().pub(topic+"simulation/present_imported", 0)
                 pub.Pub().pub(topic+"simulation/present_exported", 0)
                 return 0, 0
@@ -283,18 +285,18 @@ class SimCount:
                     seconds_since_previous, power_previous, power_present)
                 counter_export_present = counter_export_present + imp_exp[1]
                 counter_import_present = counter_import_present + imp_exp[0]
-                MainLogger().debug(
+                log.debug(
                     "simcount aufsummierte Energie: Bezug[Ws]: " + str(counter_import_present) +
                     ", Einspeisung[Ws]: " +
                     str(counter_export_present)
                 )
                 energy_positive_kWh = counter_import_present / 3600
                 energy_negative_kWh = counter_export_present / 3600
-                MainLogger().info(
+                log.info(
                     "simcount Ergebnis: Bezug[Wh]: " + str(energy_positive_kWh) +
                     ", Einspeisung[Wh]: " + str(energy_negative_kWh)
                 )
-                MainLogger().debug(
+                log.debug(
                     "simcount Zwischenergebnisse aktuelle Berechnung: Import: " + str(counter_import_present) +
                     " Export: " + str(counter_export_present) + " Power: " + str(power_present)
                 )
@@ -312,7 +314,7 @@ def calculate_import_export(
     seconds_since_previous: Number, power1: Number, power2: Number
 ) -> typing.Tuple[Number, Number]:
     try:
-        MainLogger().debug(
+        log.debug(
             "simcount Berechnungsgrundlage: vergangene Zeit [s]" + str(seconds_since_previous) +
             ", vorherige Leistung[W]: " + str(power1) + ", aktuelle Leistung[W]: " + str(power2)
         )
@@ -324,12 +326,12 @@ def calculate_import_export(
         def energy_function(seconds): return .5 * gradient * seconds ** 2 + power_low * seconds
 
         energy_total = energy_function(seconds_since_previous)
-        MainLogger().debug("simcount Gesamtenergie im Zeitintervall: "+str(energy_total))
+        log.debug("simcount Gesamtenergie im Zeitintervall: "+str(energy_total))
         if power_low < 0 < power_high:
             # Berechnung der Fläche im vierten Quadranten -> Export
             power_zero_seconds = -power_low / gradient
             energy_exported = energy_function(power_zero_seconds)
-            MainLogger().debug(
+            log.debug(
                 "simcount exportierte Energie im Zeitintervall: "+str(energy_exported))
             # Betragsmäßige Gesamtfläche: oberhalb der x-Achse = Import, unterhalb der x-Achse: Export
             return energy_total - energy_exported, energy_exported * -1

--- a/packages/modules/common/store/_api.py
+++ b/packages/modules/common/store/_api.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from typing import Generic, TypeVar
 
 T = TypeVar("T")
-log = logging.getLogger("ValueStore")
+log = logging.getLogger(__name__)
 
 
 class ValueStore(Generic[T]):

--- a/packages/modules/configuration.py
+++ b/packages/modules/configuration.py
@@ -1,5 +1,8 @@
-from helpermodules.log import MainLogger
+import logging
+
 from helpermodules.pub import Pub
+
+log = logging.getLogger(__name__)
 
 
 def pub_configurable():
@@ -16,7 +19,7 @@ def _pub_configurable_soc_modules() -> None:
         ]
         Pub().pub("openWB/set/system/configurable/soc_modules", soc_modules)
     except Exception:
-        MainLogger().exception("Fehler im configuration-Modul")
+        log.exception("Fehler im configuration-Modul")
 
 
 def _pub_configurable_devices_components() -> None:
@@ -402,7 +405,7 @@ def _pub_configurable_devices_components() -> None:
         ]
         Pub().pub("openWB/set/system/configurable/devices_components", devices_components)
     except Exception:
-        MainLogger().exception("Fehler im configuration-Modul")
+        log.exception("Fehler im configuration-Modul")
 
 
 def _pub_configurable_chargepoints() -> None:
@@ -431,4 +434,4 @@ def _pub_configurable_chargepoints() -> None:
         ]
         Pub().pub("openWB/set/system/configurable/chargepoints", chargepoints)
     except Exception:
-        MainLogger().exception("Fehler im configuration-Modul")
+        log.exception("Fehler im configuration-Modul")

--- a/packages/modules/discovergy/device.py
+++ b/packages/modules/discovergy/device.py
@@ -23,7 +23,7 @@ component_registry = {
     "inverter": inverter.create_component
 }
 
-log = logging.getLogger("Discovergy")
+log = logging.getLogger(__name__)
 
 
 class Device(AbstractDevice):

--- a/packages/modules/fronius/bat.py
+++ b/packages/modules/fronius/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import req
 from modules.common import simcount
 from modules.common.component_state import BatState

--- a/packages/modules/fronius/bat.py
+++ b/packages/modules/fronius/bat.py
@@ -27,7 +27,6 @@ class FroniusBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         meter_id = str(self.device_config["meter_id"])
 
         resp_json = req.get_http_session().get(

--- a/packages/modules/fronius/counter_s0.py
+++ b/packages/modules/fronius/counter_s0.py
@@ -4,7 +4,6 @@ from modules.common.fault_state import ComponentInfo
 from modules.common.component_state import CounterState
 from modules.common import req
 from modules.common import simcount
-from helpermodules import log
 
 
 def get_default_config() -> dict:
@@ -27,7 +26,6 @@ class FroniusS0Counter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> CounterState:
-
         session = req.get_http_session()
         response = session.get(
             'http://'+self.device_config["ip_address"]+'/solar_api/v1/GetPowerFlowRealtimeData.fcgi',
@@ -50,9 +48,7 @@ class FroniusS0Counter:
             exported=exported,
             power=power
         )
-        log.MainLogger().debug("Fronius SM Leistung[W]: " + str(counter_state.power))
         return counter_state
 
     def set_counter_state(self, counter_state: CounterState) -> None:
-        log.MainLogger().debug("Fronius SM Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/fronius/counter_s0.py
+++ b/packages/modules/fronius/counter_s0.py
@@ -27,7 +27,6 @@ class FroniusS0Counter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> CounterState:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         session = req.get_http_session()
         response = session.get(

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
+import logging
 from requests import Session
 from typing import Tuple
 
-from helpermodules import log
 from modules.common import req
 from modules.common import simcount
 from modules.common.component_state import CounterState
 from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 from modules.fronius.meter import MeterLocation
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -60,7 +62,6 @@ class FroniusSmCounter:
         return counter_state, meter_location
 
     def set_counter_state(self, counter_state: CounterState) -> None:
-        log.MainLogger().debug("Fronius SM Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)
 
     def __update_variant_0_1(self, session: Session) -> Tuple[CounterState, MeterLocation]:
@@ -86,7 +87,7 @@ class FroniusSmCounter:
         response_json_id = response.json()["Body"]["Data"]
 
         meter_location = MeterLocation(response_json_id["Meter_Location_Current"])
-        log.MainLogger().debug("Einbauort: "+str(meter_location))
+        log.debug("Einbauort: "+str(meter_location))
 
         if meter_location == MeterLocation.grid:
             power = response_json_id["PowerReal_P_Sum"]

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -37,7 +37,6 @@ class FroniusSmCounter:
 
     def update(self) -> Tuple[CounterState, MeterLocation]:
         variant = self.component_config["configuration"]["variant"]
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         session = req.get_http_session()
 

--- a/packages/modules/fronius/device.py
+++ b/packages/modules/fronius/device.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Optional, Union, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import MultiComponentUpdateContext
@@ -10,6 +10,8 @@ from modules.fronius import counter_s0
 from modules.fronius import counter_sm
 from modules.fronius import inverter
 from modules.fronius import meter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -41,7 +43,7 @@ class Device(AbstractDevice):
         try:
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -55,7 +57,7 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             with MultiComponentUpdateContext(self.components):
                 # zuerst den WR auslesen
@@ -91,7 +93,7 @@ class Device(AbstractDevice):
                     if isinstance(self.components[component], bat.FroniusBat):
                         self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -132,7 +134,7 @@ def read_legacy(
     component_config["id"] = num
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Fronius IP-Adresse: ' + str(ip_address))
+    log.debug('Fronius IP-Adresse: ' + str(ip_address))
 
     dev.update()
 

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -32,7 +32,6 @@ class FroniusInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> float:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         # Rückgabewert ist die aktuelle Wirkleistung in [W].
         params = (

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-
 import requests
 
-from helpermodules import log
 from modules.common import req
 from modules.common import simcount
 from modules.common.component_state import InverterState

--- a/packages/modules/http/api.py
+++ b/packages/modules/http/api.py
@@ -1,8 +1,10 @@
 import functools
+import logging
 from typing import Callable, Union
 
-from helpermodules import log
 from modules.common import req
+
+log = logging.getLogger(__name__)
 
 
 def request_value(url: str) -> float:
@@ -11,7 +13,7 @@ def request_value(url: str) -> float:
     else:
         response = req.get_http_session().get(url, timeout=5)
         response.encoding = 'utf-8'
-        log.MainLogger().debug("Antwort auf "+str(url)+" "+str(response.text))
+        log.debug("Antwort auf "+str(url)+" "+str(response.text))
         return float(response.text.replace("\n", ""))
 
 

--- a/packages/modules/http/bat.py
+++ b/packages/modules/http/bat.py
@@ -32,7 +32,6 @@ class HttpBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         bat_state = BatState(
             power=self.__get_power(),
             soc=self.__get_soc(),

--- a/packages/modules/http/bat.py
+++ b/packages/modules/http/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common.component_state import BatState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_bat_value_store

--- a/packages/modules/http/counter.py
+++ b/packages/modules/http/counter.py
@@ -38,7 +38,6 @@ class HttpCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         counter_state = CounterState(
             currents=[getter() for getter in self.__get_currents],

--- a/packages/modules/http/counter.py
+++ b/packages/modules/http/counter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common.component_state import CounterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_counter_value_store
@@ -38,7 +37,6 @@ class HttpCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-
         counter_state = CounterState(
             currents=[getter() for getter in self.__get_currents],
             imported=self.__get_imported(),

--- a/packages/modules/http/device.py
+++ b/packages/modules/http/device.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
+import logging
 import re
 from typing import Dict, Union, List
 
 from urllib3.util import parse_url
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.http import bat
 from modules.http import counter
 from modules.http import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -41,7 +43,7 @@ class Device(AbstractDevice):
         try:
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -57,14 +59,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -92,7 +94,7 @@ def create_paths_dict(**kwargs):
 def run_device_legacy(device_config: dict, component_config: dict):
     device = Device(device_config)
     device.add_component(component_config)
-    log.MainLogger().debug(
+    log.debug(
         'Http Konfiguration: ' + str(device_config["configuration"]) + str(component_config["configuration"])
     )
     device.update()

--- a/packages/modules/http/inverter.py
+++ b/packages/modules/http/inverter.py
@@ -28,7 +28,6 @@ class HttpInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         inverter_state = InverterState(
             # for compatibility: in 1.x power URL values are positive!
             power=(-self.__get_power() if compatibility.is_ramdisk_in_use() else self.__get_power()),

--- a/packages/modules/http/inverter.py
+++ b/packages/modules/http/inverter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from helpermodules import log, compatibility
+from helpermodules import compatibility
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_inverter_value_store

--- a/packages/modules/huawei/bat.py
+++ b/packages/modules/huawei/bat.py
@@ -31,7 +31,6 @@ class HuaweiBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         time.sleep(0.1)
         power = self.__tcp_client.read_holding_registers(37765, ModbusDataType.INT_32, unit=self.__modbus_id)

--- a/packages/modules/huawei/bat.py
+++ b/packages/modules/huawei/bat.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import time
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import BatState
@@ -31,7 +30,6 @@ class HuaweiBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-
         time.sleep(0.1)
         power = self.__tcp_client.read_holding_registers(37765, ModbusDataType.INT_32, unit=self.__modbus_id)
         time.sleep(0.1)

--- a/packages/modules/huawei/counter.py
+++ b/packages/modules/huawei/counter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import time
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import CounterState

--- a/packages/modules/huawei/counter.py
+++ b/packages/modules/huawei/counter.py
@@ -31,7 +31,6 @@ class HuaweiCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         time.sleep(0.1)
         power = self.__tcp_client.read_holding_registers(37113, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
         time.sleep(0.1)

--- a/packages/modules/huawei/device.py
+++ b/packages/modules/huawei/device.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
+import logging
 import time
 from typing import Dict, Union, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
@@ -10,6 +10,8 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.huawei import bat
 from modules.huawei import counter
 from modules.huawei import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -43,7 +45,7 @@ class Device(AbstractDevice):
             time.sleep(7)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -59,14 +61,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -84,7 +86,7 @@ def read_legacy(ip_address: str, modbus_id: int, read_counter: str = "False", re
         components_to_read.append("counter")
     if read_battery.lower() == "true":
         components_to_read.append("bat")
-    log.MainLogger().debug("components to read: " + str(components_to_read))
+    log.debug("components to read: " + str(components_to_read))
 
     device_config = get_default_config()
     device_config["configuration"]["ip_address"] = ip_address
@@ -105,8 +107,8 @@ def read_legacy(ip_address: str, modbus_id: int, read_counter: str = "False", re
         component_config["id"] = num
         dev.add_component(component_config)
 
-    log.MainLogger().debug('Huawei IP-Adresse: ' + str(ip_address))
-    log.MainLogger().debug('Huawei Modbus-ID: ' + str(modbus_id))
+    log.debug('Huawei IP-Adresse: ' + str(ip_address))
+    log.debug('Huawei Modbus-ID: ' + str(modbus_id))
 
     dev.update()
 

--- a/packages/modules/huawei/inverter.py
+++ b/packages/modules/huawei/inverter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import time
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import InverterState

--- a/packages/modules/huawei/inverter.py
+++ b/packages/modules/huawei/inverter.py
@@ -31,7 +31,6 @@ class HuaweiInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         time.sleep(0.1)
         power = self.__tcp_client.read_holding_registers(32064, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
 

--- a/packages/modules/janitza/counter.py
+++ b/packages/modules/janitza/counter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import CounterState
@@ -46,5 +45,4 @@ class JanitzaCounter:
             exported=exported,
             power=power
         )
-        log.MainLogger().debug("Janitza Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/janitza/counter.py
+++ b/packages/modules/janitza/counter.py
@@ -28,7 +28,6 @@ class JanitzaCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power = self.__tcp_client.read_holding_registers(19026, ModbusDataType.FLOAT_32, unit=1)
 

--- a/packages/modules/janitza/device.py
+++ b/packages/modules/janitza/device.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Optional, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.janitza import counter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -32,7 +34,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 502)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -46,14 +48,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -76,7 +78,7 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None)
     component_config["id"] = num
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Janitza IP-Adresse: ' + str(ip_address))
+    log.debug('Janitza IP-Adresse: ' + str(ip_address))
 
     dev.update()
 

--- a/packages/modules/json/bat.py
+++ b/packages/modules/json/bat.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import jq
 
-from helpermodules import log
 from modules.common import simcount
 from modules.common.component_state import BatState
 from modules.common.fault_state import ComponentInfo

--- a/packages/modules/json/bat.py
+++ b/packages/modules/json/bat.py
@@ -30,7 +30,6 @@ class JsonBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self, response) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         config = self.component_config["configuration"]
 
         power = jq.compile(config["jq_power"]).input(response).first()

--- a/packages/modules/json/counter.py
+++ b/packages/modules/json/counter.py
@@ -31,7 +31,6 @@ class JsonCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self, response):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         config = self.component_config["configuration"]
 
         power = jq.compile(config["jq_power"]).input(response).first()

--- a/packages/modules/json/counter.py
+++ b/packages/modules/json/counter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import jq
 
-from helpermodules import log
 from modules.common import simcount
 from modules.common.component_state import CounterState
 from modules.common.fault_state import ComponentInfo

--- a/packages/modules/json/device.py
+++ b/packages/modules/json/device.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, List, Union, Optional
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import req
 from modules.common.abstract_device import AbstractDevice
@@ -9,6 +9,8 @@ from modules.common.component_context import MultiComponentUpdateContext
 from modules.json import bat
 from modules.json import counter
 from modules.json import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -39,7 +41,7 @@ class Device(AbstractDevice):
         try:
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -53,14 +55,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             with MultiComponentUpdateContext(self.components):
                 response = req.get_http_session().get(self.device_config["configuration"]["ip_address"], timeout=5)
                 for component in self.components:
                     self.components[component].update(response.json())
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )

--- a/packages/modules/json/inverter.py
+++ b/packages/modules/json/inverter.py
@@ -30,7 +30,6 @@ class JsonInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self, response) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         config = self.component_config["configuration"]
 
         power = float(jq.compile(config["jq_power"]).input(response).first())

--- a/packages/modules/json/inverter.py
+++ b/packages/modules/json/inverter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import jq
 
-from helpermodules import log
 from modules.common import simcount
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo

--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -1,15 +1,17 @@
 """ Fragt die Werte der Module ab. Nur die openWB Kits können mit mehreren Threads gleichzeitig abgefragt werden.
 """
 
+import logging
 import threading
 from typing import Callable, List
 
 
 from control import data
 from control import chargepoint
-from helpermodules.log import MainLogger
 
 from modules import ripple_control_receiver
+
+log = logging.getLogger(__name__)
 
 
 def get_hardware_values():
@@ -42,12 +44,12 @@ def __get_values(value_functions: List[Callable]):
 
             for thread in threads:
                 if thread.is_alive():
-                    MainLogger().error(
+                    log.error(
                         thread.name +
                         " konnte nicht innerhalb des Timeouts die Werte abfragen, die abgefragten Werte werden" +
                         " nicht in der Regelung verwendet.")
     except Exception:
-        MainLogger().exception("Fehler im loadvars-Modul")
+        log.exception("Fehler im loadvars-Modul")
 
 
 def _get_virtual_counters():
@@ -65,10 +67,10 @@ def _get_virtual_counters():
                         if thread is not None:
                             modules_threads.append(thread)
             except Exception:
-                MainLogger().exception("Fehler im loadvars-Modul")
+                log.exception("Fehler im loadvars-Modul")
         return modules_threads
     except Exception:
-        MainLogger().exception("Fehler im loadvars-Modul")
+        log.exception("Fehler im loadvars-Modul")
     finally:
         return modules_threads
 
@@ -85,9 +87,9 @@ def _get_cp() -> List[threading.Thread]:
                     if thread is not None:
                         modules_threads.append(thread)
             except Exception:
-                MainLogger().exception("Fehler im loadvars-Modul")
+                log.exception("Fehler im loadvars-Modul")
     except Exception:
-        MainLogger().exception("Fehler im loadvars-Modul")
+        log.exception("Fehler im loadvars-Modul")
     finally:
         return modules_threads
 
@@ -101,7 +103,7 @@ def _get_general() -> List[threading.Thread]:
                 "ripple_control_receiver"]["configured"]:
             threads.append(threading.Thread(target=ripple_control_receiver.read, args=()))
     except Exception:
-        MainLogger().exception("Fehler im loadvars-Modul")
+        log.exception("Fehler im loadvars-Modul")
     finally:
         return threads
 
@@ -119,10 +121,10 @@ def _get_modules() -> List[threading.Thread]:
                         if thread is not None:
                             modules_threads.append(thread)
             except Exception:
-                MainLogger().exception("Fehler im loadvars-Modul")
+                log.exception("Fehler im loadvars-Modul")
         return modules_threads
     except Exception:
-        MainLogger().exception("Fehler im loadvars-Modul")
+        log.exception("Fehler im loadvars-Modul")
     finally:
         return modules_threads
 
@@ -146,6 +148,6 @@ def _get_soc() -> List[threading.Thread]:
                         "timestamp_last_request")):
                     modules_threads.append(threading.Thread(target=ev.soc_module.update, args=(cp_state,)))
     except Exception:
-        MainLogger().exception("Fehler im loadvars-Modul")
+        log.exception("Fehler im loadvars-Modul")
     finally:
         return modules_threads

--- a/packages/modules/mqtt/chargepoint_module.py
+++ b/packages/modules/mqtt/chargepoint_module.py
@@ -1,9 +1,11 @@
+import logging
 from typing import Dict
 
-from helpermodules.log import MainLogger
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.fault_state import ComponentInfo
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> Dict:
@@ -27,11 +29,11 @@ class ChargepointModule(AbstractChargepoint):
 
     def set_current(self, current: float) -> None:
         with SingleComponentUpdateContext(self.component_info):
-            MainLogger().debug("MQTT-Ladepunkte subscriben die Daten direkt vom Broker.")
+            log.debug("MQTT-Ladepunkte subscriben die Daten direkt vom Broker.")
 
     def get_values(self) -> None:
         with SingleComponentUpdateContext(self.component_info):
-            MainLogger().debug("MQTT-Ladepunkte müssen nicht ausgelesen werden.")
+            log.debug("MQTT-Ladepunkte müssen nicht ausgelesen werden.")
 
     def switch_phases(self, phases_to_use: int, duration: int) -> None:
-        MainLogger().warning("Phasenumschaltung für MQTT-Ladepunkte nicht unterstuezt.")
+        log.warning("Phasenumschaltung für MQTT-Ladepunkte nicht unterstüzt.")

--- a/packages/modules/mqtt/device.py
+++ b/packages/modules/mqtt/device.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-from helpermodules.log import MainLogger
+import logging
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import MultiComponentUpdateContext
 from modules.mqtt import bat
 from modules.mqtt import counter
 from modules.mqtt import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -28,7 +30,7 @@ class Device(AbstractDevice):
         try:
             self.device_config = device_config
         except Exception:
-            MainLogger().exception("Fehler im Modul " + device_config["name"])
+            log.exception("Fehler im Modul " + device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -39,9 +41,9 @@ class Device(AbstractDevice):
     def update(self) -> None:
         if self.components:
             with MultiComponentUpdateContext(self.components):
-                MainLogger().debug("MQTT-Module müssen nicht ausgelesen werden.")
+                log.debug("MQTT-Module müssen nicht ausgelesen werden.")
         else:
-            MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )

--- a/packages/modules/openwb/device.py
+++ b/packages/modules/openwb/device.py
@@ -1,12 +1,14 @@
+import logging
 from typing import Dict, Union, Optional, List
 
-from helpermodules.log import MainLogger
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.openwb import bat
 from modules.openwb import counter
 from modules.openwb import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -41,14 +43,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -75,7 +77,7 @@ def read_legacy(component_type: str, version: int, num: Optional[int] = None):
     component_config["configuration"]["version"] = version
     dev.add_component(component_config)
 
-    MainLogger().debug('openWB Version: ' + str(version))
+    log.debug('openWB Version: ' + str(version))
 
     dev.update()
 

--- a/packages/modules/openwb/inverter.py
+++ b/packages/modules/openwb/inverter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules.log import MainLogger
 from modules.common import modbus
 from modules.common.fault_state import FaultState
 from modules.openwb_flex.inverter import PvKitFlex
@@ -19,19 +18,15 @@ def get_default_config() -> dict:
 
 class PvKit(PvKitFlex):
     def __init__(self, device_id: int, component_config: dict) -> None:
-        try:
-            self.data = {"config": component_config}
-            version = self.data["config"]["configuration"]["version"]
-            if version == 0 or version == 1:
-                id = 0x08
-            elif version == 2:
-                id = 116
-            else:
-                raise FaultState.error("Version "+str(version) +
-                                       " unbekannt.")
-            self.data["config"]["configuration"]["id"] = id
+        self.data = {"config": component_config}
+        version = self.data["config"]["configuration"]["version"]
+        if version == 0 or version == 1:
+            id = 0x08
+        elif version == 2:
+            id = 116
+        else:
+            raise FaultState.error("Version "+str(version) +
+                                   " unbekannt.")
+        self.data["config"]["configuration"]["id"] = id
 
-            super().__init__(device_id, self.data["config"], modbus.ModbusClient("192.168.193.13", 8899))
-        except Exception:
-            MainLogger().exception("Fehler im Modul " +
-                                   self.data["config"]["components"]["component0"]["name"])
+        super().__init__(device_id, self.data["config"], modbus.ModbusClient("192.168.193.13", 8899))

--- a/packages/modules/openwb_flex/bat.py
+++ b/packages/modules/openwb_flex/bat.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules.log import MainLogger
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.fault_state import ComponentInfo
@@ -33,7 +32,6 @@ class BatKitFlex:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        MainLogger().debug("Start kit reading")
         # TCP-Verbindung schließen möglichst bevor etwas anderes gemacht wird, um im Fehlerfall zu verhindern,
         # dass offene Verbindungen den Modbus-Adapter blockieren.
         with self.__tcp_client:
@@ -50,5 +48,4 @@ class BatKitFlex:
             exported=exported,
             power=power
         )
-        MainLogger().debug("Speicher-Kit Leistung[W]: " + str(bat_state.power))
         self.__store.set(bat_state)

--- a/packages/modules/openwb_flex/counter.py
+++ b/packages/modules/openwb_flex/counter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules.log import MainLogger
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import CounterState
@@ -37,7 +36,6 @@ class EvuKitFlex:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        MainLogger().debug("Start kit reading")
         # TCP-Verbindung schließen möglichst bevor etwas anderes gemacht wird, um im Fehlerfall zu verhindern,
         # dass offene Verbindungen den Modbus-Adapter blockieren.
         try:
@@ -79,5 +77,4 @@ class EvuKitFlex:
             power=power,
             frequency=frequency
         )
-        MainLogger().debug("EVU-Kit Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/openwb_flex/device.py
+++ b/packages/modules/openwb_flex/device.py
@@ -1,6 +1,6 @@
+import logging
 from typing import Dict, Union, Optional, List
 
-from helpermodules.log import MainLogger
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
@@ -8,6 +8,8 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.openwb_flex import bat
 from modules.openwb_flex import counter
 from modules.openwb_flex import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -37,7 +39,7 @@ class Device(AbstractDevice):
             port = device_config["configuration"]["port"]
             self.client = modbus.ModbusClient(ip_address, port)
         except Exception:
-            MainLogger().exception("Fehler im Modul " + device_config["name"])
+            log.exception("Fehler im Modul " + device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -50,14 +52,14 @@ class Device(AbstractDevice):
                             ','.join(self.COMPONENT_TYPE_TO_CLASS.keys()))
 
     def update(self) -> None:
-        MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -71,7 +73,7 @@ def read_legacy(component_type: str, version: int, ip_address: str, port: int, i
         "counter": counter,
         "inverter": inverter
     }
-    MainLogger().debug('Start reading flex')
+    log.debug('Start reading flex')
     device_config = get_default_config()
     device_config["configuration"]["ip_address"] = ip_address
     device_config["configuration"]["port"] = port
@@ -89,10 +91,10 @@ def read_legacy(component_type: str, version: int, ip_address: str, port: int, i
     component_config["configuration"]["id"] = id
     dev.add_component(component_config)
 
-    MainLogger().debug('openWB flex Version: ' + str(version))
-    MainLogger().debug('openWB flex-Kit IP-Adresse: ' + str(ip_address))
-    MainLogger().debug('openWB flex-Kit Port: ' + str(port))
-    MainLogger().debug('openWB flex-Kit ID: ' + str(id))
+    log.debug('openWB flex Version: ' + str(version))
+    log.debug('openWB flex-Kit IP-Adresse: ' + str(ip_address))
+    log.debug('openWB flex-Kit Port: ' + str(port))
+    log.debug('openWB flex-Kit ID: ' + str(id))
 
     dev.update()
 

--- a/packages/modules/openwb_flex/inverter.py
+++ b/packages/modules/openwb_flex/inverter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules.log import MainLogger
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo
@@ -44,7 +43,6 @@ class PvKitFlex:
                 power = power*-1
             currents = self.__client.get_currents()
 
-        MainLogger().debug("PV-Kit Leistung[W]: "+str(power))
         inverter_state = InverterState(
             power=power,
             counter=counter,

--- a/packages/modules/openwb_pro/chargepoint_module.py
+++ b/packages/modules/openwb_pro/chargepoint_module.py
@@ -1,14 +1,16 @@
 
+import logging
 import time
 import requests
 from typing import Dict
 
-from helpermodules.log import MainLogger
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_chargepoint_value_store
 from modules.common.component_state import ChargepointState
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> Dict:
@@ -50,7 +52,7 @@ class ChargepointModule(AbstractChargepoint):
             response = requests.get('http://'+ip_address+'/api2.php')
             response.raise_for_status()
             json_rsp = response.json()
-            MainLogger().debug("openWB Pro "+str(self.id)+": "+str(json_rsp))
+            log.debug("openWB Pro "+str(self.id)+": "+str(json_rsp))
 
             chargepoint_state = ChargepointState(
                 power=json_rsp["power_all"],

--- a/packages/modules/openwb_pv_evu/device.py
+++ b/packages/modules/openwb_pv_evu/device.py
@@ -1,10 +1,12 @@
+import logging
 from typing import Dict, List, Optional
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.openwb_pv_evu import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -37,14 +39,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -58,7 +60,7 @@ def read_legacy(version: int, num: Optional[int] = None):
     dev = Device(get_default_config())
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Zähler an EVU-Kit Version: ' + str(version))
+    log.debug('Zähler an EVU-Kit Version: ' + str(version))
     dev.update()
 
 

--- a/packages/modules/openwb_pv_evu/inverter.py
+++ b/packages/modules/openwb_pv_evu/inverter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common.fault_state import FaultState
 from modules.openwb_flex.inverter import PvKitFlex
@@ -19,19 +18,15 @@ def get_default_config() -> dict:
 
 class PvKit(PvKitFlex):
     def __init__(self, device_id: int, component_config: dict) -> None:
-        try:
-            self.data = {"config": component_config}
-            version = self.data["config"]["configuration"]["version"]
-            if version == 0 or version == 1:
-                id = 0x08
-            elif version == 2:
-                id = 116
-            else:
-                raise FaultState.error("Version "+str(version) +
-                                       " unbekannt.")
-            self.data["config"]["configuration"]["id"] = id
+        self.data = {"config": component_config}
+        version = self.data["config"]["configuration"]["version"]
+        if version == 0 or version == 1:
+            id = 0x08
+        elif version == 2:
+            id = 116
+        else:
+            raise FaultState.error("Version "+str(version) +
+                                   " unbekannt.")
+        self.data["config"]["configuration"]["id"] = id
 
-            super().__init__(device_id, self.data["config"], modbus.ModbusClient("192.168.193.15", 8899))
-        except Exception:
-            log.MainLogger().exception("Fehler im Modul " +
-                                       self.data["config"]["components"]["component0"]["name"])
+        super().__init__(device_id, self.data["config"], modbus.ModbusClient("192.168.193.15", 8899))

--- a/packages/modules/powerdog/counter.py
+++ b/packages/modules/powerdog/counter.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-from helpermodules import log
+import logging
+
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import CounterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -30,7 +33,7 @@ class PowerdogCounter:
     def update(self):
         with self.__tcp_client:
             home_consumption = self.__tcp_client.read_input_registers(40026, ModbusDataType.INT_32, unit=1)
-        log.MainLogger().debug("Powerdog Hausverbrauch[W]: " + str(home_consumption))
+        log.debug("Powerdog Hausverbrauch[W]: " + str(home_consumption))
         return home_consumption
 
     def set_counter_state(self, power: float) -> None:
@@ -48,5 +51,4 @@ class PowerdogCounter:
             exported=exported,
             power=power
         )
-        log.MainLogger().debug("Powerdog Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/powerdog/counter.py
+++ b/packages/modules/powerdog/counter.py
@@ -28,7 +28,6 @@ class PowerdogCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             home_consumption = self.__tcp_client.read_input_registers(40026, ModbusDataType.INT_32, unit=1)
         log.MainLogger().debug("Powerdog Hausverbrauch[W]: " + str(home_consumption))

--- a/packages/modules/powerdog/device.py
+++ b/packages/modules/powerdog/device.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Union, Optional, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import MultiComponentUpdateContext, SingleComponentUpdateContext
 from modules.powerdog import counter
 from modules.powerdog import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -40,7 +42,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 502)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -54,7 +56,7 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if len(self.components) == 1:
             for component in self.components:
                 if isinstance(self.components[component], inverter.PowerdogInverter):
@@ -79,7 +81,7 @@ class Device(AbstractDevice):
                     if isinstance(self.components[component], counter.PowerdogCounter):
                         self.components[component].set_counter_state(counter_power)
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine oder zu viele Komponenten konfiguriert wurden."
             )
@@ -105,7 +107,7 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None)
         inverter_config["id"] = 1
         dev.add_component(inverter_config)
 
-    log.MainLogger().debug('Powerdog IP-Adresse: ' + str(ip_address))
+    log.debug('Powerdog IP-Adresse: ' + str(ip_address))
 
     dev.update()
 

--- a/packages/modules/powerdog/inverter.py
+++ b/packages/modules/powerdog/inverter.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import logging
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:

--- a/packages/modules/powerdog/inverter.py
+++ b/packages/modules/powerdog/inverter.py
@@ -29,7 +29,6 @@ class PowerdogInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> float:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power = self.__tcp_client.read_input_registers(40002, ModbusDataType.INT_32, unit=1) * -1
 

--- a/packages/modules/ripple_control_receiver.py
+++ b/packages/modules/ripple_control_receiver.py
@@ -1,8 +1,10 @@
+import logging
 import RPi.GPIO as GPIO
 import time
 
-from helpermodules.log import MainLogger
 from helpermodules.pub import Pub
+
+log = logging.getLogger(__name__)
 
 
 def read():
@@ -31,4 +33,4 @@ def read():
             time.sleep(0.2)
     except Exception:
         GPIO.cleanup()
-        MainLogger().exception()
+        log.exception()

--- a/packages/modules/saxpower/bat.py
+++ b/packages/modules/saxpower/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import BatState

--- a/packages/modules/saxpower/bat.py
+++ b/packages/modules/saxpower/bat.py
@@ -28,7 +28,6 @@ class SaxpowerBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             # Die beiden Register müssen zwingend zusammen ausgelesen werden, sonst scheitert die zweite Abfrage.
             soc, power = self.__tcp_client.read_holding_registers(46, [ModbusDataType.INT_16]*2, unit=64)

--- a/packages/modules/saxpower/device.py
+++ b/packages/modules/saxpower/device.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.saxpower import bat
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -32,7 +34,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 3600)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -46,14 +48,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -76,7 +78,7 @@ def read_legacy(component_type: str, ip_address: str) -> None:
     component_config["id"] = None
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Saxpower IP-Adresse: ' + str(ip_address))
+    log.debug('Saxpower IP-Adresse: ' + str(ip_address))
 
     dev.update()
 

--- a/packages/modules/siemens/bat.py
+++ b/packages/modules/siemens/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import BatState

--- a/packages/modules/siemens/bat.py
+++ b/packages/modules/siemens/bat.py
@@ -31,7 +31,6 @@ class SiemensBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power = self.__tcp_client.read_holding_registers(6, ModbusDataType.INT_32, unit=1) * -1
             soc = int(self.__tcp_client.read_holding_registers(8, ModbusDataType.INT_32, unit=1))

--- a/packages/modules/siemens/counter.py
+++ b/packages/modules/siemens/counter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import CounterState
@@ -50,5 +49,4 @@ class SiemensCounter:
             exported=exported,
             power=power
         )
-        log.MainLogger().debug("Siemens Zähler Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/siemens/counter.py
+++ b/packages/modules/siemens/counter.py
@@ -31,7 +31,6 @@ class SiemensCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         with self.__tcp_client:
             power = self.__tcp_client.read_holding_registers(14, ModbusDataType.INT_32, unit=1)

--- a/packages/modules/siemens/device.py
+++ b/packages/modules/siemens/device.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Union, Optional, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.siemens import bat
 from modules.siemens import counter
 from modules.siemens import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -36,7 +38,7 @@ class Device(AbstractDevice):
         try:
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -50,14 +52,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading" + str(self.components))
+        log.debug("Start device reading" + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -82,7 +84,7 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None)
     component_config["configuration"]["ip_address"] = ip_address
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Siemens IP-Adresse: ' + str(ip_address))
+    log.debug('Siemens IP-Adresse: ' + str(ip_address))
 
     dev.update()
 

--- a/packages/modules/siemens/inverter.py
+++ b/packages/modules/siemens/inverter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import InverterState

--- a/packages/modules/siemens/inverter.py
+++ b/packages/modules/siemens/inverter.py
@@ -32,7 +32,6 @@ class SiemensInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power = self.__tcp_client.read_holding_registers(16, ModbusDataType.INT_32, unit=1) * -1
 

--- a/packages/modules/sma_modbus_tcp/device.py
+++ b/packages/modules/sma_modbus_tcp/device.py
@@ -12,7 +12,7 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.store import get_inverter_value_store
 
 
-log = logging.getLogger("SMA Inverter")
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:

--- a/packages/modules/sma_modbus_tcp/inverter_modbus_tcp.py
+++ b/packages/modules/sma_modbus_tcp/inverter_modbus_tcp.py
@@ -17,7 +17,7 @@ def get_default_config() -> dict:
     }
 
 
-log = logging.getLogger("SMA ModbusTCP")
+log = logging.getLogger(__name__)
 
 
 class SmaModbusTcpInverter:

--- a/packages/modules/sma_modbus_tcp/inverter_webbox.py
+++ b/packages/modules/sma_modbus_tcp/inverter_webbox.py
@@ -16,7 +16,7 @@ def get_default_config() -> dict:
     }
 
 
-log = logging.getLogger("SMA Webbox")
+log = logging.getLogger(__name__)
 
 
 class SmaWebboxInverter:

--- a/packages/modules/sma_shm/device.py
+++ b/packages/modules/sma_shm/device.py
@@ -23,7 +23,7 @@ def get_default_config() -> dict:
     }
 
 
-log = logging.getLogger("SMA Speedwire")
+log = logging.getLogger(__name__)
 timeout_seconds = 5
 
 

--- a/packages/modules/sma_shm/utils.py
+++ b/packages/modules/sma_shm/utils.py
@@ -6,7 +6,7 @@ from modules.common.fault_state import ComponentInfo
 from modules.common.store import ValueStore
 
 T = TypeVar("T")
-log = logging.getLogger("SMA Speedwire")
+log = logging.getLogger(__name__)
 
 
 def _create_serial_matcher(serial: Optional[int]) -> Callable[[dict], bool]:

--- a/packages/modules/solax/bat.py
+++ b/packages/modules/solax/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import BatState

--- a/packages/modules/solax/bat.py
+++ b/packages/modules/solax/bat.py
@@ -28,7 +28,6 @@ class SolaxBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power = self.__tcp_client.read_input_registers(22, ModbusDataType.INT_16)
             soc = self.__tcp_client.read_input_registers(28, ModbusDataType.UINT_16)

--- a/packages/modules/solax/counter.py
+++ b/packages/modules/solax/counter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.fault_state import ComponentInfo
@@ -45,5 +44,4 @@ class SolaxCounter:
             powers=powers,
             frequency=frequency
         )
-        log.MainLogger().debug("Solax Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/solax/counter.py
+++ b/packages/modules/solax/counter.py
@@ -24,7 +24,6 @@ class SolaxCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power = self.__tcp_client.read_input_registers(70, ModbusDataType.INT_32, wordorder=Endian.Little) * -1
             frequency = self.__tcp_client.read_input_registers(7, ModbusDataType.UINT_16) / 100

--- a/packages/modules/solax/device.py
+++ b/packages/modules/solax/device.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Optional, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
@@ -9,6 +9,8 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.solax import bat
 from modules.solax import counter
 from modules.solax import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -36,7 +38,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 502)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -50,14 +52,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden.")
 
@@ -81,7 +83,7 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None)
     component_config["id"] = num
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Solax IP-Adresse: ' + str(ip_address))
+    log.debug('Solax IP-Adresse: ' + str(ip_address))
 
     dev.update()
 

--- a/packages/modules/solax/inverter.py
+++ b/packages/modules/solax/inverter.py
@@ -25,7 +25,6 @@ class SolaxInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power_temp = self.__tcp_client.read_input_registers(10, [ModbusDataType.UINT_16] * 2)
             power = sum(power_temp) * -1

--- a/packages/modules/solax/inverter.py
+++ b/packages/modules/solax/inverter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo

--- a/packages/modules/sonnenbatterie/bat.py
+++ b/packages/modules/sonnenbatterie/bat.py
@@ -124,8 +124,6 @@ class SonnenbatterieBat:
         )
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente '" + str(self.component_config["id"]) + "' "
-                               + self.component_config["name"] + " wird auslesen.")
         log.MainLogger().debug("Variante: " + str(self.__device_variant))
         if self.__device_variant == 0:
             state = self.__update_variant_0()

--- a/packages/modules/sonnenbatterie/bat.py
+++ b/packages/modules/sonnenbatterie/bat.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import logging
 import requests
 
-from helpermodules import log
 from modules.common import simcount
 from modules.common.component_state import BatState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_bat_value_store
 from modules.common.fault_state import FaultState
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -91,9 +93,9 @@ class SonnenbatterieBat:
         '''
         battery_state = self.__read_variant_1()
         battery_power = -battery_state["Pac_total_W"]
-        log.MainLogger().debug('Speicher Leistung: ' + str(battery_power))
+        log.debug('Speicher Leistung: ' + str(battery_power))
         battery_soc = battery_state["USOC"]
-        log.MainLogger().debug('Speicher SoC: ' + str(battery_soc))
+        log.debug('Speicher SoC: ' + str(battery_soc))
         topic_str = "openWB/set/system/device/" + str(
             self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
         imported, exported = self.__sim_count.sim_count(
@@ -134,4 +136,3 @@ class SonnenbatterieBat:
         else:
             raise FaultState.error("Unbekannte Variante: " + str(self.__device_variant))
         self.__store.set(state)
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" wurde erfolgreich auslesen.")

--- a/packages/modules/sonnenbatterie/bat.py
+++ b/packages/modules/sonnenbatterie/bat.py
@@ -126,7 +126,7 @@ class SonnenbatterieBat:
         )
 
     def update(self) -> None:
-        log.MainLogger().debug("Variante: " + str(self.__device_variant))
+        log.debug("Variante: " + str(self.__device_variant))
         if self.__device_variant == 0:
             state = self.__update_variant_0()
         elif self.__device_variant == 1:

--- a/packages/modules/sonnenbatterie/counter.py
+++ b/packages/modules/sonnenbatterie/counter.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import logging
 import requests
 
-from helpermodules import log
 from modules.common import simcount
 from modules.common.component_state import CounterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_counter_value_store
 from modules.common.fault_state import FaultState
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -74,12 +76,12 @@ class SonnenbatterieCounter:
         '''
         counter_state = self.__read_variant_1()
         grid_power = -counter_state["GridFeedIn_W"]
-        log.MainLogger().debug('EVU Leistung: ' + str(grid_power))
+        log.debug('EVU Leistung: ' + str(grid_power))
         # Es wird nur eine Spannung ausgegeben
         grid_voltage = counter_state["Uac"]
-        log.MainLogger().debug('EVU Spannung: ' + str(grid_voltage))
+        log.debug('EVU Spannung: ' + str(grid_voltage))
         grid_frequency = counter_state["Fac"]
-        log.MainLogger().debug('EVU Netzfrequenz: ' + str(grid_frequency))
+        log.debug('EVU Netzfrequenz: ' + str(grid_frequency))
         topic_str = "openWB/set/system/device/" + str(
             self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
         imported, exported = self.__sim_count.sim_count(
@@ -116,10 +118,9 @@ class SonnenbatterieCounter:
         )
 
     def update(self) -> None:
-
-        log.MainLogger().debug("Variante: " + str(self.__device_variant))
+        log.debug("Variante: " + str(self.__device_variant))
         if self.__device_variant == 0:
-            log.MainLogger().debug("Die Variante '0' bietet keine EVU Daten!")
+            log.debug("Die Variante '0' bietet keine EVU Daten!")
         elif self.__device_variant == 1:
             state = self.__update_variant_1()
         elif self.__device_variant == 2:
@@ -127,4 +128,4 @@ class SonnenbatterieCounter:
         else:
             raise FaultState.error("Unbekannte Variante: " + str(self.__device_variant))
         self.__store.set(state)
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" wurde erfolgreich auslesen.")
+        log.debug("Komponente "+self.component_config["name"]+" wurde erfolgreich auslesen.")

--- a/packages/modules/sonnenbatterie/counter.py
+++ b/packages/modules/sonnenbatterie/counter.py
@@ -116,8 +116,7 @@ class SonnenbatterieCounter:
         )
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente '" + str(self.component_config["id"]) + "' "
-                               + self.component_config["name"] + " wird auslesen.")
+
         log.MainLogger().debug("Variante: " + str(self.__device_variant))
         if self.__device_variant == 0:
             log.MainLogger().debug("Die Variante '0' bietet keine EVU Daten!")

--- a/packages/modules/sonnenbatterie/device.py
+++ b/packages/modules/sonnenbatterie/device.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 """ Modul zum Auslesen von sonnenBatterie Speichern.
 """
+import logging
 from typing import Dict, Union, Optional, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.sonnenbatterie import bat
 from modules.sonnenbatterie import counter
 from modules.sonnenbatterie import inverter
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -43,7 +45,7 @@ class Device(AbstractDevice):
         try:
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -60,14 +62,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -92,8 +94,8 @@ def read_legacy(component_type: str, address: str, variant: int, num: Optional[i
         )
     component_config["id"] = num
     dev.add_component(component_config)
-    log.MainLogger().debug('SonnenBatterie address: ' + address)
-    log.MainLogger().debug('SonnenBatterie variant: ' + str(variant))
+    log.debug('SonnenBatterie address: ' + address)
+    log.debug('SonnenBatterie variant: ' + str(variant))
     dev.update()
 
 

--- a/packages/modules/sonnenbatterie/inverter.py
+++ b/packages/modules/sonnenbatterie/inverter.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import logging
 import requests
 
-from helpermodules import log
 from modules.common import simcount
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_inverter_value_store
 from modules.common.fault_state import FaultState
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -74,7 +76,7 @@ class SonnenbatterieInverter:
         '''
         inverter_state = self.__read_variant_1()
         pv_power = -inverter_state["Production_W"]
-        log.MainLogger().debug('Speicher PV Leistung: ' + str(pv_power))
+        log.debug('Speicher PV Leistung: ' + str(pv_power))
         topic_str = "openWB/set/system/device/" + str(
             self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
         _, exported = self.__sim_count.sim_count(
@@ -94,7 +96,7 @@ class SonnenbatterieInverter:
     def __update_variant_2(self) -> InverterState:
         # Auslesen einer Sonnenbatterie Eco 6 über die integrierte REST-API des Batteriesystems
         pv_power = -int(float(self.__read_variant_2_element("M03")))
-        log.MainLogger().debug('Speicher PV Leistung: ' + str(pv_power))
+        log.debug('Speicher PV Leistung: ' + str(pv_power))
         topic_str = "openWB/set/system/device/" + str(
             self.__device_id)+"/component/"+str(self.component_config["id"])+"/"
         _, exported = self.__sim_count.sim_count(
@@ -106,9 +108,9 @@ class SonnenbatterieInverter:
         )
 
     def update(self) -> None:
-        log.MainLogger().debug("Variante: " + str(self.__device_variant))
+        log.debug("Variante: " + str(self.__device_variant))
         if self.__device_variant == 0:
-            log.MainLogger().debug("Die Variante '0' bietet keine PV Daten!")
+            log.debug("Die Variante '0' bietet keine PV Daten!")
         elif self.__device_variant == 1:
             state = self.__update_variant_1()
         elif self.__device_variant == 2:
@@ -116,4 +118,4 @@ class SonnenbatterieInverter:
         else:
             raise FaultState.error("Unbekannte Variante: " + str(self.__device_variant))
         self.__store.set(state)
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" wurde erfolgreich auslesen.")
+        log.debug("Komponente "+self.component_config["name"]+" wurde erfolgreich auslesen.")

--- a/packages/modules/sonnenbatterie/inverter.py
+++ b/packages/modules/sonnenbatterie/inverter.py
@@ -106,8 +106,6 @@ class SonnenbatterieInverter:
         )
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente '" + str(self.component_config["id"]) + "' "
-                               + self.component_config["name"] + " wird auslesen.")
         log.MainLogger().debug("Variante: " + str(self.__device_variant))
         if self.__device_variant == 0:
             log.MainLogger().debug("Die Variante '0' bietet keine PV Daten!")

--- a/packages/modules/studer/bat.py
+++ b/packages/modules/studer/bat.py
@@ -24,7 +24,6 @@ class StuderBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         unit = 60
         with self.__tcp_client:
             power = self.__tcp_client.read_input_registers(6, ModbusDataType.FLOAT_32, unit=unit)

--- a/packages/modules/studer/bat.py
+++ b/packages/modules/studer/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.modbus import ModbusDataType

--- a/packages/modules/studer/device.py
+++ b/packages/modules/studer/device.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 """ Modul zum Auslesen von Alpha Ess Speichern, Zählern und Wechselrichtern.
 """
+import logging
 from typing import Dict, List, Union, Optional
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.studer import bat
 from modules.studer import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -39,7 +41,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 502)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -53,14 +55,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )

--- a/packages/modules/studer/inverter.py
+++ b/packages/modules/studer/inverter.py
@@ -28,7 +28,6 @@ class StuderInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
 
         vc_count = self.component_config["configuration"]["vc_count"]
         vc_type = self.component_config["configuration"]["vc_type"]

--- a/packages/modules/studer/inverter.py
+++ b/packages/modules/studer/inverter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo, FaultState

--- a/packages/modules/sungrow/bat.py
+++ b/packages/modules/sungrow/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import BatState

--- a/packages/modules/sungrow/bat.py
+++ b/packages/modules/sungrow/bat.py
@@ -28,7 +28,6 @@ class SungrowBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         unit = 1
         with self.__tcp_client:
             soc = int(self.__tcp_client.read_input_registers(13022, ModbusDataType.INT_16, unit=unit) / 10)

--- a/packages/modules/sungrow/counter.py
+++ b/packages/modules/sungrow/counter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import CounterState
@@ -43,7 +42,7 @@ class SungrowCounter:
                 # powers = self.__tcp_client.read_input_registers(5084, [ModbusDataType.UINT_16] * 3,
                 #                                                 wordorder=Endian.Little, unit=unit)
                 # powers = [power / 10 for power in powers]
-                # log.MainLogger().info("power: " + str(power) + " powers?: " + str(powers))
+                # log.info("power: " + str(power) + " powers?: " + str(powers))
             else:
                 power = self.__tcp_client.read_input_registers(13009, ModbusDataType.INT_32,
                                                                wordorder=Endian.Little, unit=unit) * -1
@@ -55,7 +54,7 @@ class SungrowCounter:
                 # powers = self.__tcp_client.read_input_registers(5084, [ModbusDataType.INT_16] * 3,
                 #                                                 wordorder=Endian.Little, unit=unit)
                 # powers = [power / 10 for power in powers]
-                # log.MainLogger().info("power: " + str(power) + " powers?: " + str(powers))
+                # log.info("power: " + str(power) + " powers?: " + str(powers))
 
         topic_str = "openWB/set/system/device/{}/component/{}/".format(self.__device_id, self.component_config["id"])
         imported, exported = self.__sim_count.sim_count(
@@ -72,5 +71,4 @@ class SungrowCounter:
             voltages=voltages,
             frequency=frequency
         )
-        log.MainLogger().debug("Sungrow Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/sungrow/counter.py
+++ b/packages/modules/sungrow/counter.py
@@ -30,7 +30,6 @@ class SungrowCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         unit = 1
         with self.__tcp_client:
             if self.component_config["configuration"]["version"] == 1:

--- a/packages/modules/sungrow/device.py
+++ b/packages/modules/sungrow/device.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, List, Union, Optional
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
@@ -9,6 +9,8 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.sungrow import bat
 from modules.sungrow import counter
 from modules.sungrow import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -39,7 +41,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 502)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -53,14 +55,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )

--- a/packages/modules/sungrow/inverter.py
+++ b/packages/modules/sungrow/inverter.py
@@ -29,7 +29,6 @@ class SungrowInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power = self.__tcp_client.read_input_registers(5016, ModbusDataType.INT_32,
                                                            wordorder=Endian.Little, unit=1) * -1

--- a/packages/modules/sungrow/inverter.py
+++ b/packages/modules/sungrow/inverter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import InverterState

--- a/packages/modules/sunny_island/bat.py
+++ b/packages/modules/sunny_island/bat.py
@@ -24,7 +24,6 @@ class SunnyIslandBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         unit = 3
         with self.__tcp_client:
             soc = self.__tcp_client.read_holding_registers(30845, ModbusDataType.INT_32, unit=unit)

--- a/packages/modules/sunny_island/bat.py
+++ b/packages/modules/sunny_island/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.modbus import ModbusDataType

--- a/packages/modules/sunny_island/device.py
+++ b/packages/modules/sunny_island/device.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-""" Modul zum Auslesen von Alpha Ess Speichern, Zählern und Wechselrichtern.
-"""
+import logging
 from typing import Dict, Optional, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.sunny_island import bat
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -34,7 +34,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 502)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -48,14 +48,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -78,7 +78,7 @@ def read_legacy(component_type: str, ip_address: str, num: Optional[int] = None)
     component_config["id"] = num
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Sunny Island IP-Adresse: ' + str(ip_address))
+    log.debug('Sunny Island IP-Adresse: ' + str(ip_address))
     dev.update()
 
 

--- a/packages/modules/sunways/device.py
+++ b/packages/modules/sunways/device.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Optional, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.sunways import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -30,7 +32,7 @@ class Device(AbstractDevice):
         try:
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -46,14 +48,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine oder zu viele Komponenten konfiguriert wurden."
             )
@@ -78,8 +80,8 @@ def read_legacy(component_type: str, ip_address: str, password: str, num: Option
     component_config["id"] = num
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Sunways IP-Adresse: ' + str(ip_address))
-    log.MainLogger().debug('Sunways Passwort: ' + str(password))
+    log.debug('Sunways IP-Adresse: ' + str(ip_address))
+    log.debug('Sunways Passwort: ' + str(password))
 
     dev.update()
 

--- a/packages/modules/sunways/inverter.py
+++ b/packages/modules/sunways/inverter.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-
-import requests
 from requests.auth import HTTPDigestAuth
 
-from helpermodules import log
+from modules.common import req
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_inverter_value_store
@@ -38,10 +36,8 @@ class SunwaysInverter:
             ('HASH', '00200403'),
             ('TYPE', '1'),
         )
-        response = requests.get("http://" + self.ip_address + "/data/ajax.txt", params=params,
-                                auth=HTTPDigestAuth("customer", self.password))
-        log.MainLogger().debug("API Response: %s" % (str(response.text)))
-        response.raise_for_status()
+        response = req.get_http_session().get("http://" + self.ip_address + "/data/ajax.txt", params=params,
+                                              auth=HTTPDigestAuth("customer", self.password))
         values = response.text.split(';')
 
         inverter_state = InverterState(

--- a/packages/modules/sunways/inverter.py
+++ b/packages/modules/sunways/inverter.py
@@ -33,7 +33,6 @@ class SunwaysInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         params = (
             ('CAN', '1'),
             ('HASH', '00200403'),

--- a/packages/modules/victron/bat.py
+++ b/packages/modules/victron/bat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import BatState

--- a/packages/modules/victron/bat.py
+++ b/packages/modules/victron/bat.py
@@ -28,7 +28,6 @@ class VictronBat:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         with self.__tcp_client:
             power = self.__tcp_client.read_holding_registers(842, ModbusDataType.INT_16, unit=100)
             soc = self.__tcp_client.read_holding_registers(843, ModbusDataType.UINT_16, unit=100)

--- a/packages/modules/victron/counter.py
+++ b/packages/modules/victron/counter.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import CounterState
@@ -74,5 +73,4 @@ class VictronCounter:
                 exported=exported,
                 power=power
             )
-        log.MainLogger().debug("Victron Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/victron/counter.py
+++ b/packages/modules/victron/counter.py
@@ -32,7 +32,6 @@ class VictronCounter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self):
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         unit = self.component_config["configuration"]["modbus_id"]
         energy_meter = self.component_config["configuration"]["energy_meter"]
         with self.__tcp_client:

--- a/packages/modules/victron/device.py
+++ b/packages/modules/victron/device.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Optional, Union, List
 
-from helpermodules import log
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import AbstractDevice
@@ -9,6 +9,8 @@ from modules.common.component_context import SingleComponentUpdateContext
 from modules.victron import bat
 from modules.victron import counter
 from modules.victron import inverter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -36,7 +38,7 @@ class Device(AbstractDevice):
             self.client = modbus.ModbusClient(ip_address, 502)
             self.device_config = device_config
         except Exception:
-            log.MainLogger().exception("Fehler im Modul "+device_config["name"])
+            log.exception("Fehler im Modul "+device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -50,14 +52,14 @@ class Device(AbstractDevice):
             )
 
     def update(self) -> None:
-        log.MainLogger().debug("Start device reading " + str(self.components))
+        log.debug("Start device reading " + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            log.MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )
@@ -95,10 +97,10 @@ def read_legacy(
     component_config["configuration"]["modbus_id"] = modbus_id
     dev.add_component(component_config)
 
-    log.MainLogger().debug('Victron IP-Adresse: ' + str(ip_address))
-    log.MainLogger().debug('Victron Energy Meter: ' + str(bool(energy_meter)))
-    log.MainLogger().debug('Victron Modbus-ID: ' + str(modbus_id))
-    log.MainLogger().debug('Victron MPPT: ' + str(mppt))
+    log.debug('Victron IP-Adresse: ' + str(ip_address))
+    log.debug('Victron Energy Meter: ' + str(bool(energy_meter)))
+    log.debug('Victron Modbus-ID: ' + str(modbus_id))
+    log.debug('Victron MPPT: ' + str(mppt))
     dev.update()
 
 

--- a/packages/modules/victron/inverter.py
+++ b/packages/modules/victron/inverter.py
@@ -32,7 +32,6 @@ class VictronInverter:
         self.component_info = ComponentInfo.from_component_config(component_config)
 
     def update(self) -> None:
-        log.MainLogger().debug("Komponente "+self.component_config["name"]+" auslesen.")
         modbus_id = self.component_config["configuration"]["modbus_id"]
         with self.__tcp_client:
             if self.component_config["configuration"]["mppt"]:

--- a/packages/modules/victron/inverter.py
+++ b/packages/modules/victron/inverter.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
+import logging
 
-from helpermodules import log
 from modules.common import modbus
 from modules.common import simcount
 from modules.common.component_state import InverterState
 from modules.common.fault_state import ComponentInfo
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -40,8 +42,8 @@ class VictronInverter:
                 except Exception as e:
                     if "GatewayPathUnavailable" in str(e):
                         power = 0
-                        log.MainLogger().debug(self.component_config["name"] +
-                                               ": Reg 789 konnte nicht gelesen werden, Power auf 0 gesetzt.")
+                        log.debug(self.component_config["name"] +
+                                  ": Reg 789 konnte nicht gelesen werden, Power auf 0 gesetzt.")
                     else:
                         raise
             else:

--- a/packages/modules/virtual/counter.py
+++ b/packages/modules/virtual/counter.py
@@ -2,7 +2,6 @@
 from operator import add
 
 from control import data
-from helpermodules.log import MainLogger
 from modules.common import simcount
 from modules.common.component_state import CounterState
 from modules.common.fault_state import ComponentInfo, FaultState
@@ -89,6 +88,4 @@ class VirtualCounter:
         )
         if self.incomplete_currents is False:
             counter_state.currents = self.currents
-
-        MainLogger().debug("Virtual Leistung[W]: " + str(counter_state.power))
         self.__store.set(counter_state)

--- a/packages/modules/virtual/device.py
+++ b/packages/modules/virtual/device.py
@@ -1,9 +1,11 @@
+import logging
 from typing import Dict
 
-from helpermodules.log import MainLogger
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.virtual import counter
+
+log = logging.getLogger(__name__)
 
 
 def get_default_config() -> dict:
@@ -27,7 +29,7 @@ class Device(AbstractDevice):
         try:
             self.device_config = device_config
         except Exception:
-            MainLogger().exception("Fehler im Modul " + device_config["name"])
+            log.exception("Fehler im Modul " + device_config["name"])
 
     def add_component(self, component_config: dict) -> None:
         component_type = component_config["type"]
@@ -36,14 +38,14 @@ class Device(AbstractDevice):
                 self.device_config["id"], component_config))
 
     def get_values(self) -> None:
-        MainLogger().debug("Start device reading" + str(self.components))
+        log.debug("Start device reading" + str(self.components))
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
                 with SingleComponentUpdateContext(self.components[component].component_info):
                     self.components[component].update()
         else:
-            MainLogger().warning(
+            log.warning(
                 self.device_config["name"] +
                 ": Es konnten keine Werte gelesen werden, da noch keine Komponenten konfiguriert wurden."
             )


### PR DESCRIPTION
Es wird nun ausschließlich der eingebaute Python-Logger benutzt. Jedes Modul nutzt seinen eigenen Logger. Wenn die Logger mit `__name__` benannt werden, kann daraus die Package-Hierachie abgeleitet werden. 