### PR TITLE
use evu overhang for scheduled charging

### DIFF
--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -9,10 +9,10 @@ in der Regelung neu priorisiert werden und eine neue Zuteilung des Stroms erhalt
 from dataclasses import asdict, dataclass, field
 import logging
 import traceback
-from typing import Any, List, Dict, Optional, Tuple
+from typing import List, Dict, Optional, Tuple
 
 from control import data
-from helpermodules.abstract_plans import Limit, limit_factory, ScheduledChargingPlan, TimeChargingPlan
+from helpermodules.abstract_plans import ScheduledChargingPlan, TimeChargingPlan
 from helpermodules.pub import Pub
 from helpermodules import timecheck
 from modules.common.abstract_soc import AbstractSoc
@@ -56,6 +56,17 @@ class ScheduledCharging:
 class TimeCharging:
     active: bool = False
     plans: Dict[int, TimeChargingPlan] = field(default_factory=empty_dict_factory)
+
+
+@dataclass
+class Limit:
+    selected: str = "none"
+    amount: int = 1000
+    soc: int = 50
+
+
+def limit_factory() -> Limit:
+    return Limit()
 
 
 @dataclass
@@ -309,9 +320,9 @@ class Ev:
                     max_phases,
                     phase_switch_supported)
                 if plan_data:
-                    name = self.charge_template.data.chargemode.scheduled_charging.plans[plan_data["num"]].name
+                    name = self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].name
                     # Wenn mit einem neuen Plan geladen wird, muss auch die Energiemenge von neuem gezählt werden.
-                    if (self.charge_template.data.chargemode.scheduled_charging.plans[plan_data["num"]].limit.
+                    if (self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].limit.
                             selected == "amount" and
                             name != self.data.control_parameter.current_plan):
                         self.data.control_parameter.imported_at_plan_start = charged_since_mode_switch
@@ -591,6 +602,15 @@ class Ev:
         pass
 
 
+@dataclass
+class SelectedPlan:
+    remaining_time: float = 0
+    available_current: float = 14
+    max_current: int = 16
+    phases: int = 1
+    num: int = 0
+
+
 class ChargeTemplate:
     """ Klasse der Lademodus-Vorlage
     """
@@ -600,7 +620,10 @@ class ChargeTemplate:
         self.data: ChargeTemplateData = ChargeTemplateData()
         self.ct_num = index
 
-    def time_charging(self):
+    TIME_CHARGING_NO_PLAN_CONFIGURED = "Keine Ladung, da keine Zeitfenster für Zeitladen konfiguriert sind."
+    TIME_CHARGING_NO_PLAN_ACTIVE = "Keine Ladung, da kein Zeitfenster für Zeitladen aktiv ist."
+
+    def time_charging(self) -> Tuple[int, str, Optional[str], Optional[str]]:
         """ prüft, ob ein Zeitfenster aktiv ist und setzt entsprechend den Ladestrom
         """
         message = None
@@ -610,17 +633,21 @@ class ChargeTemplate:
                 if plan is not None:
                     return plan.current, "time_charging", message, plan.name
                 else:
-                    message = "Keine Ladung, da kein Zeitfenster für Zeitladen aktiv ist."
+                    message = self.TIME_CHARGING_NO_PLAN_ACTIVE
             else:
-                message = "Keine Ladung, da keine Zeitfenster für Zeitladen konfiguriert sind."
+                message = self.TIME_CHARGING_NO_PLAN_CONFIGURED
             log.debug(message)
             return 0, "stop", message, None
         except Exception:
             log.exception("Fehler im ev-Modul "+str(self.ct_num))
             return 0, "stop", "Keine Ladung, da da ein interner Fehler aufgetreten ist: "+traceback.format_exc(), None
 
+    INSTANT_CHARGING_PRICE_EXCEEDED = "Keine Ladung, da der aktuelle Strompreis über dem maximalen Strompreis liegt."
+    INSTANT_CHARGING_SOC_REACHED = "Keine Ladung, da der Soc bereits erreicht wurde."
+    INSTANT_CHARGING_AMOUNT_REACHED = "Keine Ladung, da die Energiemenge bereits geladen wurde."
+
     def instant_charging(self,
-                         soc: int,
+                         soc: float,
                          used_amount_instant_charging: float) -> Tuple[int, str, Optional[str]]:
         """ prüft, ob die Lademengenbegrenzung erreicht wurde und setzt entsprechend den Ladestrom.
         """
