### PR TITLE
log thread name

### DIFF
--- a/packages/control/cp_interruption.py
+++ b/packages/control/cp_interruption.py
@@ -24,7 +24,7 @@ def thread_cp_interruption(cp_num: int, chargepoint_module: AbstractChargepoint,
         # gestartet werden.
         if "thread_cp"+str(cp_num) not in cp_interruption_threads:
             cp_interruption_threads["thread_cp"+str(cp_num)] = threading.Thread(
-                target=chargepoint_module.interrupt_cp, args=(duration,))
+                target=chargepoint_module.interrupt_cp, args=(duration,), name=f"cp{chargepoint_module.id}")
             cp_interruption_threads["thread_cp"+str(cp_num)].start()
             log.debug("Thread zur CP-Unterbrechung an LP"+str(cp_num)+" gestartet.")
         else:

--- a/packages/control/phase_switch.py
+++ b/packages/control/phase_switch.py
@@ -30,7 +30,9 @@ def thread_phase_switch(
         if "thread_cp"+str(cp_num) not in phase_switch_threads:
             # Thread zur Phasenumschaltung erstellen, starten und der Liste hinzufügen.
             phase_switch_threads["thread_cp"+str(cp_num)] = threading.Thread(
-                target=_perform_phase_switch, args=(chargepoint_module, phases_to_use, duration, charge_state))
+                target=_perform_phase_switch,
+                args=(chargepoint_module, phases_to_use, duration, charge_state),
+                name=f"cp{chargepoint_module.id}")
             phase_switch_threads["thread_cp"+str(cp_num)].start()
             log.debug("Thread zur Phasenumschaltung an LP"+str(cp_num)+" gestartet.")
     except Exception:

--- a/packages/control/process.py
+++ b/packages/control/process.py
@@ -108,4 +108,5 @@ class Process:
 
     def _start_charging(self, chargepoint: chargepoint.Chargepoint) -> threading.Thread:
         return threading.Thread(target=chargepoint.chargepoint_module.set_current,
-                                args=(chargepoint.data.set.current,))
+                                args=(chargepoint.data.set.current,),
+                                name=f"cp{chargepoint.chargepoint_module.id}")

--- a/packages/helpermodules/logger.py
+++ b/packages/helpermodules/logger.py
@@ -16,7 +16,7 @@ def filter_soc_pos(record) -> bool:
 
 
 def setup_logging() -> None:
-    format_str_detailed = '%(asctime)s - {%(name)s:%(lineno)s} - %(levelname)s - %(message)s'
+    format_str_detailed = '%(asctime)s - {%(name)s:%(lineno)s} - {%(levelname)s:%(threadName)s} - %(message)s'
     format_str_short = '%(asctime)s - %(message)s'
     logging.basicConfig(filename=str(Path(__file__).resolve().parents[2] / 'ramdisk' / ('main.log')),
                         format=format_str_detailed,

--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -39,12 +39,14 @@ class Loadvars:
         for item in data.data.system_data.values():
             try:
                 if isinstance(item, AbstractDevice):
-                    modules_threads.append(threading.Thread(target=item.update, args=()))
+                    modules_threads.append(threading.Thread(target=item.update, args=(),
+                                           name=f"device{item.device_config.id}"))
             except Exception:
                 log.exception(f"Fehler im loadvars-Modul bei Element {item}")
         for cp in data.data.cp_data.values():
             try:
-                modules_threads.append(threading.Thread(target=cp.chargepoint_module.get_values, args=()))
+                modules_threads.append(threading.Thread(target=cp.chargepoint_module.get_values,
+                                       args=(), name=f"cp{cp.chargepoint_module.id}"))
             except Exception:
                 log.exception(f"Fehler im loadvars-Modul bei Element {cp.num}")
         thread_handler(modules_threads)
@@ -57,12 +59,15 @@ class Loadvars:
                 if element["type"] == ComponentType.CHARGEPOINT.value:
                     chargepoint = data.data.cp_data[f'{type_to_topic_mapping(element["type"])}{element["id"]}']
                     modules_threads.append(threading.Thread(
-                        target=update_values, args=(chargepoint.chargepoint_module,)))
+                        target=update_values,
+                        args=(chargepoint.chargepoint_module,),
+                        name=f"cp{chargepoint.chargepoint_module.id}"))
                 else:
                     component = self.__get_component_obj_by_id(element["id"])
                     if component is None:
                         continue
-                    modules_threads.append(threading.Thread(target=update_values, args=(component,)))
+                    modules_threads.append(threading.Thread(target=update_values, args=(
+                        component,), name=f"component{component.component_config.id}"))
             except Exception:
                 log.exception(f"Fehler im loadvars-Modul bei Element {element}")
         thread_handler(modules_threads)


### PR DESCRIPTION
Durch das parallele Abfragen der Module sind die Logmeldungen der Module nicht zeitlich sortiert. Durch den Threadnamen können die einzelnen Logmeldungen zugerordnet werden.
`2022-11-03 11:48:11,781 - {soc.modules.common.component_context:24} - {DEBUG:component0} - Update Komponente ['MQTT-Zähler']`