### PR TITLE
check value to has value including 0

### DIFF
--- a/packages/modules/common/store/_broker.py
+++ b/packages/modules/common/store/_broker.py
@@ -7,7 +7,7 @@ from modules.common.store._util import get_rounding_function_by_digits, process_
 def pub_to_broker(topic: str, value, digits: Union[int, None] = None) -> None:
     rounding = get_rounding_function_by_digits(digits)
     try:
-        if value:
+        if value is not None:
             if isinstance(value, list):
                 Pub().pub(topic, [rounding(v) for v in value])
             else:


### PR DESCRIPTION
Mir ist aufgefallen, dass mit den aktuellen Stand mein WR auf dem letzten Stand mit Erzeugung stehen bleibt, z.B. `openWB/pv/1/get/power = -3`.

Grund dürfte in der Datei packages/modules/common/store/_broker.py liegen:
```
def pub_to_broker(topic: str, value, digits: Union[int, None] = None) -> None:
    rounding = get_rounding_function_by_digits(digits)
    try:
        if value:
            if isinstance(value, list):
                Pub().pub(topic, [rounding(v) for v in value])
            else:
                Pub().pub(topic, rounding(value))
    except Exception as e:
        process_error(e)
```
Der Test `if value` verhindert die Verarbeitung von `value = 0`