### PR TITLE
fix phase switch conditions

### DIFF
--- a/packages/control/auto_phase_switch_test.py
+++ b/packages/control/auto_phase_switch_test.py
@@ -37,7 +37,7 @@ class Params:
                  timestamp_auto_phase_switch: Optional[str],
                  phases_to_use: int,
                  required_current: float,
-                 all_overhang: int,
+                 reserved_evu_overhang: int,
                  get_currents: List[float],
                  get_power: float,
                  expected_phases_to_use: int,
@@ -49,7 +49,7 @@ class Params:
         self.timestamp_auto_phase_switch = timestamp_auto_phase_switch
         self.phases_to_use = phases_to_use
         self.required_current = required_current
-        self.all_overhang = all_overhang
+        self.reserved_evu_overhang = reserved_evu_overhang
         self.get_currents = get_currents
         self.get_power = get_power
         self.expected_phases_to_use = expected_phases_to_use
@@ -60,42 +60,42 @@ class Params:
 
 cases = [
     Params("1to3, enough power, start timer", max_current_one_phase=16, timestamp_auto_phase_switch=None,
-           phases_to_use=1, required_current=6, all_overhang=800, get_currents=[15, 0, 0], get_power=3450,
+           phases_to_use=1, required_current=6, reserved_evu_overhang=0, get_currents=[15, 0, 0], get_power=3450,
            expected_phases_to_use=1, expected_current=6,
            expected_message="Umschaltverzögerung von 1 auf 3 Phasen für 7.0 Min aktiv.",
            expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52"),
     Params("1to3, not enough power, start timer", max_current_one_phase=16, timestamp_auto_phase_switch=None,
-           phases_to_use=1, required_current=6, all_overhang=300, get_currents=[15, 0, 0], get_power=3450,
+           phases_to_use=1, required_current=6, reserved_evu_overhang=500, get_currents=[15, 0, 0], get_power=3450,
            expected_phases_to_use=1, expected_current=6),
     Params("1to3, enough power, timer not expired", max_current_one_phase=16,
-           timestamp_auto_phase_switch="05/16/2022, 08:35:52", phases_to_use=1, required_current=6, all_overhang=800,
-           get_currents=[15, 0, 0], get_power=3450, expected_phases_to_use=1, expected_current=6,
-           expected_message="Umschaltverzögerung von 1 auf 3 Phasen für 7.0 Min aktiv.",
+           timestamp_auto_phase_switch="05/16/2022, 08:35:52", phases_to_use=1, required_current=6,
+           reserved_evu_overhang=0, get_currents=[15, 0, 0], get_power=3450, expected_phases_to_use=1,
+           expected_current=6, expected_message="Umschaltverzögerung von 1 auf 3 Phasen für 7.0 Min aktiv.",
            expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52"),
     Params("1to3, enough power, timer expired", max_current_one_phase=16,
-           timestamp_auto_phase_switch="05/16/2022, 08:32:52", phases_to_use=1, required_current=6, all_overhang=800,
-           get_currents=[15, 0, 0], get_power=3450, expected_phases_to_use=3, expected_current=6),
+           timestamp_auto_phase_switch="05/16/2022, 08:32:52", phases_to_use=1, required_current=6,
+           reserved_evu_overhang=0, get_currents=[15, 0, 0], get_power=3450, expected_phases_to_use=3,
+           expected_current=6),
 
     Params("3to1, start timer", max_current_one_phase=16, timestamp_auto_phase_switch=None, phases_to_use=3,
-           required_current=6, all_overhang=200, get_currents=[4.5, 4.4, 5.8], get_power=3381, expected_phases_to_use=3,
-           expected_current=6, expected_message="Umschaltverzögerung von 3 auf 1 Phasen für 9.0 Min aktiv.",
-           expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52"),
-    Params("3to1, timer not expired", max_current_one_phase=16, timestamp_auto_phase_switch="05/16/2022, 08:35:52",
-           phases_to_use=3, required_current=6,  all_overhang=200, get_currents=[4.5, 4.4, 5.8], get_power=3381,
+           required_current=6, reserved_evu_overhang=900, get_currents=[4.5, 4.4, 5.8], get_power=3381,
            expected_phases_to_use=3, expected_current=6,
            expected_message="Umschaltverzögerung von 3 auf 1 Phasen für 9.0 Min aktiv.",
            expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52"),
+    Params("3to1, timer not expired", max_current_one_phase=16, timestamp_auto_phase_switch="05/16/2022, 08:35:52",
+           phases_to_use=3, required_current=6,  reserved_evu_overhang=900, get_currents=[4.5, 4.4, 5.8],
+           get_power=3381, expected_phases_to_use=3, expected_current=6,
+           expected_message="Umschaltverzögerung von 3 auf 1 Phasen für 9.0 Min aktiv.",
+           expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52"),
     Params("3to1, timer expired", max_current_one_phase=16, timestamp_auto_phase_switch="05/16/2022, 08:29:52",
-           phases_to_use=3, required_current=6, all_overhang=200, get_currents=[4.5, 4.4, 5.8], get_power=3381,
-           expected_phases_to_use=1, expected_current=16),
+           phases_to_use=3, required_current=6, reserved_evu_overhang=900, get_currents=[4.5, 4.4, 5.8],
+           get_power=3381, expected_phases_to_use=1, expected_current=16),
 ]
 
 
 @pytest.mark.parametrize("params", cases, ids=[c.name for c in cases])
 def test_auto_phase_switch(monkeypatch, vehicle: Ev, params: Params):
     # setup
-    mock_overhang_left = Mock(name="overhang_left", return_value=params.all_overhang)
-    monkeypatch.setattr(data.data.pv_data["all"], "overhang_left", mock_overhang_left)
     mock_power_for_bat_charging = Mock(name="power_for_bat_charging", return_value=0)
     monkeypatch.setattr(data.data.bat_data["all"], "power_for_bat_charging", mock_power_for_bat_charging)
 
@@ -103,6 +103,8 @@ def test_auto_phase_switch(monkeypatch, vehicle: Ev, params: Params):
     vehicle.data["control_parameter"]["timestamp_auto_phase_switch"] = params.timestamp_auto_phase_switch
     vehicle.data["control_parameter"]["phases"] = params.phases_to_use
     vehicle.data["control_parameter"]["required_current"] = params.required_current
+    data.data.pv_data["all"].data["set"]["available_power"] = 800
+    data.data.pv_data["all"].data["set"]["reserved_evu_overhang"] = params.reserved_evu_overhang
 
     # execution
     phases_to_use, current, message = vehicle.auto_phase_switch(0, params.get_currents, params.get_power)

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -327,6 +327,7 @@ class Ev:
         phases_to_use = self.data["control_parameter"]["phases"]
         phases_in_use = self.data["control_parameter"]["phases"]
         pv_config = data.data.general_data["general"].data["chargemode_config"]["pv_charging"]
+        max_phases_ev = self.ev_template.data["max_phases"]
         if self.charge_template.data["chargemode"]["pv_charging"]["feed_in_limit"]:
             feed_in_yield = pv_config["feed_in_yield"]
         else:
@@ -338,7 +339,7 @@ class Ev:
         if phases_in_use == 1:
             direction_str = "Umschaltverzögerung von 1 auf 3"
             delay = pv_config["phase_switch_delay"] * 60
-            required_power = self.ev_template.data["min_current"] * 3 * \
+            required_power = self.ev_template.data["min_current"] * max_phases_ev * \
                 230 - self.ev_template.data["max_current_one_phase"] * 230
             new_phase = 3
             new_current = self.ev_template.data["min_current"]
@@ -346,7 +347,7 @@ class Ev:
             direction_str = "Umschaltverzögerung von 3 auf 1"
             delay = (16 - pv_config["phase_switch_delay"]) * 60
             required_power = self.ev_template.data["max_current_one_phase"] * \
-                230 - self.ev_template.data["min_current"] * 3 * 230
+                230 - self.ev_template.data["min_current"] * max_phases_ev * 230
             new_phase = 1
             new_current = self.ev_template.data["max_current_one_phase"]
 
@@ -358,7 +359,8 @@ class Ev:
                 "timestamp_perform_phase_switch"] is None:
             if timestamp_auto_phase_switch is None:
                 condition_1_to_3 = (max(get_currents) > max_current and
-                                    all_overhang > self.ev_template.data["min_current"] * 3 * 230 - get_power and
+                                    all_overhang > self.ev_template.data[
+                                        "min_current"] * max_phases_ev * 230 - get_power and
                                     phases_in_use == 1)
                 condition_3_to_1 = max(get_currents) < min_current and all_overhang < 0 and phases_in_use == 3
                 if condition_3_to_1 or condition_1_to_3:


### PR DESCRIPTION
Forum: [https://openwb.de/forum/viewtopic.php?p=65674#p65674](url)
Umschaltbedingungen angepasst
1->3: max. Strom größer als Maximalstrom abzüglich der Toleranz und der Überschuss muss größer als die Differenz der Leistung, die nachher benötigt wird, sein.
3->1: Stromstärke muss kleiner als die Minimalstromstärke + 1A sein (manche EV laden bei 6A Sollstrom mit 6.1A) und der Überschuss unter Berücksichtigung des Regelintervalls muss kleiner 0 sein. Wenn nur die Stromstärke berückischtigt wird, wird bei Umschaltung einer 16kW-Box trotz 4kW verfügbarer Leistung und fehlendem Bezug wieder umgeschaltet, weil nur mit 6A geladen wird.