### PR TITLE
don't put values in graph if module is in state error

### DIFF
--- a/packages/control/bat.py
+++ b/packages/control/bat.py
@@ -21,6 +21,7 @@ import logging
 
 from control import data
 from helpermodules.pub import Pub
+from modules.common.fault_state import FaultStateLevel
 
 log = logging.getLogger(__name__)
 
@@ -89,8 +90,8 @@ class BatAll:
                 if parent_data["config"]["max_ac_out"] > 0:
                     max_bat_power = parent_data["config"]["max_ac_out"]*-1 - parent_data["get"]["power"]
                     if battery.data["get"]["power"] > max_bat_power:
-                        if battery.data["get"]["fault_state"] == 0:
-                            battery.data["get"]["fault_state"] = 1
+                        if battery.data["get"]["fault_state"] == FaultStateLevel.NO_ERROR:
+                            battery.data["get"]["fault_state"] = FaultStateLevel.WARNING.value
                             battery.data["get"]["fault_str"] = ("Die maximale Entladeleistung des Wechselrichters" +
                                                                 " ist erreicht.")
                             Pub().pub(f"openWB/set/bat/{battery.bat_num}/get/fault_state",

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, List
 from control import data
 from helpermodules.pub import Pub
 from modules.common.component_type import ComponentType
+from modules.common.fault_state import FaultStateLevel
 
 log = logging.getLogger(__name__)
 
@@ -65,8 +66,8 @@ class CounterAll:
                 log.error(
                     f"Ungültiger Hausverbrauch: Leistung der Elemente {power}W, "
                     f"EVU-Leistung {evu}W, Berücksichtigte Komponenten neben EVU {elements}")
-                if evu_counter_data["get"]["fault_state"] == 0:
-                    evu_counter_data["get"]["fault_state"] = 1
+                if evu_counter_data["get"]["fault_state"] == FaultStateLevel.NO_ERROR:
+                    evu_counter_data["get"]["fault_state"] = FaultStateLevel.WARNING.value
                     evu_counter_data["get"][
                         "fault_str"] = "Der Wert für den Hausverbrauch ist nicht plausibel (negativ). Bitte "\
                         "die Leistungen der Komponenten und die Anordnung in der Hierarchie prüfen."
@@ -374,11 +375,11 @@ class Counter:
             # Wenn der Zähler keine Werte liefert, darf nicht geladen werden.
             connected_cps = data.data.counter_data["all"].get_chargepoints_of_counter(f'counter{self.counter_num}')
             for cp in connected_cps:
-                if self.data["get"]["fault_state"] > 0:
+                if self.data["get"]["fault_state"] == FaultStateLevel.ERROR:
                     data.data.cp_data[cp].data["set"]["loadmanagement_available"] = False
                 else:
                     data.data.cp_data[cp].data["set"]["loadmanagement_available"] = True
-            if self.data["get"]["fault_state"] > 0:
+            if self.data["get"]["fault_state"] == FaultStateLevel.ERROR:
                 self.data["get"]["power"] = 0
                 return
 

--- a/packages/helpermodules/graph.py
+++ b/packages/helpermodules/graph.py
@@ -6,6 +6,7 @@ import logging
 
 from control import data
 from helpermodules.pub import Pub
+from modules.common.fault_state import FaultStateLevel
 
 log = logging.getLogger(__name__)
 
@@ -23,13 +24,13 @@ class Graph:
             dataline = {"timestamp": int(
                 time.time()), "time": datetime.datetime.today().strftime("%H:%M:%S")}
             evu_counter = data.data.counter_data["all"].get_evu_counter()
-            if data.data.counter_data[evu_counter].data["get"]["fault_state"] == 0:
+            if data.data.counter_data[evu_counter].data["get"]["fault_state"] < FaultStateLevel.ERROR:
                 dataline.update({"grid": _convert_to_kW(
                     data.data.counter_data[evu_counter].data["get"]["power"])})
             for c in data.data.counter_data:
                 if "counter" in c and evu_counter not in c:
                     counter = data.data.counter_data[c]
-                    if counter.data["get"]["fault_state"] == 0:
+                    if counter.data["get"]["fault_state"] < FaultStateLevel.ERROR:
                         dataline.update({"counter"+str(counter.counter_num) +
                                          "-power": _convert_to_kW(counter.data["get"]["power"])})
             dataline.update(
@@ -43,7 +44,7 @@ class Graph:
                 for cp in data.data.cp_data:
                     if "cp" in cp:
                         chargepoint = data.data.cp_data[cp]
-                        if chargepoint.data["get"]["fault_state"] == 0:
+                        if chargepoint.data["get"]["fault_state"] < FaultStateLevel.ERROR:
                             dataline.update(
                                 {"cp" + str(chargepoint.cp_num) +
                                  "-power": _convert_to_kW(chargepoint.data["get"]["power"])})

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import IntEnum
 import logging
 import traceback
 from typing import Optional
@@ -9,7 +9,7 @@ from modules.common import component_type
 log = logging.getLogger("soc."+__name__)
 
 
-class FaultStateLevel(Enum):
+class FaultStateLevel(IntEnum):
     NO_ERROR = 0
     WARNING = 1
     ERROR = 2
@@ -33,7 +33,7 @@ class FaultState(Exception):
 
     def store_error(self, component_info: ComponentInfo) -> None:
         try:
-            if self.fault_state is not FaultStateLevel.NO_ERROR:
+            if self.fault_state != FaultStateLevel.NO_ERROR:
                 log.error(component_info.name + ": FaultState " +
                           str(self.fault_state) + ", FaultStr " +
                           self.fault_str + ", Traceback: \n" +


### PR DESCRIPTION
Wenn der Hausverbrauch ungültig ist, zB weil aufgrund von Timing die Werte nicht exakt zur gleichen Zeit ausgelesen wurden, wird dies als Warnung auf der Statusseite im EVU-Zähler angezeigt. Wenn ein Zähler im Error-Status ist, werden die Daten nicht im Graph angezeigt.