### PR TITLE
do not publish setdata until subdata is initialised

### DIFF
--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -3,6 +3,7 @@
 
 import copy
 import dataclasses
+import threading
 from typing import List, Optional, Tuple
 import re
 
@@ -18,14 +19,21 @@ mqtt_log = logging.getLogger("mqtt")
 
 
 class SetData:
-    def __init__(self, event_ev_template, event_charge_template, event_cp_config):
+    def __init__(self,
+                 event_ev_template: threading.Event,
+                 event_charge_template: threading.Event,
+                 event_cp_config: threading.Event,
+                 event_subdata_initialized: threading.Event):
         self.event_ev_template = event_ev_template
         self.event_charge_template = event_charge_template
         self.event_cp_config = event_cp_config
+        self.event_subdata_initialized = event_subdata_initialized
         self.heartbeat = False
 
     def set_data(self):
         self.internal_broker_client = InternalBrokerClient("mqttset", self.on_connect, self.on_message)
+        self.event_subdata_initialized.wait()
+        log.debug("Subdata initialisation completed. Starting setdata loop to broker.")
         self.internal_broker_client.start_infinite_loop()
 
     def disconnect(self) -> None:

--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -56,13 +56,15 @@ class SubData:
                  event_cp_config: threading.Event,
                  event_module_update_completed: threading.Event,
                  event_copy_data: threading.Event,
-                 event_global_data_initialized: threading.Event):
+                 event_global_data_initialized: threading.Event,
+                 event_subdata_initialized: threading.Event):
         self.event_ev_template = event_ev_template
         self.event_charge_template = event_charge_template
         self.event_cp_config = event_cp_config
         self.event_module_update_completed = event_module_update_completed
         self.event_copy_data = event_copy_data
         self.event_global_data_initialized = event_global_data_initialized
+        self.event_subdata_initialized = event_subdata_initialized
         self.heartbeat = False
 
         self.bat_data["all"] = bat.BatAll()
@@ -92,8 +94,10 @@ class SubData:
         client.subscribe("openWB/system/device/module_update_completed", 2)
         client.subscribe("openWB/system/mqtt/bridge/+", 2)
         client.subscribe("openWB/system/device/+/config", 2)
+        Pub().pub("openWB/system/subdata_initialized", True)
 
-    def on_message(self, client, userdata, msg):
+    def on_message(self, client, userdata,
+                   msg):
         """ wartet auf eingehende Topics.
         """
         mqtt_log.debug("Topic: "+str(msg.topic) +
@@ -695,6 +699,9 @@ class SubData:
                 elif "openWB/system/available_branches" == msg.topic:
                     # Logged in update.log, not used in data.data and removed due to readability purposes of main.log.
                     return
+                elif "openWB/system/subdata_initialized" == msg.topic:
+                    Pub().pub("openWB/system/subdata_initialized", "")
+                    self.event_subdata_initialized.set()
                 self.set_json_payload(var["system"].data, msg)
         except Exception:
             log.exception("Fehler im subdata-Modul")

--- a/packages/main.py
+++ b/packages/main.py
@@ -153,12 +153,13 @@ try:
     event_copy_data = threading.Event()  # set: Kopieren abgeschlossen, reset: es wird kopiert
     event_copy_data.set()
     event_global_data_initialized = threading.Event()
+    event_subdata_initialized = threading.Event()
     prep = prepare.Prepare()
     set = setdata.SetData(event_ev_template, event_charge_template,
-                          event_cp_config)
+                          event_cp_config, event_subdata_initialized)
     sub = subdata.SubData(event_ev_template, event_charge_template,
                           event_cp_config, loadvars_.event_module_update_completed,
-                          event_copy_data, event_global_data_initialized)
+                          event_copy_data, event_global_data_initialized, event_subdata_initialized)
     comm = command.Command()
     soc = update_soc.UpdateSoc()
     t_sub = Thread(target=sub.sub_topics, args=())


### PR DESCRIPTION
Die setdata greift auf die Datenstruktur von subdata zu, daher müssen erst alle Topics in der subdata empfangen werden, bevor set-Topics verarbeitet werden.