### PR TITLE
request hybrid systems

### DIFF
--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -1,7 +1,7 @@
 """Zähler-Logik
 """
 import logging
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Union
 
 from control import data
 from helpermodules.pub import Pub
@@ -355,6 +355,21 @@ class CounterAll:
                         return True
         else:
             return False
+
+    def get_list_of_elements_per_level(self) -> List[List[Dict[str, Union[int, str]]]]:
+        elements_per_level = []
+        for item in self.data["get"]["hierarchy"]:
+            list(zip(elements_per_level, self._get_list_of_elements_per_level(elements_per_level, item, 0)))
+        return elements_per_level
+
+    def _get_list_of_elements_per_level(self, elements_per_level: List, child: Dict, index: int):
+        try:
+            elements_per_level[index].extend([{"type": child["type"], "id": child["id"]}])
+        except IndexError:
+            elements_per_level.insert(index, [{"type": child["type"], "id": child["id"]}])
+        for child in child["children"]:
+            elements_per_level = self._get_list_of_elements_per_level(elements_per_level, child, index+1)
+        return elements_per_level
 
 
 def get_max_id_in_hierarchy(current_entry: List, max_id: int) -> int:

--- a/packages/control/data.py
+++ b/packages/control/data.py
@@ -416,6 +416,7 @@ class Data:
                 self.__copy_cp_data()
                 self.__copy_counter_data()
                 self.__copy_system_data()
+                self.__copy_module_data()
                 self.graph_data = copy.deepcopy(SubData.graph_data)
             except Exception:
                 log.exception("Fehler im Prepare-Modul")

--- a/packages/control/hierarchy_test.py
+++ b/packages/control/hierarchy_test.py
@@ -250,3 +250,28 @@ def test_get_all_elements_without_children(params: ParamsItem):
 
     # evaluation
     assert actual == params.expected_return
+
+
+cases_list_of_elements_per_level = [
+    ParamsItem("list_of_elements_per_level_cp", hierarchy_cp(),
+               0, expected_return=[[{"id": 0, "type": "counter"}],
+                                   [{"id": 7, "type": "inverter"}, {"id": 2, "type": "counter"}],
+                                   [{"id": 3, "type": "cp"}, {"id": 4, "type": "counter"}],
+                                   [{"id": 5, "type": "cp"}, {"id": 6, "type": "cp"}]]),
+    ParamsItem("list_of_elements_per_level_two_level", hierarchy_two_level(),
+               0, expected_return=[[{"id": 0, "type": "counter"}, {"id": 7, "type": "inverter"}],
+                                   [{"id": 2, "type": "cp"}]]),
+    ParamsItem("list_of_elements_per_level_one_level", hierarchy_one_level(),
+               0, expected_return=[[{"id": 0, "type": "counter"}]])
+]
+
+
+@pytest.mark.parametrize("params",
+                         cases_list_of_elements_per_level,
+                         ids=[c.name for c in cases_list_of_elements_per_level])
+def test_list_of_elements_per_level(params: ParamsItem):
+    # execution
+    actual = params.counter_all.get_list_of_elements_per_level()
+
+    # evaluation
+    assert actual == params.expected_return

--- a/packages/helpermodules/measurement_log_test.py
+++ b/packages/helpermodules/measurement_log_test.py
@@ -35,8 +35,11 @@ def test_get_daily_yields(mock_pub):
             try:
                 if call.args[0] == topic:
                     assert value == call.args[1]
+                    break
             except IndexError:
                 pass
+        else:
+            pytest.fail(f"Topic {topic} is missing")
 
 
 EXPECTED = {

--- a/packages/main.py
+++ b/packages/main.py
@@ -42,17 +42,9 @@ class HandlerAlgorithm:
             @exit_after(data.data.general_data.data.control_interval)
             def handler_with_control_interval():
                 if (data.data.general_data.data.control_interval / 10) == self.interval_counter:
-                    # Mit aktuellen Einstellungen arbeiten.
                     data.data.copy_data()
                     log.setLevel(data.data.system_data["system"].data["debug_level"])
-                    loadvars_.get_hardware_values()
-                    # Virtuelle Module ermitteln die Werte rechnerisch auf Basis der Messwerte anderer Module.
-                    # Daher können sie erst die Werte ermitteln, wenn die physischen Module ihre Werte ermittelt
-                    # haben. Würde man alle Module parallel abfragen, wären die virtuellen Module immer einen
-                    # Zyklus hinterher.
-                    data.data.copy_module_data()
-                    loadvars_.get_virtual_values()
-                    data.data.copy_module_data()
+                    loadvars_.get_values()
                     data.data.copy_data()
                     self.heartbeat = True
                     if data.data.system_data["system"].data["perform_update"]:

--- a/packages/modules/alpha_ess/bat.py
+++ b/packages/modules/alpha_ess/bat.py
@@ -25,7 +25,7 @@ class AlphaEssBat:
         self.component_config = dataclass_from_dict(AlphaEssBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, unit_id: int) -> None:
@@ -52,7 +52,7 @@ class AlphaEssBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=AlphaEssBatSetup)

--- a/packages/modules/alpha_ess/counter.py
+++ b/packages/modules/alpha_ess/counter.py
@@ -20,7 +20,7 @@ class AlphaEssCounter:
                  device_config: AlphaEssConfiguration) -> None:
         self.component_config = dataclass_from_dict(AlphaEssCounterSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
         self.__device_config = device_config
 
@@ -28,7 +28,7 @@ class AlphaEssCounter:
         time.sleep(0.1)
         factory_method = self.__get_values_factory()
         counter_state = factory_method(unit_id)
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
     def __get_values_factory(self,) -> Callable[[int], CounterState]:
         if self.__device_config.source == 0 and self.__device_config.version == 0:

--- a/packages/modules/alpha_ess/inverter.py
+++ b/packages/modules/alpha_ess/inverter.py
@@ -21,7 +21,7 @@ class AlphaEssInverter:
         self.component_config = dataclass_from_dict(AlphaEssInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
         self.__device_config = device_config
 
@@ -34,7 +34,7 @@ class AlphaEssInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
     def __version_factory(self) -> int:
         if self.__device_config.source == 0 and self.__device_config.version == 0:

--- a/packages/modules/batterx/bat.py
+++ b/packages/modules/batterx/bat.py
@@ -15,7 +15,7 @@ class BatterXBat:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(BatterXBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, resp: Dict) -> None:
@@ -28,7 +28,7 @@ class BatterXBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=BatterXBatSetup)

--- a/packages/modules/batterx/counter.py
+++ b/packages/modules/batterx/counter.py
@@ -18,7 +18,7 @@ class BatterXCounter:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(BatterXCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, resp: Dict) -> None:
@@ -46,7 +46,7 @@ class BatterXCounter:
         )
         if power_factors:
             counter_state.power_factors = power_factors
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
     def __parse_list_values(self, resp_json: Dict,
                             id: int, factor: int = 1) -> List[float]:

