### PR TITLE
quickfix mosquitto config

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -56,7 +56,31 @@ echo "apt packages..."
 # nothing here yet, all in install.sh
 
 # check for mosquitto configuration
-# nothing todo here yet, mosquitto is configured in install-skript
+echo "check mosquitto installation..."
+# check for mosquitto configuration
+if [ ! -f /etc/mosquitto/conf.d/openwb.conf ] || ! sudo grep -Fq "persistent_client_expiration" /etc/mosquitto/mosquitto.conf; then
+	echo "updating mosquitto config file"
+	sudo cp ${OPENWBBASEDIR}/data/config/openwb.conf /etc/mosquitto/conf.d/openwb.conf
+	sudo service mosquitto restart
+fi
+
+#check for mosquitto_local instance
+if [ ! -f /etc/mosquitto/mosquitto_local.conf ]; then
+	echo "setting up mosquitto local instance"
+	sudo install -d -m 0755 -o root -g root /etc/mosquitto/conf_local.d/
+	sudo install -d -m 0755 -o mosquitto -g root /var/lib/mosquitto_local
+	sudo cp -a ${OPENWBBASEDIR}/data/config/mosquitto_local.conf /etc/mosquitto/mosquitto_local.conf
+	sudo cp -a ${OPENWBBASEDIR}/data/config/openwb_local.conf /etc/mosquitto/conf_local.d/
+
+	sudo cp ${OPENWBBASEDIR}/data/config/mosquitto_local_init /etc/init.d/mosquitto_local
+	sudo chown root.root /etc/init.d/mosquitto_local
+	sudo chmod 755 /etc/init.d/mosquitto_local
+else
+	sudo cp -a ${OPENWBBASEDIR}/data/config/openwb_local.conf /etc/mosquitto/conf_local.d/
+fi
+sudo systemctl daemon-reload
+sudo service mosquitto_local start
+echo "mosquitto done"
 
 # check for other dependencies
 echo "python packages..."


### PR DESCRIPTION
Durch die Änderung in #221 wurde die Broker-Konfiguration nur noch während der Installation aktualisiert. Jetzt wird sie auch wieder bei einem Neustart aktualisiert.