### PR TITLE
fix CacheExpire on SSL

### DIFF
--- a/data/config/apache-openwb-ssl.conf
+++ b/data/config/apache-openwb-ssl.conf
@@ -100,11 +100,12 @@
 		<Directory /usr/lib/cgi-bin>
 				SSLOptions +StdEnvVars
 		</Directory>
-		<Directory /var/www/>
-			Options Indexes FollowSymLinks
+		<Directory /var/www/html/openWB>
 			AllowOverride All
 			Require all granted
 		</Directory>
+
+
 
 		#   SSL Protocol Adjustments:
 		#   The safe and default but still SSL/TLS standard compliant shutdown

--- a/data/config/apache-openwb-ssl.conf
+++ b/data/config/apache-openwb-ssl.conf
@@ -100,6 +100,11 @@
 		<Directory /usr/lib/cgi-bin>
 				SSLOptions +StdEnvVars
 		</Directory>
+		<Directory /var/www/>
+			Options Indexes FollowSymLinks
+			AllowOverride All
+			Require all granted
+		</Directory>
 
 		#   SSL Protocol Adjustments:
 		#   The safe and default but still SSL/TLS standard compliant shutdown


### PR DESCRIPTION
Set AllowOverrice All and other options on /var/www/ directory in apache ssl config