### PR TITLE
Hybrid systems

### DIFF
--- a/packages/control/bat.py
+++ b/packages/control/bat.py
@@ -80,7 +80,7 @@ class BatAll:
             log.exception("Fehler im Bat-Modul")
 
     def __max_bat_power_hybrid_system(self, battery: Bat) -> float:
-        if battery.data["get"]["power"] < 0:
+        if battery.data["get"]["power"] > 0:
             parent = data.data.counter_data["all"].get_entry_of_parent(battery.bat_num)
             if parent.get("type") == "inverter":
                 parent_data = data.data.pv_data[f"pv{parent['id']}"].data

--- a/packages/control/bat.py
+++ b/packages/control/bat.py
@@ -31,8 +31,8 @@ class Bat:
         self.data = {}
         self.bat_num = index
         self.data["get"] = {}
-        self.data["get"]["daily_yield_import"] = 0
-        self.data["get"]["daily_yield_export"] = 0
+        self.data["get"]["daily_imported"] = 0
+        self.data["get"]["daily_exported"] = 0
 
 
 class BatAll:
@@ -86,8 +86,8 @@ class BatAll:
                 parent_data = data.data.pv_data[f"pv{parent['id']}"].data
                 # Bei einem Hybrid-System darf die Summe aus Batterie-Ladeleistung, die für den Algorithmus verwendet
                 # werden soll und PV-Leistung nicht größer als die max Ausgangsleistung des WR sein.
-                if parent_data["config"]["max_ac_out"] < 0:
-                    max_bat_power = parent_data["config"]["max_ac_out"] - parent_data["get"]["power"]
+                if parent_data["config"]["max_ac_out"] > 0:
+                    max_bat_power = parent_data["config"]["max_ac_out"]*-1 - parent_data["get"]["power"]
                     if battery.data["get"]["power"] > max_bat_power:
                         if battery.data["get"]["fault_state"] == 0:
                             battery.data["get"]["fault_state"] = 1
@@ -289,20 +289,3 @@ class BatAll:
                          "W Speicher-Leistung , die für die folgenden Ladepunkte übrig ist.")
         except Exception:
             log.exception("Fehler im Bat-Modul")
-
-
-<< << << < HEAD
-
-
-class Bat:
-
-    def __init__(self, index):
-        self.data = {}
-        self.bat_num = index
-        self.data["get"] = {}
-        self.data["get"]["daily_imported"] = 0
-        self.data["get"]["daily_exported"] = 0
-
-
-== == == =
->>>>>> > 7e3f5164(max_bat_power_hybrid_system)

--- a/packages/control/bat.py
+++ b/packages/control/bat.py
@@ -14,21 +14,8 @@ Kann es derzeit passieren das die PV 20kW erzeugt, die Batterie mit 5kW geladen 
 Zieht die openWB nun Überschuss (15kW Überschuss + 5kW Batterieladung = 20kW) kommt es zu 5kW Bezug weil der
 Wechselrichter nur 15kW abgeben kann.
 
-aktuell wird halt bei ev vorrang die Batterieladeleistung hinzugerechnet. weil die openWB von ausgeht das die
-dann das laden aufhört und diese leistung eigentlich Überschuss ist.
-Blöd halt wenn der Wechselrichter die nicht zur Verfügung stellen kann.
-Heißt aktuell denkt die openWB "0 Watt Überschuss" weil 5kW bezogen werden, aber eben auch 5kW in die Batterie
-gehen (die ihre Ladung aber nicht drosselt)
-
-du musst halt zum "antesten" bezug generieren damit die Batterie entsprechend gegenregelt. erst wenn sie das nach
- x Sekunden nicht tut kannst von ausgehen da gibt es eine Grenze
-
-__Wie schnell regelt denn ein Speicher?
+__Wie schnell regelt ein Speicher?
 Je nach Speicher 1-4 Sekunden.
