### PR TITLE
don't overwrite faultstate, set current to 0 if readings fails for 5 cycles

### DIFF
--- a/packages/modules/common/component_type.py
+++ b/packages/modules/common/component_type.py
@@ -30,3 +30,16 @@ def type_to_topic_mapping(component_type: str) -> str:
         return "pv"
     else:
         return component_type
+
+
+def type_topic_mapping_comp(component_type: str) -> str:
+    if "bat" in component_type:
+        return "houseBattery"
+    elif "counter" in component_type:
+        return "evu"
+    elif "inverter" in component_type:
+        return "pv"
+    elif "vehicle" in component_type or "chargepoint" in component_type:
+        return "lp"
+    else:
+        raise Exception("Unbekannter Komponenten-Typ: " + component_type)

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -16,14 +16,15 @@ class FaultStateLevel(IntEnum):
 
 
 class ComponentInfo:
-    def __init__(self, id: int, name: str, type: str) -> None:
+    def __init__(self, id: int, name: str, type: str, hostname: str = "localhost") -> None:
         self.id = id
         self.name = name
         self.type = type
+        self.hostname = hostname
 
     @staticmethod
-    def from_component_config(component_config: dict):
-        return ComponentInfo(component_config["id"], component_config["name"], component_config["type"])
+    def from_component_config(component_config: dict, hostname: str = "localhost"):
+        return ComponentInfo(component_config["id"], component_config["name"], component_config["type"], hostname)
 
 
 class FaultState(Exception):
@@ -40,37 +41,29 @@ class FaultState(Exception):
                           traceback.format_exc())
             ramdisk = compatibility.is_ramdisk_in_use()
             if ramdisk:
-                topic = component_type.type_to_topic_mapping(component_info.type)
+                topic = component_type.type_topic_mapping_comp(component_info.type)
                 prefix = "openWB/set/" + topic + "/"
                 if component_info.id is not None:
-                    if topic == "lp":
+                    if component_type == "vehicle":
                         prefix += str(component_info.id) + "/socF"
                     else:
                         prefix += str(component_info.id) + "/f"
                 else:
                     prefix += "f"
-                pub.pub_single(prefix + "aultStr", self.fault_str)
-                pub.pub_single(prefix + "aultState", self.fault_state.value)
+                pub.pub_single(prefix + "aultStr", self.fault_str, hostname=component_info.hostname)
+                pub.pub_single(prefix + "aultState", self.fault_state.value, hostname=component_info.hostname)
+                if "chargepoint" in component_info.type:
+                    pub.pub_single("openWB/set/" + topic + "/" + str(component_info.id) +
+                                   "/get/fault_str", self.fault_str, hostname=component_info.hostname)
+                    pub.pub_single("openWB/set/" + topic + "/" + str(component_info.id) +
+                                   "/get/fault_state", self.fault_state.value, hostname=component_info.hostname)
             else:
                 topic = component_type.type_to_topic_mapping(component_info.type)
-                pub.Pub().pub(
-                    "openWB/set/" + topic + "/" + str(component_info.id) + "/get/fault_str", self.fault_str)
+                pub.Pub().pub("openWB/set/" + topic + "/" + str(component_info.id) + "/get/fault_str", self.fault_str)
                 pub.Pub().pub(
                     "openWB/set/" + topic + "/" + str(component_info.id) + "/get/fault_state", self.fault_state.value)
         except Exception:
             log.exception("Fehler im Modul fault_state")
-
-    def __type_topic_mapping_comp(self, component_type: str) -> str:
-        if "bat" in component_type:
-            return "houseBattery"
-        elif "counter" in component_type:
-            return "evu"
-        elif "inverter" in component_type:
-            return "pv"
-        elif "vehicle" in component_type:
-            return "lp"
-        else:
-            raise Exception("Unbekannter Komponenten-Typ: " + component_type)
 
     @staticmethod
     def error(message: str) -> "FaultState":

--- a/packages/modules/external_openwb/chargepoint_module.py
+++ b/packages/modules/external_openwb/chargepoint_module.py
@@ -4,7 +4,7 @@ from typing import Dict
 from control import data
 from helpermodules import pub
 from modules.common.abstract_chargepoint import AbstractChargepoint
-from modules.common.component_context import SingleComponentUpdateContext
+from modules.common.component_context import ErrorCounterContext, SingleComponentUpdateContext
 from modules.common.fault_state import ComponentInfo
 
 
@@ -29,40 +29,49 @@ class ChargepointModule(AbstractChargepoint):
         self.component_info = ComponentInfo(
             self.id,
             "Ladepunkt", "chargepoint")
+        self.__client_error_context = ErrorCounterContext(
+            "Anhaltender Fehler beim Auslesen des Ladepunkts. Sollstromstärke wird zurückgesetzt.")
 
     def set_current(self, current: float) -> None:
