### PR TITLE
Adding soc component to mqtt module

### DIFF
--- a/packages/modules/mqtt/config.py
+++ b/packages/modules/mqtt/config.py
@@ -64,3 +64,20 @@ class MqttInverterSetup:
         self.type = type
         self.id = id
         self.configuration = configuration or MqttInverterConfiguration()
+
+
+class MqttSocConfiguration:
+    def __init__(self):
+        pass
+
+
+class MqttSocSetup:
+    def __init__(self,
+                 name: str = "mqtt",
+                 type: str = "mqtt",
+                 id: int = 0,
+                 configuration: MqttSocConfiguration = None) -> None:
+        self.name = name
+        self.type = type
+        self.id = id
+        self.configuration = configuration or MqttSocConfiguration()

--- a/packages/modules/mqtt/soc.py
+++ b/packages/modules/mqtt/soc.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from typing import List, Union
+from modules.common.fault_state import ComponentInfo
+import logging
+import sys
+
+from dataclass_utils import dataclass_from_dict
+from modules.mqtt.config import MqttSocSetup
+from helpermodules.cli import run_using_positional_cli_args
+from modules.common import store
+from modules.common.abstract_device import DeviceDescriptor
+from modules.common.abstract_soc import AbstractSoc
+
+log = logging.getLogger("soc."+__name__)
+
+
+class Soc(AbstractSoc):
+    def __init__(self, device_config: Union[dict, MqttSocSetup], vehicle: int):
+        self.config = dataclass_from_dict(MqttSocSetup, device_config)
+        self.vehicle = vehicle
+        self.store = store.get_car_value_store(self.vehicle)
+        self.component_info = ComponentInfo(self.vehicle, self.config.name, "vehicle")
+
+    def update(self, charge_state: bool = False) -> None:
+        pass
+
+
+def mqtt_update(akey: str, token: str, charge_point: int):
+    pass
+
+
+def main(argv: List[str]):
+    log.debug('Mqtt SOC main, argv: ' + sys.argv[1:])
+    run_using_positional_cli_args(mqtt_update, argv)
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=MqttSocSetup)


### PR DESCRIPTION
soc component for mqtt, no configuration required
external apps can send these topics:
soc:                    openWB/set/vehicle/<vehicle_num>/get/soc
range:                openWB/set/vehicle/<vehicle_num>/get/range
soc_timestamp: openWB/set/vehicle/<vehicle_num>/get/soc_timestamp