### PR TITLE
set current to 0 if ev doesn't charge and switch off threshold is rea…

### DIFF
--- a/packages/control/algorithm.py
+++ b/packages/control/algorithm.py
@@ -496,10 +496,6 @@ class Algorithm:
         for cp in data.data.cp_data.values():
             if isinstance(cp, Chargepoint):
                 try:
-                    # chargestate, weil nur die geprüft werden sollen, die tatsächlich laden und nicht die, die in
-                    # diesem Zyklus eingeschaltet wurden.
-                    if not cp.data["get"]["charge_state"]:
-                        continue
                     if cp.data["set"]["charging_ev"] != -1:
                         charging_ev = cp.data["set"]["charging_ev_data"]
                         if((charging_ev.charge_template.data["prio"] == prio) and
@@ -523,7 +519,8 @@ class Algorithm:
             for cp in preferenced_chargepoints:
                 try:
                     if cp.data["set"]["current"] != 0:
-                        data.data.pv_data["all"].switch_off_check_threshold(cp, overhang)
+                        if data.data.pv_data["all"].switch_off_check_threshold(cp, overhang) is False:
+                            cp.data["set"]["current"] = 0
                 except Exception:
                     log.exception(f"Fehler im Algorithmus-Modul für Ladepunkt{cp.cp_num}")
 


### PR DESCRIPTION
…ched

EV, die ohnehin nicht laden, wird direkt die Ladefreigabe entzogen. Würde man required_power vom released_evu_overhang subtrahieren, würden keine anderen EVs abgeschaltet werden und nach der Abschaltverzögerung des nicht-ladeden EVs wäre die Abschaltschwelle immer noch überschritten. Würde man die tatsächliche Leistung von released_evu_overhang subtrahieren, würde released_evu_overhang nach Ablauf der Verzögerung nicht 0 sein, wenn sich die Ladeleistung zwischendurch verändert hat.