-        with SingleComponentUpdateContext(self.component_info):
-            if self.connection_module["configuration"]["duo_num"] == 1:
-                pub.pub_single("openWB/set/isss/Current", current,
-                               hostname=self.connection_module["configuration"]["ip_address"])
-            else:
-                pub.pub_single("openWB/set/isss/Lp2Current", current,
-                               hostname=self.connection_module["configuration"]["ip_address"])
+        if self.__client_error_context.error_counter_exceeded():
+            current = 0
+        with SingleComponentUpdateContext(self.component_info, False):
+            with self.__client_error_context:
+                if self.connection_module["configuration"]["duo_num"] == 1:
+                    pub.pub_single("openWB/set/isss/Current", current,
+                                   hostname=self.connection_module["configuration"]["ip_address"])
+                else:
+                    pub.pub_single("openWB/set/isss/Lp2Current", current,
+                                   hostname=self.connection_module["configuration"]["ip_address"])
 
     def get_values(self) -> None:
         with SingleComponentUpdateContext(self.component_info):
-            ip_address = self.connection_module["configuration"]["ip_address"]
-            cp_num = self.id
-            my_ip_address = data.data.system_data["system"].data["ip_address"]
-            pub.pub_single("openWB/set/isss/heartbeat", 0, hostname=ip_address)
-            pub.pub_single("openWB/set/isss/parentWB", my_ip_address,
-                           hostname=ip_address, no_json=True)
-            if (self.connection_module["configuration"]["duo_num"] == 2):
-                pub.pub_single("openWB/set/isss/parentCPlp2", str(cp_num), hostname=ip_address)
-            else:
-                pub.pub_single("openWB/set/isss/parentCPlp1", str(cp_num), hostname=ip_address)
+            with self.__client_error_context:
+                ip_address = self.connection_module["configuration"]["ip_address"]
+                cp_num = self.id
+                my_ip_address = data.data.system_data["system"].data["ip_address"]
+                pub.pub_single("openWB/set/isss/heartbeat", 0, hostname=ip_address)
+                pub.pub_single("openWB/set/isss/parentWB", my_ip_address,
+                               hostname=ip_address, no_json=True)
+                if (self.connection_module["configuration"]["duo_num"] == 2):
+                    pub.pub_single("openWB/set/isss/parentCPlp2", str(cp_num), hostname=ip_address)
+                else:
+                    pub.pub_single("openWB/set/isss/parentCPlp1", str(cp_num), hostname=ip_address)
+                self.__client_error_context.reset_error_counter()
 
     def switch_phases(self, phases_to_use: int, duration: int) -> None:
-        with SingleComponentUpdateContext(self.component_info):
-            pub.pub_single("openWB/set/isss/U1p3p", phases_to_use,
-                           self.connection_module["configuration"]["ip_address"])
-            time.sleep(6+duration-1)
+        with SingleComponentUpdateContext(self.component_info, False):
+            with self.__client_error_context:
+                pub.pub_single("openWB/set/isss/U1p3p", phases_to_use,
+                               self.connection_module["configuration"]["ip_address"])
+                time.sleep(6+duration-1)
 
     def interrupt_cp(self, duration: int) -> None:
-        with SingleComponentUpdateContext(self.component_info):
-            ip_address = self.connection_module["configuration"]["ip_address"]
-            if (self.connection_module["configuration"]["duo_num"] == 2):
-                pub.pub_single("openWB/set/isss/Cpulp2", "1", hostname=ip_address)
-            else:
-                pub.pub_single("openWB/set/isss/Cpulp1", "1", hostname=ip_address)
-            time.sleep(duration)
+        with SingleComponentUpdateContext(self.component_info, False):
+            with self.__client_error_context:
+                ip_address = self.connection_module["configuration"]["ip_address"]
+                if (self.connection_module["configuration"]["duo_num"] == 2):
+                    pub.pub_single("openWB/set/isss/Cpulp2", "1", hostname=ip_address)
+                else:
+                    pub.pub_single("openWB/set/isss/Cpulp1", "1", hostname=ip_address)
+                time.sleep(duration)

--- a/packages/modules/smartwb/chargepoint_module.py
+++ b/packages/modules/smartwb/chargepoint_module.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 from helpermodules import timecheck
 from modules.common.abstract_chargepoint import AbstractChargepoint
-from modules.common.component_context import SingleComponentUpdateContext
+from modules.common.component_context import ErrorCounterContext, SingleComponentUpdateContext
 from modules.common.fault_state import ComponentInfo
 from modules.common.store import get_chargepoint_value_store
 from modules.common.component_state import ChargepointState
@@ -34,53 +34,60 @@ class ChargepointModule(AbstractChargepoint):
         self.component_info = ComponentInfo(
             self.id,
             "Ladepunkt", "chargepoint")