--- a/packages/modules/batterx/inverter.py
+++ b/packages/modules/batterx/inverter.py
@@ -15,7 +15,7 @@ class BatterXInverter:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(BatterXInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, resp: Dict) -> None:
@@ -27,7 +27,7 @@ class BatterXInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=BatterXInverterSetup)

--- a/packages/modules/byd/bat.py
+++ b/packages/modules/byd/bat.py
@@ -22,7 +22,7 @@ class BYDBat:
         self.__device_config = device_config
         self.component_config = dataclass_from_dict(BYDBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_config.id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -35,7 +35,7 @@ class BYDBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
     def get_values(self) -> Tuple[float, float]:
         '''BYD Speicher bieten zwei HTML-Seiten, auf denen Informationen abgegriffen werden können:

--- a/packages/modules/carlo_gavazzi/counter.py
+++ b/packages/modules/carlo_gavazzi/counter.py
@@ -23,7 +23,7 @@ class CarloGavazziCounter:
         self.component_config = dataclass_from_dict(CarloGavazziCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -51,7 +51,7 @@ class CarloGavazziCounter:
             power=power,
             frequency=frequency
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=CarloGavazziCounterSetup)

--- a/packages/modules/common/store/__init__.py
+++ b/packages/modules/common/store/__init__.py
@@ -1,4 +1,4 @@
-from modules.common.store._api import ValueStore
+from modules.common.store._api import ValueStore, update_values
 from modules.common.store._battery import get_bat_value_store
 from modules.common.store._car import get_car_value_store
 from modules.common.store._chargepoint import get_chargepoint_value_store

--- a/packages/modules/common/store/_api.py
+++ b/packages/modules/common/store/_api.py
@@ -2,6 +2,8 @@ import logging
 from abc import abstractmethod
 from typing import Generic, TypeVar
 
+from modules.common.component_context import SingleComponentUpdateContext
+
 T = TypeVar("T")
 log = logging.getLogger("soc."+__name__)
 
@@ -11,11 +13,25 @@ class ValueStore(Generic[T]):
     def set(self, state: T) -> None:
         pass
 
+    @abstractmethod
+    def update(self) -> None:
+        pass
+
 
 class LoggingValueStore(Generic[T], ValueStore[T]):
     def __init__(self, delegate: ValueStore[T]):
         self.delegate = delegate
 
     def set(self, state: T) -> None:
-        log.debug("Saving %s", state)
+        log.debug("Raw data %s", state)
         self.delegate.set(state)
+
+    def update(self) -> None:
+        log.debug("Saving %s", self.delegate.state)
+        self.delegate.update()
+
+
+def update_values(component):
+    with SingleComponentUpdateContext(component.component_info):
+        if hasattr(component, "store"):
+            component.store.update()

--- a/packages/modules/common/store/_battery.py
+++ b/packages/modules/common/store/_battery.py
@@ -1,9 +1,9 @@
 from helpermodules import compatibility
 from modules.common.component_state import BatState
+from modules.common.fault_state import FaultState
 from modules.common.store import ValueStore
 from modules.common.store._api import LoggingValueStore
 from modules.common.store._broker import pub_to_broker
-from modules.common.store._util import process_error
 from modules.common.store.ramdisk import files
 
 
@@ -19,7 +19,7 @@ class BatteryValueStoreRamdisk(ValueStore[BatState]):
             files.battery.energy_imported.write(bat_state.imported)
             files.battery.energy_exported.write(bat_state.exported)
         except Exception as e:
-            process_error(e)
+            raise FaultState.from_exception(e)
 
 
 class BatteryValueStoreBroker(ValueStore[BatState]):
@@ -27,14 +27,17 @@ class BatteryValueStoreBroker(ValueStore[BatState]):
         self.num = component_num
 
     def set(self, bat_state: BatState):
+        self.state = bat_state
+
+    def update(self):
         try:
-            pub_to_broker("openWB/set/bat/"+str(self.num)+"/get/power", bat_state.power, 2)
-            if bat_state.soc:
-                pub_to_broker("openWB/set/bat/"+str(self.num)+"/get/soc", bat_state.soc, 0)
-            pub_to_broker("openWB/set/bat/"+str(self.num)+"/get/imported", bat_state.imported, 2)
-            pub_to_broker("openWB/set/bat/"+str(self.num)+"/get/exported", bat_state.exported, 2)
+            pub_to_broker("openWB/set/bat/"+str(self.num)+"/get/power", self.state.power, 2)
+            if self.state.soc:
+                pub_to_broker("openWB/set/bat/"+str(self.num)+"/get/soc", self.state.soc, 0)
+            pub_to_broker("openWB/set/bat/"+str(self.num)+"/get/imported", self.state.imported, 2)
+            pub_to_broker("openWB/set/bat/"+str(self.num)+"/get/exported", self.state.exported, 2)
         except Exception as e:
-            process_error(e)
+            raise FaultState.from_exception(e)
 
 
 def get_bat_value_store(component_num: int) -> ValueStore[BatState]:

--- a/packages/modules/common/store/_chargepoint.py
+++ b/packages/modules/common/store/_chargepoint.py
@@ -1,5 +1,6 @@
 from modules.common.component_state import ChargepointState
 from modules.common.store import ValueStore
+from modules.common.store._api import LoggingValueStore
 from modules.common.store._broker import pub_to_broker
 
 
@@ -8,17 +9,20 @@ class ChargepointValueStoreBroker(ValueStore[ChargepointState]):
         self.num = cp_id
 
     def set(self, state: ChargepointState) -> None:
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/voltages", state.voltages, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/currents", state.currents, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/power_factors", state.power_factors, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/imported", state.imported, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/exported", state.exported, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/power", state.power, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/phases_in_use", state.phases_in_use, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/charge_state", state.charge_state, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/plug_state", state.plug_state, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/read_tag", state.read_tag)
+        self.state = state
+
+    def update(self):
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/voltages", self.state.voltages, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/currents", self.state.currents, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/power_factors", self.state.power_factors, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/imported", self.state.imported, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/exported", self.state.exported, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/power", self.state.power, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/phases_in_use", self.state.phases_in_use, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/charge_state", self.state.charge_state, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/plug_state", self.state.plug_state, 2)
+        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/read_tag", self.state.read_tag)
 
 
 def get_chargepoint_value_store(id: int) -> ValueStore[ChargepointState]:
-    return ChargepointValueStoreBroker(id)
+    return LoggingValueStore(ChargepointValueStoreBroker(id))

--- a/packages/modules/common/store/_counter_test.py
+++ b/packages/modules/common/store/_counter_test.py
@@ -1,0 +1,78 @@
+# bad integration test
+
+from typing import Callable, NamedTuple
+from unittest.mock import Mock
+
+import pytest
+
+
+from control import data
+from control.bat import Bat
+from control.chargepoint import Chargepoint
+from control.counter import Counter, CounterAll
+from control.pv import Pv
+from modules.common.component_state import CounterState
+from modules.common.store._counter import PurgeCounterState
+
+
+@pytest.fixture(autouse=True)
+def mock_data() -> None:
+    data.data_init(Mock())
+    data.data.counter_data["all"] = CounterAll()
+    data.data.counter_data["all"].data.update({"get": {"hierarchy": []}})
+
+
+def add_chargepoint(id: int):
+    data.data.cp_data[f"cp{id}"] = Mock(spec=Chargepoint,
+                                        id=id,
+                                        chargepoint_module=Mock(),
+                                        data=Mock(
+                                            config=Mock(phase_1=1),
+                                            get=Mock(power=13359,
+                                                     currents=[19.36, 19.36, 19.36],
+                                                     imported=0,
+                                                     exported=0)))
+
+
+def mock_data_standard():
+    add_chargepoint(3)
+    data.data.bat_data["inverter1"] = Mock(spec=Pv, data={"get": {"power": 5786, "exported": 200}})
+    data.data.bat_data["bat2"] = Mock(spec=Bat, data={"get": {"power": 223, "exported": 200, "imported": 100}})
+    data.data.counter_data["all"].data["get"]["hierarchy"] = [{"id": 0, "type": "counter",
+                                                               "children": [{"id": 3, "type": "cp", "children": []}]},
+                                                              {"id": 1, "type": "inverter", "children": []},
+                                                              {"id": 2, "type": "bat", "children": []}]
+
+
+def mock_data_nested():
+    add_chargepoint(1)
+    add_chargepoint(3)
+    data.data.counter_data["counter2"] = Mock(
+        spec=Counter, data={"get": {"power": 13359, "exported": 0, "imported": 0, "currents": [19.36, 19.36, 19.36]}})
+    data.data.counter_data["all"].data["get"]["hierarchy"] = [
+        {"id": 0, "type": "counter",
+         "children": [{"id": 1, "type": "cp", "children": []},
+                      {"id": 2, "type": "counter",
+                       "children": [
+                           {"id": 3, "type": "cp", "children": []}]}]}]
+
+
+Params = NamedTuple("Params", [("name", str), ("mock_data", Callable), ("expected_state", CounterState)])
+cases = [
+    Params("standard", mock_data_standard, CounterState(power=8358, currents=[26.61]*3, exported=200, imported=100)),
+    Params("nested virtual", mock_data_nested, CounterState(
+        power=21717, currents=[45.97]*3, exported=200, imported=100))
+]
+
+
+@pytest.mark.parametrize("params", cases, ids=[c.name for c in cases])
+def test_calc_virtual(params):
+    # setup
+    params.mock_data()
+    purge = PurgeCounterState(delegate=Mock(delegate=Mock(num=0)), add_child_values=True)
+
+    # execution
+    state = purge.calc_virtual(CounterState(power=-5001, currents=[7.25]*3, exported=200, imported=100))
+
+    # evaluation
+    assert vars(state) == vars(params.expected_state)

--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -1,3 +1,7 @@
+from operator import add
+import logging
+
+from control import data
 from helpermodules import compatibility
 from modules.common.component_state import InverterState
 from modules.common.fault_state import FaultState
@@ -6,6 +10,8 @@ from modules.common.store._api import LoggingValueStore
 from modules.common.store._broker import pub_to_broker
 from modules.common.store.ramdisk import files
 
+log = logging.getLogger(__name__)
+
 
 class InverterValueStoreRamdisk(ValueStore[InverterState]):
     def __init__(self, component_num: int) -> None:
@@ -13,7 +19,7 @@ class InverterValueStoreRamdisk(ValueStore[InverterState]):
 
     def set(self, inverter_state: InverterState):
         try:
-            self.__pv.power.write(inverter_state.power)
+            self.__pv.power.write(int(inverter_state.power))
             self.__pv.energy.write(inverter_state.exported)
             self.__pv.energy_k.write(inverter_state.exported / 1000)
             if inverter_state.currents:
@@ -27,16 +33,47 @@ class InverterValueStoreBroker(ValueStore[InverterState]):
         self.num = component_num
 
     def set(self, inverter_state: InverterState):
-        try:
-            pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/power", inverter_state.power, 2)
-            pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/exported", inverter_state.exported, 3)
-            if inverter_state.currents:
-                pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/currents", inverter_state.currents, 1)
-        except Exception as e:
-            raise FaultState.from_exception(e)
+        self.state = inverter_state
+
+    def update(self):
+        pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/power", self.state.power, 2)
+        pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/exported", self.state.exported, 3)
+        if self.state.currents:
+            pub_to_broker("openWB/set/pv/" + str(self.num) + "/get/currents", self.state.currents, 1)
 
 
-def get_inverter_value_store(component_num: int) -> ValueStore[InverterState]:
-    return LoggingValueStore(
+class PurgeInverterState:
+    def __init__(self, delegate: LoggingValueStore) -> None:
+        self.delegate = delegate
+
+    def set(self, state: InverterState) -> None:
+        self.delegate.set(state)
+
+    def update(self) -> None:
+        state = self.fix_hybrid_values(self.delegate.delegate.state)
+        self.delegate.set(state)
+        self.delegate.update()
+
+    def fix_hybrid_values(self, state: InverterState) -> InverterState:
+        children = data.data.counter_data["all"].get_entry_of_element(self.delegate.delegate.num)["children"]
+        if len(children):
+            hybrid = []
+            for c in children:
+                if c.get("type") == "bat":
+                    hybrid.append(f'bat{c["id"]}')
+                    break
+            if len(hybrid):
+                for bat in hybrid:
+                    state.power -= data.data.bat_data[bat].data["get"]["power"]
+                    state.exported -= data.data.bat_data[bat].data["get"]["exported"]
+                    if state.currents and data.data.bat_data[bat].data["get"].get("currents"):
+                        state.currents = list(map(add, state.currents, data.data.bat_data[bat].data["get"]["currents"]))
+                    else:
+                        state.currents = [0.0]*3
+        return state
+
+
+def get_inverter_value_store(component_num: int) -> PurgeInverterState:
+    return PurgeInverterState(LoggingValueStore(
         (InverterValueStoreRamdisk if compatibility.is_ramdisk_in_use() else InverterValueStoreBroker)(component_num)
-    )
+    ))

--- a/packages/modules/common/store/_inverter_test.py
+++ b/packages/modules/common/store/_inverter_test.py
@@ -1,0 +1,53 @@
+# bad integration test
+
+from typing import List, NamedTuple
+from unittest.mock import Mock
+
+import pytest
+
+
+from control import data
+from control.bat import Bat
+from control.counter import CounterAll
+from modules.common.component_state import InverterState
+from modules.common.store._inverter import PurgeInverterState
+
+
+@pytest.fixture(autouse=True)
+def mock_data() -> None:
+    data.data_init(Mock())
+    data.data.counter_data["all"] = CounterAll()
+    data.data.counter_data["all"].data.update({"get": {"hierarchy": []}})
+
+
+STANDARD_HIERARCHY = [{"id": 0, "type": "counter",
+                       "children": [{"id": 3, "type": "cp", "children": []}]},
+                      {"id": 1, "type": "inverter", "children": []},
+                      {"id": 2, "type": "bat", "children": []}]
+
+
+HYBRID_HIERARCHY = [{"id": 0, "type": "counter",
+                     "children": [{"id": 3, "type": "cp", "children": []}]},
+                    {"id": 1, "type": "inverter",
+                     "children": [{"id": 2, "type": "bat", "children": []}]}]
+
+
+Params = NamedTuple("Params", [("name", str), ("hierarchy", List), ("expected_state", InverterState)])
+cases = [
+    Params("standard", STANDARD_HIERARCHY, InverterState(power=-5786, exported=200)),
+    Params("hybrid", HYBRID_HIERARCHY, InverterState(power=-6009, exported=0))
+]
+
+
+@ pytest.mark.parametrize("params", cases, ids=[c.name for c in cases])
+def test_fix_hybrid_values(params):
+    # setup
+    data.data.counter_data["all"].data["get"]["hierarchy"] = params.hierarchy
+    data.data.bat_data["bat2"] = Mock(spec=Bat, data={"get": {"power": 223, "exported": 200, "imported": 100}})
+    purge = PurgeInverterState(delegate=Mock(delegate=Mock(num=1)))
+
+    # execution
+    state = purge.fix_hybrid_values(InverterState(power=-5786, exported=200))
+
+    # evaluation
+    assert vars(state) == vars(params.expected_state)

--- a/packages/modules/fronius/bat.py
+++ b/packages/modules/fronius/bat.py
@@ -21,7 +21,7 @@ class FroniusBat:
         self.component_config = dataclass_from_dict(FroniusBatSetup, component_config)
         self.device_config = device_config
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -54,7 +54,7 @@ class FroniusBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=FroniusBatSetup)

--- a/packages/modules/fronius/counter_s0.py
+++ b/packages/modules/fronius/counter_s0.py
@@ -20,7 +20,7 @@ class FroniusS0Counter:
         self.component_config = dataclass_from_dict(FroniusS0CounterSetup, component_config)
         self.device_config = device_config
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -38,7 +38,7 @@ class FroniusS0Counter:
             exported=exported,
             power=power
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=FroniusS0CounterSetup)

--- a/packages/modules/fronius/counter_sm.py
+++ b/packages/modules/fronius/counter_sm.py
@@ -26,11 +26,10 @@ class FroniusSmCounter:
         self.component_config = dataclass_from_dict(FroniusSmCounterSetup, component_config)
         self.device_config = device_config
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
-
         session = req.get_http_session()
         variant = self.component_config.configuration.variant
         if variant == 0 or variant == 1:
@@ -39,9 +38,8 @@ class FroniusSmCounter:
             counter_state = self.__update_variant_2(session)
         else:
             raise FaultState.error("Unbekannte Variante: "+str(variant))
-
         counter_state.imported, counter_state.exported = self.sim_counter.sim_count(counter_state.power)
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
     def __update_variant_0_1(self, session: Session) -> CounterState:
         variant = self.component_config.configuration.variant

--- a/packages/modules/fronius/inverter.py
+++ b/packages/modules/fronius/inverter.py
@@ -22,7 +22,7 @@ class FroniusInverter:
         self.component_config = dataclass_from_dict(FroniusInverterSetup, component_config)
         self.device_config = device_config
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def read_power(self) -> float:
@@ -54,7 +54,7 @@ class FroniusInverter:
         )
 
     def update(self) -> None:
-        self.__store.set(self.fill_inverter_state(self.read_power()))
+        self.store.set(self.fill_inverter_state(self.read_power()))
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=FroniusInverterSetup)

--- a/packages/modules/good_we/bat.py
+++ b/packages/modules/good_we/bat.py
@@ -19,7 +19,7 @@ class GoodWeBat:
         self.__modbus_id = modbus_id
         self.component_config = dataclass_from_dict(GoodWeBatSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -37,7 +37,7 @@ class GoodWeBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=GoodWeBatSetup)

--- a/packages/modules/good_we/counter.py
+++ b/packages/modules/good_we/counter.py
@@ -19,7 +19,7 @@ class GoodWeCounter:
         self.__modbus_id = modbus_id
         self.component_config = dataclass_from_dict(GoodWeCounterSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -49,7 +49,7 @@ class GoodWeCounter:
             power_factors=power_factors,
             frequency=frequency
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=GoodWeCounterSetup)

--- a/packages/modules/good_we/inverter.py
+++ b/packages/modules/good_we/inverter.py
@@ -19,7 +19,7 @@ class GoodWeInverter:
         self.__modbus_id = modbus_id
         self.component_config = dataclass_from_dict(GoodWeInverterSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -33,7 +33,7 @@ class GoodWeInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=GoodWeInverterSetup)

--- a/packages/modules/http/bat.py
+++ b/packages/modules/http/bat.py
@@ -16,7 +16,7 @@ class HttpBat:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(HttpBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
@@ -37,7 +37,7 @@ class HttpBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=HttpBatSetup)

--- a/packages/modules/http/counter.py
+++ b/packages/modules/http/counter.py
@@ -16,7 +16,7 @@ class HttpCounter:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(HttpCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
@@ -41,7 +41,7 @@ class HttpCounter:
             exported=exported,
             power=power
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=HttpCounterSetup)

--- a/packages/modules/http/inverter.py
+++ b/packages/modules/http/inverter.py
@@ -17,7 +17,7 @@ class HttpInverter:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(HttpInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
         self.__get_exported = create_request_function(url, self.component_config.configuration.exported_path)
@@ -33,7 +33,7 @@ class HttpInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=HttpInverterSetup)

--- a/packages/modules/huawei/bat.py
+++ b/packages/modules/huawei/bat.py
@@ -24,7 +24,7 @@ class HuaweiBat:
         self.component_config = dataclass_from_dict(HuaweiBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -40,7 +40,7 @@ class HuaweiBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=HuaweiBatSetup)

--- a/packages/modules/huawei/counter.py
+++ b/packages/modules/huawei/counter.py
@@ -24,7 +24,7 @@ class HuaweiCounter:
         self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -42,7 +42,7 @@ class HuaweiCounter:
             exported=exported,
             power=power
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=HuaweiCounterSetup)

--- a/packages/modules/huawei/inverter.py
+++ b/packages/modules/huawei/inverter.py
@@ -24,7 +24,7 @@ class HuaweiInverter:
         self.component_config = dataclass_from_dict(HuaweiInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -36,7 +36,7 @@ class HuaweiInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=HuaweiInverterSetup)

--- a/packages/modules/ip_evse/chargepoint_module.py
+++ b/packages/modules/ip_evse/chargepoint_module.py
@@ -30,7 +30,7 @@ class ChargepointModule(AbstractChargepoint):
         self.power_module = power_module
         ip_address = self.connection_module["configuration"]["ip_address"]
         self.__client = modbus.ModbusClient(ip_address, 8899)
-        self.__store = get_chargepoint_value_store(self.id)
+        self.store = get_chargepoint_value_store(self.id)
         self.component_info = ComponentInfo(
             self.id,
             "Ladepunkt", "chargepoint")
@@ -54,7 +54,7 @@ class ChargepointModule(AbstractChargepoint):
             chargepoint_state = ChargepointState(
                 plug_state=plug_state,
                 charge_state=charge_state)
-            self.__store.set(chargepoint_state)
+            self.store.set(chargepoint_state)
 
     def set_current(self, current: float) -> None:
         with SingleComponentUpdateContext(self.component_info):

--- a/packages/modules/janitza/counter.py
+++ b/packages/modules/janitza/counter.py
@@ -21,7 +21,7 @@ class JanitzaCounter:
         self.component_config = dataclass_from_dict(JanitzaCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -45,7 +45,7 @@ class JanitzaCounter:
             frequency=frequency,
             power_factors=power_factors
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=JanitzaCounterSetup)

--- a/packages/modules/json/bat.py
+++ b/packages/modules/json/bat.py
@@ -17,7 +17,7 @@ class JsonBat:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(JsonBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response) -> None:
@@ -41,7 +41,7 @@ class JsonBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=JsonBatSetup)

--- a/packages/modules/json/counter.py
+++ b/packages/modules/json/counter.py
@@ -17,7 +17,7 @@ class JsonCounter:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(JsonCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response):
@@ -36,7 +36,7 @@ class JsonCounter:
             exported=exported,
             power=power
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=JsonCounterSetup)

--- a/packages/modules/json/inverter.py
+++ b/packages/modules/json/inverter.py
@@ -17,7 +17,7 @@ class JsonInverter:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(JsonInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response) -> None:
@@ -35,7 +35,7 @@ class JsonInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=JsonInverterSetup)

--- a/packages/modules/kostal_piko/counter.py
+++ b/packages/modules/kostal_piko/counter.py
@@ -20,7 +20,7 @@ class KostalPikoCounter:
         self.component_config = dataclass_from_dict(KostalPikoCounterSetup, component_config)
         self.ip_address = ip_address
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def get_values(self) -> Tuple[float, List[float]]:
@@ -41,7 +41,7 @@ class KostalPikoCounter:
             power=power,
             powers=powers
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=KostalPikoCounterSetup)

--- a/packages/modules/kostal_piko/inverter.py
+++ b/packages/modules/kostal_piko/inverter.py
@@ -17,7 +17,7 @@ class KostalPikoInverter:
                  ip_address: str) -> None:
         self.component_config = dataclass_from_dict(KostalPikoInverterSetup, component_config)
         self.ip_address = ip_address
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def get_values(self) -> Tuple[float, float]:
@@ -32,11 +32,8 @@ class KostalPikoInverter:
             power = power*-1
 
         exported = float(resp["dxsEntries"][1]["value"]) * 1000
-        return power, exported
 
-    def update(self):
-        power, exported = self.get_values()
-        self.__store.set(InverterState(
+        self.store.set(InverterState(
             exported=exported,
             power=power
         ))

--- a/packages/modules/lg/bat.py
+++ b/packages/modules/lg/bat.py
@@ -16,7 +16,7 @@ class LgBat:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(LgBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response) -> None:
@@ -37,7 +37,7 @@ class LgBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=LgBatSetup)

--- a/packages/modules/lg/counter.py
+++ b/packages/modules/lg/counter.py
@@ -15,7 +15,7 @@ class LgCounter:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(LgCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response) -> None:
@@ -29,7 +29,7 @@ class LgCounter:
             exported=exported,
             power=power
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=LgCounterSetup)

--- a/packages/modules/lg/inverter.py
+++ b/packages/modules/lg/inverter.py
@@ -15,7 +15,7 @@ class LgInverter:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(LgInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, response: Dict) -> None:
@@ -25,7 +25,7 @@ class LgInverter:
             exported=exported,
             power=power
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=LgInverterSetup)

--- a/packages/modules/openwb_flex/bat.py
+++ b/packages/modules/openwb_flex/bat.py
@@ -27,7 +27,7 @@ class BatKitFlex:
                                 tcp_client)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -50,7 +50,7 @@ class BatKitFlex:
             exported=exported,
             power=power
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=BatKitFlexSetup)

--- a/packages/modules/openwb_flex/counter.py
+++ b/packages/modules/openwb_flex/counter.py
@@ -27,7 +27,7 @@ class EvuKitFlex:
                                 tcp_client)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -61,7 +61,7 @@ class EvuKitFlex:
             power=power,
             frequency=frequency
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=EvuKitFlexSetup)

--- a/packages/modules/openwb_flex/inverter.py
+++ b/packages/modules/openwb_flex/inverter.py
@@ -26,7 +26,7 @@ class PvKitFlex:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.simulation = {}
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -52,7 +52,7 @@ class PvKitFlex:
             exported=exported,
             currents=currents
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=PvKitFlexSetup)

--- a/packages/modules/openwb_pro/chargepoint_module.py
+++ b/packages/modules/openwb_pro/chargepoint_module.py
@@ -30,7 +30,7 @@ class ChargepointModule(AbstractChargepoint):
         self.id = id
         self.connection_module = connection_module
         self.power_module = power_module
-        self.__store = get_chargepoint_value_store(self.id)
+        self.store = get_chargepoint_value_store(self.id)
         self.component_info = ComponentInfo(
             self.id,
             "Ladepunkt", "chargepoint")
@@ -69,7 +69,7 @@ class ChargepointModule(AbstractChargepoint):
                     phases_in_use=json_rsp["phases_in_use"]
                 )
 
-                self.__store.set(chargepoint_state)
+                self.store.set(chargepoint_state)
                 self.__client_error_context.reset_error_counter()
 
     def switch_phases(self, phases_to_use: int, duration: int) -> None:

--- a/packages/modules/powerdog/counter.py
+++ b/packages/modules/powerdog/counter.py
@@ -24,7 +24,7 @@ class PowerdogCounter:
         self.component_config = dataclass_from_dict(PowerdogCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -40,7 +40,7 @@ class PowerdogCounter:
             exported=exported,
             power=power
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=PowerdogCounterSetup)

--- a/packages/modules/powerdog/inverter.py
+++ b/packages/modules/powerdog/inverter.py
@@ -24,7 +24,7 @@ class PowerdogInverter:
         self.component_config = dataclass_from_dict(PowerdogInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> float:
@@ -36,7 +36,7 @@ class PowerdogInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
         return power
 
 

--- a/packages/modules/saxpower/bat.py
+++ b/packages/modules/saxpower/bat.py
@@ -21,7 +21,7 @@ class SaxpowerBat:
         self.component_config = dataclass_from_dict(SaxpowerBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -37,7 +37,7 @@ class SaxpowerBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SaxpowerBatSetup)

--- a/packages/modules/siemens/bat.py
+++ b/packages/modules/siemens/bat.py
@@ -21,7 +21,7 @@ class SiemensBat:
         self.component_config = dataclass_from_dict(SiemensBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -36,7 +36,7 @@ class SiemensBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SiemensBatSetup)

--- a/packages/modules/siemens/counter.py
+++ b/packages/modules/siemens/counter.py
@@ -21,7 +21,7 @@ class SiemensCounter:
         self.component_config = dataclass_from_dict(SiemensCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -36,7 +36,7 @@ class SiemensCounter:
             exported=exported,
             power=power
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SiemensCounterSetup)

--- a/packages/modules/siemens/inverter.py
+++ b/packages/modules/siemens/inverter.py
@@ -21,7 +21,7 @@ class SiemensInverter:
         self.component_config = dataclass_from_dict(SiemensInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -33,7 +33,7 @@ class SiemensInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SiemensInverterSetup)

--- a/packages/modules/sma_sunny_boy/bat.py
+++ b/packages/modules/sma_sunny_boy/bat.py
@@ -17,7 +17,7 @@ class SunnyBoyBat:
                  tcp_client: ModbusTcpClient_) -> None:
         self.component_config = dataclass_from_dict(SmaSunnyBoyBatSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def read(self) -> BatState:
@@ -41,7 +41,7 @@ class SunnyBoyBat:
         )
 
     def update(self) -> None:
-        self.__store.set(self.read())
+        self.store.set(self.read())
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SmaSunnyBoyBatSetup)

--- a/packages/modules/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/sma_sunny_boy/bat_smart_energy.py
@@ -22,11 +22,11 @@ class SunnyBoySmartEnergyBat:
         self.component_config = dataclass_from_dict(SmaSunnyBoySmartEnergyBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
-        self.__store.set(self.read())
+        self.store.set(self.read())
 
     def read(self) -> BatState:
         unit = 3

--- a/packages/modules/sma_sunny_boy/counter.py
+++ b/packages/modules/sma_sunny_boy/counter.py
@@ -21,7 +21,7 @@ class SmaSunnyBoyCounter:
         self.component_config = dataclass_from_dict(SmaSunnyBoyCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -39,7 +39,7 @@ class SmaSunnyBoyCounter:
             exported=exported,
             power=power
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SmaSunnyBoyCounterSetup)

--- a/packages/modules/sma_sunny_boy/inverter.py
+++ b/packages/modules/sma_sunny_boy/inverter.py
@@ -25,11 +25,11 @@ class SmaSunnyBoyInverter:
                  tcp_client: modbus.ModbusTcpClient_) -> None:
         self.component_config = dataclass_from_dict(SmaSunnyBoyInverterSetup, component_config)
         self.tcp_client = tcp_client
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
-        self.__store.set(self.read()[0])
+        self.store.set(self.read()[0])
 
     def read(self) -> Tuple[InverterState, bool]:
         if self.component_config.configuration.version == SmaInverterVersion.default:

--- a/packages/modules/sma_sunny_island/bat.py
+++ b/packages/modules/sma_sunny_island/bat.py
@@ -17,7 +17,7 @@ class SunnyIslandBat:
                  tcp_client: modbus.ModbusTcpClient_) -> None:
         self.component_config = dataclass_from_dict(SmaSunnyIslandBatSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def read(self) -> BatState:
@@ -36,7 +36,7 @@ class SunnyIslandBat:
         )
 
     def update(self) -> None:
-        self.__store.set(self.read())
+        self.store.set(self.read())
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SmaSunnyIslandBatSetup)

--- a/packages/modules/sma_webbox/inverter.py
+++ b/packages/modules/sma_webbox/inverter.py
@@ -14,11 +14,11 @@ class SmaWebboxInverter:
     def __init__(self, device_address: str, component_config: Union[Dict, SmaWebboxInverterSetup]) -> None:
         self.__device_address = device_address
         self.component_config = dataclass_from_dict(SmaWebboxInverterSetup, component_config)
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
-        self.__store.set(self.read())
+        self.store.set(self.read())
 
     def read(self) -> InverterState:
         data = {'RPC': '{"version": "1.0","proc": "GetPlantOverview","id": "1","format": "JSON"}'}

--- a/packages/modules/smartwb/chargepoint_module.py
+++ b/packages/modules/smartwb/chargepoint_module.py
@@ -30,7 +30,7 @@ class ChargepointModule(AbstractChargepoint):
         self.id = id
         self.connection_module = connection_module
         self.power_module = power_module
-        self.__store = get_chargepoint_value_store(self.id)
+        self.store = get_chargepoint_value_store(self.id)
         self.component_info = ComponentInfo(
             self.id,
             "Ladepunkt", "chargepoint")
@@ -98,7 +98,7 @@ class ChargepointModule(AbstractChargepoint):
                 if json_rsp.get("voltageP1"):
                     chargepoint_state.voltages = [json_rsp["voltageP1"], json_rsp["voltageP2"], json_rsp["voltageP3"]]
 
-                self.__store.set(chargepoint_state)
+                self.store.set(chargepoint_state)
                 self.__client_error_context.reset_error_counter()
 
     def clear_rfid(self) -> None:

--- a/packages/modules/solaredge/bat.py
+++ b/packages/modules/solaredge/bat.py
@@ -26,11 +26,11 @@ class SolaredgeBat:
         self.component_config = dataclass_from_dict(SolaredgeBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, state: BatState) -> None:
-        self.__store.set(state)
+        self.store.set(state)
 
     def read_state(self):
         power, soc = self.get_values()

--- a/packages/modules/solaredge/counter.py
+++ b/packages/modules/solaredge/counter.py
@@ -19,7 +19,7 @@ class SolaredgeCounter:
                  tcp_client: modbus.ModbusTcpClient_) -> None:
         self.component_config = dataclass_from_dict(SolaredgeCounterSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -78,7 +78,7 @@ class SolaredgeCounter:
             power_factors=power_factors,
             frequency=frequency
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolaredgeCounterSetup)

--- a/packages/modules/solaredge/external_inverter.py
+++ b/packages/modules/solaredge/external_inverter.py
@@ -21,11 +21,11 @@ class SolaredgeExternalInverter:
         self.component_config = dataclass_from_dict(SolaredgeExternalInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, state: InverterState) -> None:
-        self.__store.set(state)
+        self.store.set(state)
 
     def read_state(self) -> InverterState:
         unit = self.component_config.configuration.modbus_id

--- a/packages/modules/solaredge/inverter.py
+++ b/packages/modules/solaredge/inverter.py
@@ -19,11 +19,11 @@ class SolaredgeInverter:
                  tcp_client: modbus.ModbusTcpClient_) -> None:
         self.component_config = dataclass_from_dict(SolaredgeInverterSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, state: InverterState) -> None:
-        self.__store.set(state)
+        self.store.set(state)
 
     def read_state(self):
         def read_scaled_int16(address: int, count: int):

--- a/packages/modules/solarmax/inverter.py
+++ b/packages/modules/solarmax/inverter.py
@@ -23,7 +23,7 @@ class SolarmaxInverter:
         self.component_config = dataclass_from_dict(SolarmaxInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -35,7 +35,7 @@ class SolarmaxInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolarmaxInverterSetup)

--- a/packages/modules/solax/bat.py
+++ b/packages/modules/solax/bat.py
@@ -23,7 +23,7 @@ class SolaxBat:
         self.component_config = dataclass_from_dict(SolaxBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -38,7 +38,7 @@ class SolaxBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolaxBatSetup)

--- a/packages/modules/solax/counter.py
+++ b/packages/modules/solax/counter.py
@@ -22,7 +22,7 @@ class SolaxCounter:
         self.component_config = dataclass_from_dict(SolaxCounterSetup, component_config)
         self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -48,7 +48,7 @@ class SolaxCounter:
             powers=powers,
             frequency=frequency
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolaxCounterSetup)

--- a/packages/modules/solax/inverter.py
+++ b/packages/modules/solax/inverter.py
@@ -21,7 +21,7 @@ class SolaxInverter:
         self.component_config = dataclass_from_dict(SolaxInverterSetup, component_config)
         self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -35,7 +35,7 @@ class SolaxInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolaxInverterSetup)

--- a/packages/modules/sonnenbatterie/bat.py
+++ b/packages/modules/sonnenbatterie/bat.py
@@ -26,7 +26,7 @@ class SonnenbatterieBat:
         self.__device_variant = device_variant
         self.component_config = dataclass_from_dict(SonnenbatterieBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def __read_variant_0(self):
@@ -127,7 +127,7 @@ class SonnenbatterieBat:
             state = self.__update_variant_2()
         else:
             raise FaultState.error("Unbekannte Variante: " + str(self.__device_variant))
-        self.__store.set(state)
+        self.store.set(state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SonnenbatterieBatSetup)

--- a/packages/modules/sonnenbatterie/counter.py
+++ b/packages/modules/sonnenbatterie/counter.py
@@ -26,7 +26,7 @@ class SonnenbatterieCounter:
         self.__device_variant = device_variant
         self.component_config = dataclass_from_dict(SonnenbatterieCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def __read_variant_1(self):
@@ -116,7 +116,7 @@ class SonnenbatterieCounter:
             state = self.__update_variant_2()
         else:
             raise FaultState.error("Unbekannte Variante: " + str(self.__device_variant))
-        self.__store.set(state)
+        self.store.set(state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SonnenbatterieCounterSetup)

--- a/packages/modules/sonnenbatterie/inverter.py
+++ b/packages/modules/sonnenbatterie/inverter.py
@@ -26,7 +26,7 @@ class SonnenbatterieInverter:
         self.__device_variant = device_variant
         self.component_config = dataclass_from_dict(SonnenbatterieInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def __read_variant_1(self):
@@ -105,7 +105,7 @@ class SonnenbatterieInverter:
             state = self.__update_variant_2()
         else:
             raise FaultState.error("Unbekannte Variante: " + str(self.__device_variant))
-        self.__store.set(state)
+        self.store.set(state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SonnenbatterieInverterSetup)

--- a/packages/modules/studer/bat.py
+++ b/packages/modules/studer/bat.py
@@ -17,7 +17,7 @@ class StuderBat:
                  tcp_client: modbus.ModbusTcpClient_) -> None:
         self.component_config = dataclass_from_dict(StuderBatSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -34,7 +34,7 @@ class StuderBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=StuderBatSetup)

--- a/packages/modules/studer/inverter.py
+++ b/packages/modules/studer/inverter.py
@@ -17,7 +17,7 @@ class StuderInverter:
                  tcp_client: modbus.ModbusTcpClient_) -> None:
         self.component_config = dataclass_from_dict(StuderInverterSetup, component_config)
         self.__tcp_client = tcp_client
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -54,7 +54,7 @@ class StuderInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=StuderInverterSetup)

--- a/packages/modules/sungrow/bat.py
+++ b/packages/modules/sungrow/bat.py
@@ -23,7 +23,7 @@ class SungrowBat:
         self.component_config = dataclass_from_dict(SungrowBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -42,7 +42,7 @@ class SungrowBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SungrowBatSetup)

--- a/packages/modules/sungrow/counter.py
+++ b/packages/modules/sungrow/counter.py
@@ -23,7 +23,7 @@ class SungrowCounter:
         self.component_config = dataclass_from_dict(SungrowCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -62,7 +62,7 @@ class SungrowCounter:
             voltages=voltages,
             frequency=frequency
         )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SungrowCounterSetup)

--- a/packages/modules/sungrow/inverter.py
+++ b/packages/modules/sungrow/inverter.py
@@ -23,7 +23,7 @@ class SungrowInverter:
         self.component_config = dataclass_from_dict(SungrowInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -39,7 +39,7 @@ class SungrowInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SungrowInverterSetup)

--- a/packages/modules/sunways/inverter.py
+++ b/packages/modules/sunways/inverter.py
@@ -26,7 +26,7 @@ class SunwaysInverter:
         self.component_config = dataclass_from_dict(SunwaysInverterSetup, component_config)
         self.ip_address = ip_address
         self.password = password
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -43,7 +43,7 @@ class SunwaysInverter:
             power=float(values[1].split(' ')[0])*-1,
             exported=float(values[16])*1000
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SunwaysInverterSetup)

--- a/packages/modules/tesla/bat.py
+++ b/packages/modules/tesla/bat.py
@@ -13,11 +13,11 @@ from modules.tesla.config import TeslaBatSetup
 class TeslaBat:
     def __init__(self, component_config: Union[Dict, TeslaBatSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaBatSetup, component_config)
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, client: PowerwallHttpClient, aggregate) -> None:
-        self.__store.set(BatState(
+        self.store.set(BatState(
             imported=aggregate["battery"]["energy_imported"],
             exported=aggregate["battery"]["energy_exported"],
             power=-aggregate["battery"]["instant_power"],

--- a/packages/modules/tesla/counter.py
+++ b/packages/modules/tesla/counter.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 class TeslaCounter:
     def __init__(self, component_config: Union[Dict, TeslaCounterSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaCounterSetup, component_config)
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, client: PowerwallHttpClient, aggregate):
@@ -43,7 +43,7 @@ class TeslaCounter:
                 exported=aggregate["site"]["energy_exported"],
                 power=aggregate["site"]["instant_power"]
             )
-        self.__store.set(powerwall_state)
+        self.store.set(powerwall_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=TeslaCounterSetup)

--- a/packages/modules/tesla/inverter.py
+++ b/packages/modules/tesla/inverter.py
@@ -13,14 +13,14 @@ from modules.tesla.config import TeslaInverterSetup
 class TeslaInverter:
     def __init__(self, component_config: Union[Dict, TeslaInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaInverterSetup, component_config)
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self, client: PowerwallHttpClient, aggregate) -> None:
         pv_watt = aggregate["solar"]["instant_power"]
         if pv_watt > 5:
             pv_watt = pv_watt*-1
-        self.__store.set(InverterState(
+        self.store.set(InverterState(
             exported=aggregate["solar"]["energy_exported"],
             power=pv_watt
         ))

--- a/packages/modules/victron/bat.py
+++ b/packages/modules/victron/bat.py
@@ -21,7 +21,7 @@ class VictronBat:
         self.component_config = dataclass_from_dict(VictronBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
-        self.__store = get_bat_value_store(self.component_config.id)
+        self.store = get_bat_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -37,7 +37,7 @@ class VictronBat:
             imported=imported,
             exported=exported
         )
-        self.__store.set(bat_state)
+        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=VictronBatSetup)

--- a/packages/modules/victron/counter.py
+++ b/packages/modules/victron/counter.py
@@ -21,7 +21,7 @@ class VictronCounter:
         self.component_config = dataclass_from_dict(VictronCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
@@ -59,7 +59,7 @@ class VictronCounter:
                 exported=exported,
                 power=power
             )
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=VictronCounterSetup)

--- a/packages/modules/victron/inverter.py
+++ b/packages/modules/victron/inverter.py
@@ -24,7 +24,7 @@ class VictronInverter:
         self.component_config = dataclass_from_dict(VictronInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
-        self.__store = get_inverter_value_store(self.component_config.id)
+        self.store = get_inverter_value_store(self.component_config.id)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self) -> None:
@@ -53,7 +53,7 @@ class VictronInverter:
             power=power,
             exported=exported
         )
-        self.__store.set(inverter_state)
+        self.store.set(inverter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=VictronInverterSetup)

--- a/packages/modules/virtual/counter.py
+++ b/packages/modules/virtual/counter.py
@@ -1,76 +1,34 @@
 #!/usr/bin/env python3
 from typing import Dict, Union
-from operator import add
 
 from dataclass_utils import dataclass_from_dict
-from control import data
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo, FaultState
+from modules.common.fault_state import ComponentInfo
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
-from modules.common.component_type import ComponentType
 from modules.virtual.config import VirtualCounterSetup
 
 
 class VirtualCounter:
-    # Gedrehter Anschluss der Ladepunkte:
-    # Phase 1 LP -> LP 0 = EVU 0, LP 1 = EVU 1, LP 2 = EVU 2
-    # Phase 1 LP -> LP 0 = EVU 2, LP 1 = EVU 0, LP 2 = EVU 1
-    # Phase 3 LP -> LP 0 = EVU 1, LP 1 = EVU 2, LP 2 = EVU 0
-    cp_to_evu_phase_mapping = {"1": [0, 1, 2], "2": [2, 0, 1], "3": [1, 2, 0]}
 
     def __init__(self, device_id: int, component_config: Union[Dict, VirtualCounterSetup]) -> None:
         self.__device_id = device_id
         self.component_config = dataclass_from_dict(VirtualCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.__store = get_counter_value_store(self.component_config.id)
+        self.store = get_counter_value_store(self.component_config.id, add_child_values=True)
         self.component_info = ComponentInfo.from_component_config(self.component_config)
 
     def update(self):
-        self.currents = [0.0]*3
-        self.incomplete_currents = False
-        self.power = 0
+        imported, exported = self.sim_counter.sim_count(self.component_config.configuration.external_consumption)
 
-        def add_current_power(element):
-            if element.data["get"]["currents"]:
-                self.currents = list(map(add, self.currents, element.data["get"]["currents"]))
-            else:
-                self.currents = [0, 0, 0]
-                self.incomplete_currents = True
-            self.power += element.data["get"]["power"]
-
-        counter_all = data.data.counter_data["all"]
-        elements = counter_all.get_all_elements_without_children(self.component_config.id)
-        for element in elements:
-            if element["type"] == ComponentType.CHARGEPOINT.value:
-                chargepoint = data.data.cp_data[f"cp{element['id']}"]
-                try:
-                    evu_phases = self.cp_to_evu_phase_mapping[str(chargepoint.data.config.phase_1)]
-                except KeyError:
-                    raise FaultState.error(f"Für den virtuellen Zähler muss der Anschluss der Phasen von Ladepunkt "
-                                           f"{chargepoint.num} an die Phasen der EVU angegeben werden.")
-                self.currents = [self.currents[i] + chargepoint.data.get.currents[evu_phases[i]] for i in range(0, 3)]
-
-                self.power = self.power + chargepoint.data.get.power
-            elif element["type"] == ComponentType.BAT.value:
-                add_current_power(data.data.bat_data[f"bat{element['id']}"])
-            elif element["type"] == ComponentType.COUNTER.value:
-                add_current_power(data.data.counter_data[f"counter{element['id']}"])
-            elif element["type"] == ComponentType.INVERTER.value:
-                add_current_power(data.data.pv_data[f"pv{element['id']}"])
-
-        self.power += self.component_config.configuration.external_consumption
-        self.currents = [c + self.component_config.configuration.external_consumption/3/230 for c in self.currents]
-        imported, exported = self.sim_counter.sim_count(self.power)
         counter_state = CounterState(
             imported=imported,
             exported=exported,
-            power=self.power
+            power=self.component_config.configuration.external_consumption,
+            currents=[self.component_config.configuration.external_consumption/3/230]*3
         )
-        if self.incomplete_currents is False:
-            counter_state.currents = self.currents
-        self.__store.set(counter_state)
+        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=VirtualCounterSetup)


### PR DESCRIPTION
Das Verrechnen von Hybrid-Systemen soll in 2.0 automatisch erfolgen und nicht in jedem WR-Modul implementiert werden. Wenn ein Hybrid-System vorhanden ist und die Speicher-Leistung aus der WR-Leistung herausgerechnet werden muss, wird der Speicher in der Hierarchie unter dem WR angeordnet. Ebenso werden anhand der Hierarchie die Werte für die virtuellen Zähler berechnet. Nach dem Abfragen der WR von den Modulen per Modbus werden diese nicht direkt gepublished, sondern die Werte werden falls erforderlich verrechnet. 
Dazu wurde die store-Routine aufgeteilt: Nach dem Auslesen werden die Werte dort abgelegt und in einem zweiten Schritt werden alle Komponenten in der Hierarchie aufsteigend durchgegangen, verrechnet und gepublished.