-__Muss dann immer ein bisschen Überschuss über sein und wenn dieser im nächsten Zyklus noch da ist, kann der LP
-hochgeregelt werden. Wenn nicht muss der LP runtergeregelt werden?
-Üblicherweise reicht es so zu regeln das rund 50 Watt Einspeisung da sind, dann "nimmt" der Speicher sich die von
-alleine
 """
 import logging
 
@@ -44,8 +31,7 @@ class BatAll:
             "get": {"power":  0},
             "config": {"configured": False},
             "set": {"charging_power_left": 0,
-                    "switch_on_soc_reached": 0,
-                    "hybrid_system_detected": False}
+                    "switch_on_soc_reached": 0}
         }
 
     def calc_power_for_all_components(self):
@@ -103,7 +89,6 @@ class BatAll:
                 self.data["get"]["power"] = 0
             Pub().pub("openWB/set/bat/set/charging_power_left", self.data["set"]["charging_power_left"])
             Pub().pub("openWB/set/bat/set/switch_on_soc_reached", self.data["set"]["switch_on_soc_reached"])
-            Pub().pub("openWB/set/bat/set/hybrid_system_detected", self.data["set"]["hybrid_system_detected"])
         except Exception:
             log.exception("Fehler im Bat-Modul")
 
@@ -114,23 +99,6 @@ class BatAll:
             evu_counter = data.data.counter_data["all"].get_evu_counter()
             config = data.data.general_data["general"].data["chargemode_config"]["pv_charging"]
             if not config["bat_prio"]:
-                # Wenn der Speicher lädt und gleichzeitig Bezug da ist, sind entweder die Werte sehr ungünstig abgefragt
-                # worden
-                # (deshalb wird noch ein Zyklus gewartet) oder es liegt ein Hybrid-System vor.
-                if data.data.counter_data[evu_counter].data["get"]["power"] > 0:
-                    if self.data["set"]["hybrid_system_detected"]:
-                        log.debug("".join(("verbleibende Speicher-Leistung für Hybrid-System: max(",
-                                           self.data["set"]["charging_power_left"], " - ",
-                                           data.data.counter_data[evu_counter].data["get"]["power"],
-                                           ", 0)")))
-                        self.data["set"]["charging_power_left"] = max(
-                            self.data["set"]["charging_power_left"]
-                            - data.data.counter_data[evu_counter].data["get"]["power"], 0)
-                    else:
-                        self.data["set"]["hybrid_system_detected"] = True
-                        log.debug("Erstmalig Hybrid-System detektiert.")
-                elif self.data["set"]["hybrid_system_detected"]:
-                    self.data["set"]["hybrid_system_detected"] = False
                 # Laderegelung wurde noch nicht freigegeben
                 if not self.data["set"]["switch_on_soc_reached"]:
                     if config["switch_on_soc"] != 0:

--- a/packages/control/hierarchy_test.py
+++ b/packages/control/hierarchy_test.py
@@ -188,6 +188,28 @@ def test_get_entry_of_element(params: ParamsItem):
     assert actual == params.expected_return
 
 
+cases_get_entry_of_parent = [
+    ParamsItem("get_entry_of_parent_cp", hierarchy_cp(), 5, {"id": 4, "type": "counter", "children": [
+        {"id": 5, "type": "cp", "children": []},
+        {"id": 6, "type": "cp", "children": []}]}),
+    ParamsItem("get_entry_of_parent_two_level", hierarchy_two_level(), 2, {"id": 0, "type": "counter",
+                                                                           "children": [
+                                                                               {"id": 2,
+                                                                                "type": "cp",
+                                                                                "children": []}]}),
+    ParamsItem("get_entry_of_parent_one_level", hierarchy_one_level(), 0, {})
+]
+
+
+@pytest.mark.parametrize("params", cases_get_entry_of_parent, ids=[c.name for c in cases_get_entry_of_parent])
+def test_get_entry_of_parent(params: ParamsItem):
+    # execution
+    actual = params.counter_all.get_entry_of_parent(params.id)
+
+    # evaluation
+    assert actual == params.expected_return
+
+
 def test_empty_hierarchy():
     # execution
     c = hierarchy_empty()

--- a/packages/control/pv.py
+++ b/packages/control/pv.py
@@ -428,6 +428,10 @@ class PvAll:
             log.exception("Fehler im allgemeinen PV-Modul")
 
 
+def get_inverter_default_config():
+    return {"max_ac_out": 0}
+
+
 class Pv:
 
     def __init__(self, index):

--- a/packages/control/pv.py
+++ b/packages/control/pv.py
@@ -435,9 +435,12 @@ def get_inverter_default_config():
 class Pv:
 
     def __init__(self, index):
-        self.data = {}
+        self.data = {
+            "get": {
+                "daily_yield": 0,
+                "monthly_yield": 0,
+                "yearly_yield": 0
+            },
+            "config": {}
+        }
         self.pv_num = index
-        self.data["get"] = {}
-        self.data["get"]["daily_yield"] = 0
-        self.data["get"]["monthly_yield"] = 0
-        self.data["get"]["yearly_yield"] = 0

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -20,6 +20,7 @@ from control import chargepoint
 from control import data
 from control import ev
 from control import counter
+from control import pv
 from modules.common.component_type import ComponentType, special_to_general_type_mapping, type_to_topic_mapping
 
 log = logging.getLogger(__name__)
@@ -365,6 +366,10 @@ class Command:
             default_config = counter.get_counter_default_config()
             for item in default_config:
                 Pub().pub("openWB/set/counter/"+str(new_id)+"/config/"+item, default_config[item])
+        elif general_type == ComponentType.INVERTER:
+            default_config = pv.get_inverter_default_config()
+            for item in default_config:
+                Pub().pub("openWB/set/pv/"+str(new_id)+"/config/"+item, default_config[item])
         Pub().pub("openWB/set/system/device/"+str(payload["data"]["deviceId"]
                                                   )+"/component/"+str(new_id)+"/config", component_default)
         self.max_id_hierarchy = self.max_id_hierarchy + 1

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -574,7 +574,7 @@ class SetData:
                 self._validate_value(
                     msg, float, [(float("-inf"), 0)], collection=list)
             elif "/config/max_ac_out" in msg.topic:
-                self._validate_value(msg, int, [(float("-inf"), 0)])
+                self._validate_value(msg, int, [(0, float("inf"))])
             else:
                 self.__unknown_topic(msg)
         except Exception:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -575,6 +575,8 @@ class SetData:
             elif "/get/currents" in msg.topic:
                 self._validate_value(
                     msg, float, [(float("-inf"), 0)], collection=list)
+            elif "/config/max_ac_out" in msg.topic:
+                self._validate_value(msg, int, [(float("-inf"), 0)])
             else:
                 self.__unknown_topic(msg)
         except Exception:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -557,8 +557,6 @@ class SetData:
                 self._validate_value(msg, float)
             elif "openWB/set/pv/set/available_power" in msg.topic:
                 self._validate_value(msg, float)
-            elif "/config" in msg.topic:
-                self._validate_value(msg, "json")
             elif "/get/fault_state" in msg.topic:
                 self._validate_value(msg, int, [(0, 2)])
             elif "/get/fault_str" in msg.topic:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -591,8 +591,7 @@ class SetData:
         """
         try:
             if ("openWB/set/bat/config/configured" in msg.topic or
-                    "openWB/set/bat/set/switch_on_soc_reached" in msg.topic or
-                    "openWB/set/bat/set/hybrid_system_detected" in msg.topic):
+                    "openWB/set/bat/set/switch_on_soc_reached" in msg.topic):
                 self._validate_value(msg, bool)
             elif "openWB/set/bat/set/charging_power_left" in msg.topic:
                 self._validate_value(msg, float)

