### PR TITLE
rse: skip if not running on pi

### DIFF
--- a/packages/modules/ripple_control_receiver.py
+++ b/packages/modules/ripple_control_receiver.py
@@ -1,36 +1,37 @@
 import logging
-import RPi.GPIO as GPIO
 import time
-
 from helpermodules.pub import Pub
 
 log = logging.getLogger(__name__)
+has_gpio = True
+
+try:
+    import RPi.GPIO as GPIO
+except ImportError:
+    has_gpio = False
+    log.info("failed to import RPi.GPIO! maybe we are not running on a pi")
+    log.warning("RSE disabled!")
 
 
 def read():
+    rse1: bool = False
+    rse2: bool = False
 
-    GPIO.setmode(GPIO.BCM)
-    GPIO.setup(8, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-    GPIO.setup(9, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+    if has_gpio:
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(8, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        GPIO.setup(9, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-    try:
-        button1_state = GPIO.input(8)
-        button2_state = GPIO.input(9)
+        try:
+            button1_state = GPIO.input(8)
+            button2_state = GPIO.input(9)
 
-        time.sleep(10.2)
+            time.sleep(10.2)
 
-        if not button1_state:
-            Pub().pub("openWB/set/general/ripple_control_receiver/r1_active", True)
-            time.sleep(0.2)
-        else:
-            Pub().pub("openWB/set/general/ripple_control_receiver/r1_active", False)
-            time.sleep(0.2)
-        if not button2_state:
-            Pub().pub("openWB/set/general/ripple_control_receiver/r2_active", True)
-            time.sleep(0.2)
-        else:
-            Pub().pub("openWB/set/general/ripple_control_receiver/r2_active", False)
-            time.sleep(0.2)
-    except Exception:
-        GPIO.cleanup()
-        log.exception()
+            rse1 = not button1_state
+            rse2 = not button2_state
+        except Exception:
+            GPIO.cleanup()
+            log.exception()
+    Pub().pub("openWB/set/general/ripple_control_receiver/r1_active", rse1)
+    Pub().pub("openWB/set/general/ripple_control_receiver/r2_active", rse2)


### PR DESCRIPTION
If importing RPi specific module fails, skip rse handling. This change allows openWB to run on other hardware or as vm if it is a Debian system.

ToDo: Find better handling for different platforms.