@@ -629,40 +656,29 @@ class ChargeTemplate:
             instant_charging = self.data.chargemode.instant_charging
             if data.data.optional_data["optional"].data["et"]["active"]:
                 if not data.data.optional_data["optional"].et_price_lower_than_limit():
-                    message = "Keine Ladung, da der aktuelle Strompreis über dem maximalen Strompreis liegt."
-                    return 0, "stop", message
+                    return 0, "stop", self.INSTANT_CHARGING_PRICE_EXCEEDED
             if instant_charging.limit.selected == "none":
                 return instant_charging.current, "instant_charging", message
             elif instant_charging.limit.selected == "soc":
                 if soc < instant_charging.limit.soc:
                     return instant_charging.current, "instant_charging", message
                 else:
-                    message = "Keine Ladung, da der Soc bereits erreicht wurde."
-                    return 0, "stop", message
+                    return 0, "stop", self.INSTANT_CHARGING_SOC_REACHED
             elif instant_charging.limit.selected == "amount":
                 if used_amount_instant_charging < self.data.chargemode.instant_charging.limit.amount:
                     return instant_charging.current, "instant_charging", message
                 else:
-                    message = "Keine Ladung, da die Energiemenge bereits geladen wurde."
-                    return 0, "stop", message
+                    return 0, "stop", self.INSTANT_CHARGING_AMOUNT_REACHED
             else:
                 raise TypeError(f'{instant_charging.limit.selected} unbekanntes Sofortladen-Limit.')
         except Exception:
             log.exception("Fehler im ev-Modul "+str(self.ct_num))
             return 0, "stop", "Keine Ladung, da da ein interner Fehler aufgetreten ist: "+traceback.format_exc()
 
-    def pv_charging(self, soc):
+    PV_CHARGING_SOC_REACHED = "Keine Ladung, da der maximale Soc bereits erreicht wurde."
+
+    def pv_charging(self, soc: float) -> Tuple[int, str, Optional[str]]:
         """ prüft, ob Min-oder Max-Soc erreicht wurden und setzt entsprechend den Ladestrom.
-
-        Parameter
-        ---------
-        soc: int
-            SoC des EV
-
-        Return
-        ------
-        Required Current, Chargemode: int, str
-            Theoretisch benötigter Strom, Ladmodus(soll geladen werden, auch wenn kein PV-Strom zur Verfügung steht)
         """
         message = None
         try:
@@ -678,8 +694,7 @@ class ChargeTemplate:
                     # Min PV
                     return pv_charging.min_current, "instant_charging", message
             else:
-                message = "Keine Ladung, da der maximale Soc bereits erreicht wurde."
-                return 0, "stop", message
+                return 0, "stop", self.PV_CHARGING_SOC_REACHED
         except Exception:
             log.exception("Fehler im ev-Modul "+str(self.ct_num))
             return 0, "stop", "Keine Ladung, da ein interner Fehler aufgetreten ist: "+traceback.format_exc()
@@ -689,8 +704,8 @@ class ChargeTemplate:
                                        ev_template: EvTemplate,
                                        phases: int,
                                        used_amount: float,
