### PR TITLE
SMA Modbus TCP :: Wechselrichter wird nicht abgefragt

### DIFF
--- a/packages/modules/sma_modbus_tcp/device.py
+++ b/packages/modules/sma_modbus_tcp/device.py
@@ -22,7 +22,7 @@ def get_default_config() -> dict:
         "type": "sma_modbus_tcp",
         "id": 0,
         "configuration": {
-            "ip": None
+            "ip_address": None
         }
     }
 
@@ -51,7 +51,7 @@ class Device(AbstractDevice):
         if component_type in self.COMPONENT_TYPE_TO_CLASS:
             self.components["component"+str(component_config["id"])] = (self.COMPONENT_TYPE_TO_CLASS[component_type](
                 self.device_config["id"],
-                self.device_config["configuration"]["ip"],
+                self.device_config["configuration"]["ip_address"],
                 component_config))
         else:
             raise Exception(


### PR DESCRIPTION
Es findet keine Abfrage des Wechselrichters statt, mit tcpdump überprüft. 
ping zu Wechselrichter funktioniert.
Etwas "zu Fuß" Debugging hat mich dann auf die richtige Spur gebracht:
Die IP-Adresse wird aus Konfig-Oberfläche nicht übernommen.

MQTT-Pfad openWB/system/device/0/config
ist
{"name": "SMA Modbus TCP", "type": "sma_modbus_tcp", "id": 1, "configuration": {"ip": null, "ip_address": "192.168.XXX.XXX"}}
soll (?)
{"name": "SMA Modbus TCP", "type": "sma_modbus_tcp", "id": 1, "configuration": {"ip_address": "192.168.XXX.XXX"}}

Plattform
- Raspi 4
- Image openWB Alpha3
- SMA HomeManager
- SMA Tripower WR