### PR TITLE
don't pub none as module value

### DIFF
--- a/packages/modules/common/store/_broker.py
+++ b/packages/modules/common/store/_broker.py
@@ -7,9 +7,10 @@ from modules.common.store._util import get_rounding_function_by_digits, process_
 def pub_to_broker(topic: str, value, digits: Union[int, None] = None) -> None:
     rounding = get_rounding_function_by_digits(digits)
     try:
-        if isinstance(value, list):
-            Pub().pub(topic, [rounding(v) for v in value])
-        else:
-            Pub().pub(topic, rounding(value))
+        if value:
+            if isinstance(value, list):
+                Pub().pub(topic, [rounding(v) for v in value])
+            else:
+                Pub().pub(topic, rounding(value))
     except Exception as e:
         process_error(e)


### PR DESCRIPTION
Wenn none als Modul-Wert gepublished wird, erschient jedes mal nach der Prüfung durch die setdata eine Fehlermeldung, dass der Wert unbekannt ist.
[https://openwb.de/forum/viewtopic.php?p=59252#p59252](url)