-                                       max_phases,
-                                       phase_switch_supported: bool) -> Dict[str, Any]:
+                                       max_phases: int,
+                                       phase_switch_supported: bool) -> Optional[SelectedPlan]:
         """ prüft, ob der Ziel-SoC oder die Ziel-Energiemenge erreicht wurde und stellt den zur Erreichung nötigen
         Ladestrom ein. Um etwas mehr Puffer zu haben, wird bis 20 Min nach dem Zieltermin noch geladen, wenn dieser
         nicht eingehalten werden konnte.
@@ -698,9 +713,10 @@ class ChargeTemplate:
         if phase_switch_supported and data.data.general_data.get_phases_chargemode("scheduled_charging") == 0:
             max_current = ev_template.data.max_current_multi_phases
             plan_data = self.search_plan(max_current, soc, ev_template, max_phases, used_amount)
-            if plan_data["remaining_time"] > 300:
-                max_current = ev_template.data.max_current_one_phase
-                plan_data = self.search_plan(max_current, soc, ev_template, 1, used_amount)
+            if plan_data:
+                if plan_data.remaining_time > 300:
+                    max_current = ev_template.data.max_current_one_phase
+                    plan_data = self.search_plan(max_current, soc, ev_template, 1, used_amount)
         else:
             if phases == 1:
                 max_current = ev_template.data.max_current_one_phase
@@ -709,122 +725,137 @@ class ChargeTemplate:
             plan_data = self.search_plan(max_current, soc, ev_template, phases, used_amount)
         return plan_data
 
-    def search_plan(self, max_current: int, soc: float,
+    def search_plan(self,
+                    max_current: int,
+                    soc: float,
                     ev_template: EvTemplate,
                     phases: int,
-                    used_amount: float):
+                    used_amount: float) -> Optional[SelectedPlan]:
         smallest_remaining_time = float("inf")
-        plan_data = {}
+        missed_date_today_of_plan_with_smallest_remaining_time = False
+        plan_data: Optional[SelectedPlan] = None
         battery_capacity = ev_template.data.battery_capacity
         for num, plan in self.data.chargemode.scheduled_charging.plans.items():
             if plan.active:
                 try:
-
-                    available_current = 0.8*max_current*phases
-                    if plan.limit.selected == "soc":
-                        missing_amount = ((plan.limit.soc - soc)/100) * battery_capacity*1000
-                    else:
-                        missing_amount = plan.limit.amount - used_amount
-                    duration = missing_amount/(available_current*230)
+                    duration = self.calculate_duration(plan, soc, battery_capacity, used_amount, phases)
                     remaining_time, missed_date_today = timecheck.check_duration(plan, duration, self.BUFFER)
                     if remaining_time:
-                        if (remaining_time < 0 and missed_date_today is False) or remaining_time > 0:
-                            if remaining_time < smallest_remaining_time:
+                        # Wenn der Zeitpunkt vorüber, aber noch nicht abgelaufen ist oder
+                        # wenn noch gar kein Plan vorhanden ist,
+                        if ((remaining_time < 0 and (missed_date_today is False or not plan_data)) or
+                                # oder der Zeitpunkt noch nicht vorüber ist
+                                remaining_time > 0):
+                            # Wenn die verbleibende Zeit geringer als die niedrigste bisherige verbleibende Zeit ist
+                            if (remaining_time < smallest_remaining_time or
+                                    # oder wenn der Zeitpunkt abgelaufen ist und es noch einen Zeitpunkt gibt, der in
+                                    # der Zukunft liegt.
+                                    (missed_date_today_of_plan_with_smallest_remaining_time and 0 < remaining_time)):
                                 smallest_remaining_time = remaining_time
-                                plan_data["remaining_time"] = remaining_time
-                                plan_data["available_current"] = available_current
-                                plan_data["required_wh"] = missing_amount
-                                plan_data["max_current"] = max_current
-                                plan_data["phases"] = phases
-                                plan_data["num"] = num
+                                missed_date_today_of_plan_with_smallest_remaining_time = missed_date_today
+                                plan_data = SelectedPlan(
+                                    remaining_time=remaining_time,
+                                    available_current=plan.current,
+                                    max_current=max_current,
+                                    phases=phases,
+                                    num=num)
                     log.debug(f"Plan-Nr. {num}: Differenz zum Start {remaining_time}s, Dauer {duration}h, "
                               f"Termin heute verpasst: {missed_date_today}")
                 except Exception:
                     log.exception("Fehler im ev-Modul "+str(self.ct_num))
         return plan_data
 
+    def calculate_duration(self,
+                           plan: ScheduledChargingPlan,
+                           soc: float,
+                           battery_capacity: float,
+                           used_amount: float,
+                           phases: int) -> float:
+        if plan.limit.selected == "soc":
+            missing_amount = ((plan.limit.soc_scheduled - soc) / 100) * battery_capacity * 1000
+        else:
+            missing_amount = plan.limit.amount - used_amount
+        duration = missing_amount/(plan.current * phases*230)
+        return duration
+
+    SCHEDULED_CHARGING_REACHED_LIMIT_SOC = "Keine Ladung, da der Ziel-Soc und das SoC-Limit bereits erreicht wurden."
+    SCHEDULED_CHARGING_REACHED_AMOUNT = "Keine Ladung, da die Energiemenge bereits erreicht wurde."
+    SCHEDULED_CHARGING_REACHED_SCHEDULED_SOC = ("Falls vorhanden wird mit EVU-Überschuss geladen, da der Ziel-Soc "
+                                                "bereits erreicht wurde.")
+    SCHEDULED_CHARGING_NO_PLANS_CONFIGURED = "Keine Ladung, da keine Ziel-Termine konfiguriert sind."
+    SCHEDULED_CHARGING_USE_PV = ("Kein Sofortladen, da noch Zeit bis zum Zieltermin ist. Falls vorhanden, "
+                                 "wird mit EVU-Überschuss geladen.")
+    SCHEDULED_CHARGING_MAX_CURRENT = ("Zielladen mit {}A. Der verfügbare Ladezeitraum reicht nicht aus, um "
+                                      "das zu erreichen. Daher wird bis max. 20 Minuten nach dem angegebenen "
+                                      "Zieltermin geladen.")
+    SCHEDULED_CHARGING_LIMITED_BY_SOC = 'einen SoC von {}%'
+    SCHEDULED_CHARGING_LIMITED_BY_AMOUNT = '{}kWh geladene Energie'
+    SCHEDULED_CHARGING_IN_TIME = 'Zielladen mit {}A, um {}  um {} zu erreichen.'
+
     def scheduled_charging_calc_current(self,
-                                        plan_data: dict,
+                                        plan_data: Optional[SelectedPlan],
                                         soc: int,
                                         used_amount: float,
                                         max_phases: int) -> Tuple[float, str, str, int]:
         current = 0
         mode = "stop"
-        phases = plan_data["phases"]
-        if plan_data["num"] is None:
-            message = "Keine Ladung, da keine Ziel-Termine konfiguriert sind."
-            return current, mode, message, phases
-        current_plan = self.data.chargemode.scheduled_charging.plans[plan_data["num"]]
+        if plan_data is None:
+            return current, mode, self.SCHEDULED_CHARGING_NO_PLANS_CONFIGURED, max_phases
+        current_plan = self.data.chargemode.scheduled_charging.plans[plan_data.num]
+        limit = current_plan.limit
+        phases = plan_data.phases
         log.debug("Verwendeter Plan: "+str(current_plan.name))
-        if current_plan.limit.selected == "soc" and soc >= current_plan.limit.soc:
-            message = "Keine Ladung, da der Ziel-Soc bereits erreicht wurde."
-        elif current_plan.limit.selected == "amount" and used_amount >= current_plan.limit.amount:
-            message = "Keine Ladung, da die Energiemenge bereits erreicht wurde."
-        elif 0 < plan_data["remaining_time"] < 300:  # 5 Min vor spätestem Ladestart
-            if current_plan.limit.selected == "soc":
-                limit_string = f'einen SoC von {current_plan.limit.soc}%'
+        if limit.selected == "soc" and soc >= limit.soc_limit:
+            message = self.SCHEDULED_CHARGING_REACHED_LIMIT_SOC
+        elif limit.selected == "soc" and limit.soc_scheduled <= soc < limit.soc_limit:
+            message = self.SCHEDULED_CHARGING_REACHED_SCHEDULED_SOC
+            current = 1
+            mode = "pv_charging"
+        elif limit.selected == "amount" and used_amount >= limit.amount:
+            message = self.SCHEDULED_CHARGING_REACHED_AMOUNT
+        elif 0 < plan_data.remaining_time < 300:  # 5 Min vor spätestem Ladestart
+            if limit.selected == "soc":
+                limit_string = self.SCHEDULED_CHARGING_LIMITED_BY_SOC.format(limit.soc_scheduled)
             else:
-                limit_string = f'{current_plan.limit.amount/1000}kWh geladene Energie'
-            message = (f'Zielladen mit {plan_data["available_current"]}A, um {limit_string} '
-                       f' um {current_plan.time} zu erreichen.')
-            current = plan_data["available_current"]
+                limit_string = self.SCHEDULED_CHARGING_LIMITED_BY_AMOUNT.format(limit.amount/1000)
+            message = self.SCHEDULED_CHARGING_IN_TIME.format(
+                plan_data.available_current, limit_string, current_plan.time)
+            current = plan_data.available_current
             mode = "instant_charging"
             phases = max_phases
         # weniger als die berechnete Zeit verfügbar
-        elif plan_data["remaining_time"] <= 0:  # Ladestart wurde um maximal 20 Min verpasst.
-            message = (f'Zielladen mit {plan_data["max_current"]}A. Der verfügbare Ladezeitraum reicht nicht aus, um '
-                       'das zu erreichen. Daher wird bis max. 20 Minuten nach dem angegebenen Zieltermin geladen.')
-            current = plan_data["max_current"]
+        elif plan_data.remaining_time <= 0:  # Ladestart wurde um maximal 20 Min verpasst.
+            message = self.SCHEDULED_CHARGING_MAX_CURRENT.format(plan_data.max_current)
+            current = plan_data.max_current
             mode = "instant_charging"
             phases = max_phases
         else:
-            # Liegt der Zieltermin innerhalb der nächsten 24h?
-            if 300 < plan_data["remaining_time"] < 86400:
-                # Wenn Elektronische Tarife aktiv sind, prüfen, ob jetzt ein günstiger Zeitpunkt zum Laden
-                # ist.
-                if data.data.optional_data["optional"].data["et"]["active"]:
-                    hourlist = data.data.optional_data["optional"].et_get_loading_hours(
-                        plan_data["remaining_time"])
-                    if timecheck.is_list_valid(hourlist):
-                        message = "Sofortladen, da ein günstiger Zeitpunkt zum preisbasierten Laden ist."
-                        current = plan_data["available_current"]
-                        mode = "instant_charging"
-                        phases = max_phases
-                    else:
-                        message = ("Kein Sofortladen, da kein günstiger Zeitpunkt zum preisbasierten Laden "
-                                   "ist. Falls vorhanden, wird mit EVU-Überschuss geladen.")
-                        current = 1
-                        mode = "pv_charging"
+            # Wenn Elektronische Tarife aktiv sind, prüfen, ob jetzt ein günstiger Zeitpunkt zum Laden
+            # ist.
+            if data.data.optional_data["optional"].data["et"]["active"]:
+                hourlist = data.data.optional_data["optional"].et_get_loading_hours(
+                    plan_data.remaining_time)
+                if timecheck.is_list_valid(hourlist):
+                    message = "Sofortladen, da ein günstiger Zeitpunkt zum preisbasierten Laden ist."
+                    current = plan_data.available_current
+                    mode = "instant_charging"
+                    phases = max_phases
                 else:
-                    message = ("Kein Sofortladen, da noch Zeit bis zum Zieltermin ist. Falls vorhanden, "
-                               "wird mit EVU-Überschuss geladen.")
+                    message = ("Kein Sofortladen, da kein günstiger Zeitpunkt zum preisbasierten Laden "
+                               "ist. Falls vorhanden, wird mit EVU-Überschuss geladen.")
                     current = 1
                     mode = "pv_charging"
             else:
-                message = "Keine Ladung, da noch mehr als ein Tag bis zum Zieltermin ist. "
+                message = self.SCHEDULED_CHARGING_USE_PV
+                current = 1
+                mode = "pv_charging"
         return current, mode, message, phases
 
-    def standby(self):
-        """ setzt den benötigten Strom auf 0.
+    def standby(self) -> Tuple[int, str, str]:
+        return 0, "standby", "Keine Ladung, da der Lademodus Standby aktiv ist."
 