+        self.__client_error_context = ErrorCounterContext(
+            "Anhaltender Fehler beim Auslesen des Ladepunkts. Sollstromstärke wird zurückgesetzt.")
 
     def set_current(self, current: float) -> None:
-        with SingleComponentUpdateContext(self.component_info):
-            ip_address = self.connection_module["configuration"]["ip_address"]
-            timeout = self.connection_module["configuration"]["timeout"]
-            # Stromvorgabe in Hundertstel Ampere
-            params = (
-                ('current', int(current*100)),
-            )
-            req.get_http_session().get('http://'+ip_address+'/setCurrent', params=params, timeout=(timeout, None))
+        if self.__client_error_context.error_counter_exceeded():
+            current = 0
+        with SingleComponentUpdateContext(self.component_info, False):
+            with self.__client_error_context:
+                ip_address = self.connection_module["configuration"]["ip_address"]
+                timeout = self.connection_module["configuration"]["timeout"]
+                # Stromvorgabe in Hundertstel Ampere
+                params = (
+                    ('current', int(current*100)),
+                )
+                req.get_http_session().get('http://'+ip_address+'/setCurrent', params=params, timeout=(timeout, None))
 
     def get_values(self) -> None:
         with SingleComponentUpdateContext(self.component_info):
-            ip_address = self.connection_module["configuration"]["ip_address"]
-            timeout = self.connection_module["configuration"]["timeout"]
-            response = req.get_http_session().get('http://'+ip_address+'/getParameters', timeout=timeout)
-            json_rsp = response.json()["list"][0]
+            with self.__client_error_context:
+                ip_address = self.connection_module["configuration"]["ip_address"]
+                timeout = self.connection_module["configuration"]["timeout"]
+                response = req.get_http_session().get('http://'+ip_address+'/getParameters', timeout=timeout)
+                json_rsp = response.json()["list"][0]
 
-            ev_state = json_rsp["vehicleState"]
-            if ev_state == 3:
-                charge_state = True
-                plug_state = True
-            elif ev_state == 2:
-                charge_state = False
-                plug_state = True
-            else:
-                charge_state = False
-                plug_state = False
-
-            chargepoint_state = ChargepointState(
-                power=json_rsp["actualPower"] * 1000,
-                currents=[json_rsp["currentP1"], json_rsp["currentP2"], json_rsp["currentP3"]],
-                imported=json_rsp["meterReading"],
-                plug_state=plug_state,
-                charge_state=charge_state
-            )
-
-            if json_rsp.get("RFIDUID"):
-                if json_rsp["RFIDUID"] == "":
-                    tag = None
+                ev_state = json_rsp["vehicleState"]
+                if ev_state == 3:
+                    charge_state = True
+                    plug_state = True
+                elif ev_state == 2:
+                    charge_state = False
+                    plug_state = True
                 else:
-                    tag = json_rsp["RFIDUID"]
-                chargepoint_state.read_tag = {
-                    "read_tag": tag,
-                    "timestamp": timecheck.create_timestamp()}
+                    charge_state = False
+                    plug_state = False
 
-            if json_rsp.get("voltageP1"):
-                chargepoint_state.voltages = [json_rsp["voltageP1"], json_rsp["voltageP2"], json_rsp["voltageP3"]]
+                chargepoint_state = ChargepointState(
+                    power=json_rsp["actualPower"] * 1000,
+                    currents=[json_rsp["currentP1"], json_rsp["currentP2"], json_rsp["currentP3"]],
+                    imported=json_rsp["meterReading"],
+                    plug_state=plug_state,
+                    charge_state=charge_state
+                )
 
-            self.__store.set(chargepoint_state)
+                if json_rsp.get("RFIDUID"):
+                    if json_rsp["RFIDUID"] == "":
+                        tag = None
+                    else:
+                        tag = json_rsp["RFIDUID"]
+                    chargepoint_state.read_tag = {
+                        "read_tag": tag,
+                        "timestamp": timecheck.create_timestamp()}
+
+                if json_rsp.get("voltageP1"):
+                    chargepoint_state.voltages = [json_rsp["voltageP1"], json_rsp["voltageP2"], json_rsp["voltageP3"]]
+
+                self.__store.set(chargepoint_state)
+                self.__client_error_context.reset_error_counter()


### PR DESCRIPTION
Der Fehlerstatus wird vor dem Auslesen der Werte zurückgesetzt. Beim Setzen der Sollstromstärke,.. wird der Fehlerstatus nur gesetzt, wenn eine Exception geworfen wurde. So wird verhindert, dass ein Fehlerstatus beim Auslesen durch ein erfolgreiches Setzen der Sollstromstärke überschrieben wird. 
Tritt ein Fehler auf, wird der Error-Zähler erhöht. Wenn 5-mal die Auslesung fehlschlägt, wird der Sollstrom auf 0 gesetzt. Der Fehler-Zähler wird bei einer erfolgreichen Auslesung des LP zurückgesetzt.