--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -426,11 +426,9 @@ class SubData:
                 else:
                     if "pv"+index not in var:
                         var["pv"+index] = pv.Pv(int(index))
-                    if re.search("^.+/pv/[0-9]+/config$", msg.topic) is not None:
-                        self.set_json_payload(var["pv"+index].data, msg)
+                    if re.search("^.+/pv/[0-9]+/config/.+$", msg.topic) is not None:
+                        self.set_json_payload(var["pv"+index].data["config"], msg)
                     elif re.search("^.+/pv/[0-9]+/get/.+$", msg.topic) is not None:
-                        if "get" not in var["pv"+index].data:
-                            var["pv"+index].data["get"] = {}
                         self.set_json_payload(var["pv"+index].data["get"], msg)
             elif re.search("^.+/pv/.+$", msg.topic) is not None:
                 if re.search("^.+/pv/config/.+$", msg.topic) is not None:

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -187,6 +187,7 @@ class UpdateConfig:
                    "^openWB/pv/get/daily_yield$",
                    "^openWB/pv/get/monthly_yield$",
                    "^openWB/pv/get/yearly_yield$",
+                   "^openWB/pv/[0-9]+/config/max_ac_out$",
                    "^openWB/pv/[0-9]+/get/counter$",
                    "^openWB/pv/[0-9]+/get/power$",
                    "^openWB/pv/[0-9]+/get/currents$",

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -311,10 +311,6 @@ class UpdateConfig:
         ("openWB/system/ip_address", "unknown"),
         ("openWB/system/release_train", "master"))
 