-        Return
-        ------
-            Required Current, Chargemode: int, str
-                Theoretisch benötigter Strom, Ladmodus
-        """
-        message = "Keine Ladung, da der Lademodus Standby aktiv ist."
-        return 0, "standby", message
-
-    def stop(self):
-        """ setzt den benötigten Strom auf 0.
-
-        Return
-        ------
-            Required Current, Chargemode: int, str
-                Theoretisch benötigter Strom, Ladmodus
-        """
-        message = "Keine Ladung, da der Lademodus Stop aktiv ist."
-        return 0, "stop", message
+    def stop(self) -> Tuple[int, str, str]:
+        return 0, "stop", "Keine Ladung, da der Lademodus Stop aktiv ist."
 
 
 def get_ev_to_rfid(rfid):

--- a/packages/control/ev_charge_template_test.py
+++ b/packages/control/ev_charge_template_test.py
@@ -1,0 +1,223 @@
+from typing import Dict, NamedTuple, Optional, Tuple
+from unittest.mock import Mock
+
+import pytest
+
+from control import data
+from control import optional
+from control.ev import ChargeTemplate, EvTemplate, EvTemplateData, SelectedPlan
+from control.general import General
+from helpermodules import timecheck
+from helpermodules.abstract_plans import ScheduledChargingPlan, TimeChargingPlan
+
+
+@pytest.fixture(autouse=True)
+def data_module() -> None:
+    data.data_init(Mock())
+    data.data.general_data = General()
+    data.data.optional_data["optional"] = optional.Optional()
+
+
+@pytest.mark.parametrize(
+    "plans, plan_found, expected",
+    [pytest.param({}, None, (0, "stop", ChargeTemplate.TIME_CHARGING_NO_PLAN_CONFIGURED, None), id="no plan defined"),
+     pytest.param({"0": TimeChargingPlan()}, None,
+                  (0, "stop", ChargeTemplate.TIME_CHARGING_NO_PLAN_ACTIVE, None), id="no plan active"),
+     pytest.param({"0": TimeChargingPlan()}, TimeChargingPlan(),
+                  (16, "time_charging", None, "Zeitladen-Standard"), id="plan active")
+     ])
+def test_time_charging(plans: Dict[int, TimeChargingPlan],
+                       plan_found: TimeChargingPlan,
+                       expected: Tuple[int, str, Optional[str], Optional[str]],
+                       monkeypatch):
+    # setup
+    ct = ChargeTemplate(0)
+    ct.data.time_charging.plans = plans
+    check_plans_timeframe_mock = Mock(return_value=plan_found)
+    monkeypatch.setattr(timecheck, "check_plans_timeframe", check_plans_timeframe_mock)
+
+    # execution
+    ret = ct.time_charging()
+
+    # evaluation
+    assert ret == expected
+
+
+@pytest.mark.parametrize(
+    "selected, current_soc, used_amount, expected",
+    [
+        pytest.param("none", 0, 0, (10, "instant_charging", None), id="without limit"),
+        pytest.param("soc", 49, 0, (10, "instant_charging", None), id="limit soc: soc not reached"),
+        pytest.param("soc", 50, 0, (0, "stop", ChargeTemplate.INSTANT_CHARGING_SOC_REACHED),
+                     id="limit soc: soc reached"),
+        pytest.param("amount", 0, 999, (10, "instant_charging", None), id="limit amount: amount not reached"),
+        pytest.param("amount", 0, 1000, (0, "stop", ChargeTemplate.INSTANT_CHARGING_AMOUNT_REACHED),
+                     id="limit amount: amount reached"),
+    ])
+def test_instant_charging(selected: str, current_soc: float, used_amount: float,
+                          expected: Tuple[int, str, Optional[str]]):
+    # setup
+    data.data.optional_data["optional"].data["et"]["active"] = False
+    ct = ChargeTemplate(0)
+    ct.data.chargemode.instant_charging.limit.selected = selected
+
+    # execution
+    ret = ct.instant_charging(current_soc, used_amount)
+
+    # evaluation
+    assert ret == expected
+
+
+@pytest.mark.parametrize(
+    "min_soc, min_current, current_soc, expected",
+    [
+        pytest.param(0, 0, 100, (0, "stop", ChargeTemplate.PV_CHARGING_SOC_REACHED), id="max soc reached"),
+        pytest.param(15, 0, 14, (10, "instant_charging", None), id="min soc not reached"),
+        pytest.param(15, 8, 15, (8, "instant_charging", None), id="min current configured"),
+        pytest.param(15, 0, 15, (1, "pv_charging", None), id="bare pv charging"),
+    ])
+def test_pv_charging(min_soc: int, min_current: int, current_soc: float,
+                     expected: Tuple[int, str, Optional[str]]):
+    # setup
+    ct = ChargeTemplate(0)
+    ct.data.chargemode.pv_charging.min_soc = min_soc
+    ct.data.chargemode.pv_charging.min_current = min_current
+
+    # execution
+    ret = ct.pv_charging(current_soc)
+
+    # evaluation
+    assert ret == expected
+
+
+Params = NamedTuple("Params", [("name", str),
+                               ("phase_switch_supported", bool),
+                               ("chargemode_phases", int),
+                               ("search_plan", Optional[SelectedPlan]),
+                               ("expected_max_current", int),
+                               ("phases", int),
+                               ("max_phases", int),
+                               ("expected_phases", int)])
+
+cases = [
+    Params(name="no phase switch, one phase", phase_switch_supported=False, chargemode_phases=0,
+           search_plan=None, phases=1, max_phases=3, expected_max_current=32, expected_phases=1),
+    Params(name="no phase switch, multi phase", phase_switch_supported=False, chargemode_phases=0,
+           search_plan=None, phases=3, max_phases=3, expected_max_current=16, expected_phases=3),
+    Params(name="no automatic mode, multi phase", phase_switch_supported=True, chargemode_phases=1,
+           search_plan=None, phases=2, max_phases=2, expected_max_current=16, expected_phases=2),
+    Params(name="select phases, not enough time", phase_switch_supported=True, chargemode_phases=0, search_plan=Mock(
+        spec=SelectedPlan, remaining_time=300), phases=1, max_phases=3, expected_max_current=16, expected_phases=3),
+    Params(name="select phases, enough time", phase_switch_supported=True, chargemode_phases=0, search_plan=Mock(
+        spec=SelectedPlan, remaining_time=301), phases=1, max_phases=3, expected_max_current=32, expected_phases=1)
+]
+
+
+@pytest.mark.parametrize("params", cases, ids=[c.name for c in cases])
+def test_scheduled_charging_recent_plan(params: Params, monkeypatch):
+    # setup
+    ct = ChargeTemplate(0)
+    get_phases_chargemode_mock = Mock(return_value=params.chargemode_phases)
+    monkeypatch.setattr(data.data.general_data, "get_phases_chargemode", get_phases_chargemode_mock)
+    search_plan_mock = Mock(return_value=params.search_plan)
+    monkeypatch.setattr(ChargeTemplate, "search_plan", search_plan_mock)
+    evt_data = Mock(spec=EvTemplateData, max_current_multi_phases=16, max_current_one_phase=32)
+    evt = Mock(spec=EvTemplate, data=evt_data)
+
+    # execution
+    ct.scheduled_charging_recent_plan(50, evt, params.phases, 5, params.max_phases, params.phase_switch_supported)
+
+    # evaluation
+    assert search_plan_mock.call_args.args[0] == params.expected_max_current
+    assert search_plan_mock.call_args.args[3] == params.expected_phases
+
+
+@pytest.mark.parametrize(
+    "selected, phases, expected_duration",
+    [
+        pytest.param("soc", 1, 2.7950310559006213, id="soc, one phase"),
+        pytest.param("amount", 2, 0.12422360248447205, id="amount, two phases"),
+    ])
+def test_calculate_duration(selected: str, phases: int, expected_duration: float):
+    # setup
+    ct = ChargeTemplate(0)
+    plan = ScheduledChargingPlan()
+    plan.limit.selected = selected
+    # execution
+    duration = ct.calculate_duration(plan, 60, 45, 200, phases)
+
+    # evaluation
+    assert duration == expected_duration
+
+
+@pytest.mark.parametrize(
+    "check_duration_return1, check_duration_return2, expected_plan_num",
+    [
+        pytest.param((-50, False), (60, False), 0, id="too late, but didn't miss date for today"),
+        pytest.param((-50, True), (60, False), 1, id="too late and missed date for today"),
+        pytest.param((-50, True), (-60, True), 0, id="missed both"),
+        pytest.param((50, False), (60, False), 0, id="in time, plan 1"),
+        pytest.param((50, False), (40, False), 1, id="in time, plan 2"),
+    ])
+def test_search_plan(check_duration_return1: Tuple[Optional[float], bool],
+                     check_duration_return2: Tuple[Optional[float], bool],
+                     expected_plan_num: int,
+                     monkeypatch):
+    # setup
+    calculate_duration_mock = Mock(return_value=100)
+    monkeypatch.setattr(ChargeTemplate, "calculate_duration", calculate_duration_mock)
+    check_duration_mock = Mock(side_effect=[check_duration_return1, check_duration_return2])
+    monkeypatch.setattr(timecheck, "check_duration", check_duration_mock)
+    ct = ChargeTemplate(0)
+    plan_mock = Mock(spec=ScheduledChargingPlan, active=True, current=14)
+    ct.data.chargemode.scheduled_charging.plans = {0: plan_mock, 1: plan_mock}
+    # execution
+    plan_data = ct.search_plan(14, 60, EvTemplate(), 3, 200)
+
+    # evaluation
+    assert plan_data is not None
+    assert plan_data.num == expected_plan_num
+
+
+@pytest.mark.parametrize(
+    "plan_data, soc, used_amount, selected, expected",
+    [
+        pytest.param(None, 0, 0, "none", (0, "stop",
+                     ChargeTemplate.SCHEDULED_CHARGING_NO_PLANS_CONFIGURED, 3), id="no plans configured"),
+        pytest.param(SelectedPlan(), 90, 0, "soc", (0, "stop",
+                     ChargeTemplate.SCHEDULED_CHARGING_REACHED_LIMIT_SOC, 1), id="reached limit soc"),
+        pytest.param(SelectedPlan(), 80, 0, "soc", (1, "pv_charging",
+                     ChargeTemplate.SCHEDULED_CHARGING_REACHED_SCHEDULED_SOC, 1), id="reached scheduled soc"),
+        pytest.param(SelectedPlan(phases=3), 0, 1000, "amount", (0, "stop",
+                     ChargeTemplate.SCHEDULED_CHARGING_REACHED_AMOUNT, 3), id="reached amount"),
+        pytest.param(SelectedPlan(remaining_time=299), 0, 999, "amount",
+                     (14, "instant_charging", ChargeTemplate.SCHEDULED_CHARGING_IN_TIME.format(
+                         14, ChargeTemplate.SCHEDULED_CHARGING_LIMITED_BY_AMOUNT.format(1.0), "07:00"), 3),
+                     id="in time, limited by amount"),
+        pytest.param(SelectedPlan(remaining_time=299), 79, 0, "soc",
+                     (14, "instant_charging", ChargeTemplate.SCHEDULED_CHARGING_IN_TIME.format(
+                         14, ChargeTemplate.SCHEDULED_CHARGING_LIMITED_BY_SOC.format(80), "07:00"), 3),
+                     id="in time, limited by soc"),
+        pytest.param(SelectedPlan(remaining_time=0), 79, 0, "soc",
+                     (16, "instant_charging", ChargeTemplate.SCHEDULED_CHARGING_MAX_CURRENT.format(16), 3),
+                     id="too late, but didn't miss for today"),
+        pytest.param(SelectedPlan(remaining_time=301), 79, 0, "soc",
+                     (1, "pv_charging", ChargeTemplate.SCHEDULED_CHARGING_USE_PV, 1), id="too early, use pv"),
+    ])
+def test_scheduled_charging_calc_current(plan_data: SelectedPlan,
+                                         soc: int,
+                                         used_amount: float,
+                                         selected: str,
+                                         expected: Tuple[float, str, str, int]):
+    # setup
+    data.data.optional_data["optional"].data["et"]["active"] = False
+    ct = ChargeTemplate(0)
+    plan = ScheduledChargingPlan(active=True)
+    plan.limit.selected = selected
+    ct.data.chargemode.scheduled_charging.plans = {0: plan}
+
+    # execution
+    ret = ct.scheduled_charging_calc_current(plan_data, soc, used_amount, 3)
+
+    # evaluation
+    assert ret == expected

--- a/packages/helpermodules/abstract_plans.py
+++ b/packages/helpermodules/abstract_plans.py
@@ -26,14 +26,15 @@ def frequency_factory() -> Frequency:
 
 
 @dataclass
-class Limit:
+class ScheduledLimit:
     selected: str = "none"
     amount: int = 1000
-    soc: int = 50
+    soc_limit: int = 90
+    soc_scheduled: int = 80
 
 
-def limit_factory() -> Limit:
-    return Limit()
+def scheduled_limit_factory() -> ScheduledLimit:
+    return ScheduledLimit()
 
 
 @dataclass
@@ -49,8 +50,9 @@ class TimeframePlan(PlanBase):
 
 @dataclass
 class ScheduledChargingPlan(PlanBase):
+    current: int = 14
     name: str = "Zielladen-Standard"
-    limit: Limit = field(default_factory=limit_factory)
+    limit: ScheduledLimit = field(default_factory=scheduled_limit_factory)
     time: str = "07:00"  # ToDo: aktuelle Zeit verwenden
 
 

--- a/web/themes/dark/processAllMqttMsg.js
+++ b/web/themes/dark/processAllMqttMsg.js
@@ -182,7 +182,7 @@ function refreshChargeTemplate(templateIndex) {
 							// set values from payload
 							schedulePlanElement.find('.charge-point-schedule-name').text(value.name);
 							if (value.limit.selected == "soc") {
-								schedulePlanElement.find('.charge-point-schedule-limit').text(value.limit.soc + "%");
+								schedulePlanElement.find('.charge-point-schedule-limit').text(value.limit.soc_scheduled + "%");
 								schedulePlanElement.find('.charge-point-schedule-limit-icon').removeClass('fa-bolt');
 								schedulePlanElement.find('.charge-point-schedule-limit-icon').addClass('fa-car-battery');
 							} else {


### PR DESCRIPTION
Im Lademodus Zielladen wird der Ladestrom so
angepasst, dass das Fahrzeug zum angegebenen
Zeitpunkt den festgelegten SoC/Energiemenge
erreicht. Anhand des angegebenen Ladestroms wird
der Zeitpunkt berechnet, an dem die Ladung
spätestens starten muss. Ist der berechnete
Zeitpunkt des Ladestarts noch nicht erreicht,
wird mit PV-Überschuss geladen. Auch nach
Erreichen des Ziel-SoCs wird mit PV-Überschuss
geladen, solange bis das SoC-Limit erreicht
wird. Kann der Ziel-SoC/Energiemenge nicht
erreicht werden, z.B. weil das Auto zu spät
angesteckt wurde oder das Lastmanagement
eingegriffen hat, wird bis 20 Minuten nach dem
angegebenen Termin mit der Maximalstromstärke
geladen. Danach wird der Termin verworfen und
mit PV-Überschuss geladen.