### PR TITLE
log device and components config

### DIFF
--- a/packages/control/data.py
+++ b/packages/control/data.py
@@ -8,7 +8,9 @@ import threading
 from typing import Dict
 from control.chargepoint import AllChargepoints, Chargepoint
 
+import dataclass_utils
 from helpermodules.subdata import SubData
+from modules.common.abstract_device import AbstractDevice
 
 log = logging.getLogger(__name__)
 
@@ -273,6 +275,7 @@ class Data:
         self._print_dictionaries(self._optional_data)
         self._print_dictionaries(self._pv_data)
         self._print_dictionaries(self._system_data)
+        self._print_device_config(self._system_data)
         log.debug("\n")
 
     def _print_dictionaries(self, data):
@@ -292,6 +295,16 @@ class Data:
                         pass
                 else:
                     log.debug(key+"\n"+"Klasse fehlt")
+            except Exception:
+                log.exception("Fehler im Data-Modul")
+
+    def _print_device_config(self, data: Dict[str, AbstractDevice]):
+        for key, value in data.items():
+            try:
+                if isinstance(value, AbstractDevice):
+                    log.debug(f"{key}\n{dataclass_utils.asdict(value.device_config)}")
+                    for comp_key, comp_value in value.components.items():
+                        log.debug(f"{comp_key}\n{dataclass_utils.asdict(comp_value.component_config)}")
             except Exception:
                 log.exception("Fehler im Data-Modul")
 


### PR DESCRIPTION
Loggt die Konfiguration der Geräte und Komponenten.
**ACHTUNG: Mit diesem PR sind die Anmeldedaten der Module im Log enthalten. Missbräuchlich verwendbare Anmeldedaten müssen vor dem Posten eines Logs im Forum unkenntlich gemacht werden!**
Lokale IP-Adressen brauchen nicht unkenntlich gemacht werden.