-    new_topics = (
-        ("(openWB/pv/[0-9]+)", "/config/max_ac_out", 0),
-    )
-
     def __init__(self) -> None:
         self.all_received_topics = {}
 
@@ -333,7 +329,6 @@ class UpdateConfig:
         self.__pub_missing_defaults()
         self.__update_version()
         self.__solve_breaking_changes()
-        self.__add_new_topics()
 
     def getserial(self):
         """ Extract serial from cpuinfo file
@@ -386,11 +381,11 @@ class UpdateConfig:
                     payload.update({"prevent_charge_stop": combined_setting, "prevent_phase_switch": combined_setting})
                     Pub().pub(topic.replace("openWB/", "openWB/set/"), payload)
 
-    def __add_new_topics(self):
-        for topic in self.all_received_topics:
-            regex = re.search(f"{self.new_topics[0][0]}/get/fault_state", topic)
+        # zu konfiguriertem Wechselrichter die maximale Ausgangsleistung hinzufügen
+        for topic, payload in self.all_received_topics.items():
+            regex = re.search("(openWB/pv/[0-9]+)/get/fault_state", topic)
             if regex is not None:
                 module = regex.group(1)
-                if f"{module}{self.new_topics[0][1]}" not in self.all_received_topics:
+                if f"{module}/config/max_ac_out" not in self.all_received_topics.keys():
                     Pub().pub(
-                        f'{module.replace("openWB/", "openWB/set/")}{self.new_topics[0][1]}', self.new_topics[0][2])
+                        f'{module.replace("openWB/", "openWB/set/")}/config/max_ac_out', 0)

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -15,7 +15,6 @@ class UpdateConfig:
     valid_topic = ["^openWB/bat/config/configured$",
                    "^openWB/bat/set/charging_power_left$",
                    "^openWB/bat/set/switch_on_soc_reached$",
-                   "^openWB/bat/set/hybrid_system_detected$",
                    "^openWB/bat/get/soc$",
                    "^openWB/bat/get/power$",
                    "^openWB/bat/get/imported$",


### PR DESCRIPTION
Bei Hybrid-Systemen mit DC-Speicher kann die maximale Ausgangsleistung des WR angegeben werden. Diese wird dann bei der zu verwendenden Entladeleistung des Speichers in der Regelung berücksichtigt. Dies bezieht sich nur auf die Regelung. Damit die Werte von Hybridsystemen korrekt ausgelesen werden, muss der Speicher in der Hierarchie unterhalb des Wechselrichters positioniert werden.