### PR TITLE
prevent caching of vue settings app

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -70,6 +70,16 @@ chmod 666 "$LOGFILE"
 		sudo cp "${OPENWBBASEDIR}/data/config/000-default.conf" /etc/apache2/sites-available/
 		echo "...changed"
 	fi
+	echo "checking apache headers module..."
+	if a2query -m headers
+	then
+		echo "already enabled"
+	else
+		echo "currently disabled; enabling module"
+		sudo a2enmod headers
+		sudo systemctl restart apache2
+	fi
+	echo "done"
 
 	# check for needed packages
 	echo "apt packages..."

--- a/web/settings/.htaccess
+++ b/web/settings/.htaccess
@@ -1,0 +1,7 @@
+<Files *.html>
+    FileETag None
+    Header unset ETag
+    Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+    Header set Pragma "no-cache"
+    Header set Expires "Wed, 11 Jan 1984 05:00:00 GMT"
+</Files>

--- a/web/settings/.htaccess
+++ b/web/settings/.htaccess
@@ -1,4 +1,4 @@
-<Files *.html>
+<Files index.html>
     FileETag None
     Header unset ETag
     Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"

--- a/web/settings/dataprotection.html
+++ b/web/settings/dataprotection.html
@@ -3,6 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
   <meta name="generator" content="AsciiDoc 9.0.2" />
   <title></title>


### PR DESCRIPTION
- use `.htaccess` file to prevent caching of index.html; all other included modules use file name hashing and should be reloaded if changed
- add cache headers to dataprotection.html