### PR TITLE
request soc after plug in

### DIFF
--- a/packages/control/chargepoint.py
+++ b/packages/control/chargepoint.py
@@ -335,6 +335,8 @@ class Chargepoint:
             # set current aus dem vorherigen Zyklus, um zu wissen, ob am Ende des Zyklus die Ladung freigegeben wird
             # (für Control-Pilot-Unterbrechung)
             self.set_current_prev = 0
+            # Um herauszufinden, ob an-/abgesteckt wurde, zB für SoC.
+            self.plug_state_prev = False
             # bestehende Daten auf dem Broker nicht zurücksetzen, daher nicht publishen
             self.data: ChargepointData = ChargepointData()
             self.data.set_event(event)
@@ -502,10 +504,12 @@ class Chargepoint:
         self.data.set.energy_to_charge = 0
         Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/energy_to_charge", 0)
 
+    def remember_previous_values(self):
+        self.set_current_prev = self.data.set.current
+        self.plug_state_prev = self.data.get.plug_state
+
     def prepare_cp(self) -> Tuple[int, Optional[str]]:
         try:
-            # Für Control-Pilot-Unterbrechung set current merken.
-            self.set_current_prev = self.data.set.current
             self.__validate_rfid()
             charging_possible, message = self.is_charging_possible()
             if charging_possible:

--- a/packages/control/process.py
+++ b/packages/control/process.py
@@ -24,6 +24,7 @@ class Process:
                 try:
                     if "cp" in cp:
                         chargepoint = data.data.cp_data[cp]
+                        chargepoint.remember_previous_values()
                         if chargepoint.data.set.charging_ev != -1:
                             # Ladelog-Daten müssen vor dem Setzen des Stroms gesammelt werden,
                             # damit bei Phasenumschaltungs-empfindlichen EV sicher noch nicht geladen wurde.

--- a/packages/modules/update_soc.py
+++ b/packages/modules/update_soc.py
@@ -6,6 +6,7 @@ import time
 
 from control import data
 from control.chargepoint import AllChargepoints
+from control.ev import Ev
 from helpermodules import timecheck
 from helpermodules.pub import Pub
 from helpermodules.utils import thread_handler
@@ -24,7 +25,7 @@ class UpdateSoc:
             self.heartbeat = True
             time.sleep(max(0, next_time - time.time()))
             try:
-                threads_set, threads_update = self.__get_threads()
+                threads_set, threads_update = self._get_threads()
                 thread_handler(threads_set)
                 thread_handler(threads_update)
             except Exception:
@@ -32,33 +33,46 @@ class UpdateSoc:
             # skip tasks if we are behind schedule:
             next_time += (time.time() - next_time) // delay * delay + delay
 
-    def __get_threads(self) -> Tuple[List[threading.Thread], List[threading.Thread]]:
+    def _get_threads(self) -> Tuple[List[threading.Thread], List[threading.Thread]]:
         threads_set, threads_update = [], []
-        cp_data = copy.deepcopy(data.data.cp_data)
         ev_data = copy.deepcopy(data.data.ev_data)
         # Alle Autos durchgehen
         for ev in ev_data.values():
             try:
                 if ev.soc_module is not None:
-                    for cp in cp_data.values():
-                        if not isinstance(cp, AllChargepoints):
-                            if cp.data.set.charging_ev == ev.num:
-                                charge_state = cp.data.get.charge_state
-                                break
-                    else:
-                        charge_state = False
+                    charge_state, plugged_in = self._get_ev_state(ev.num)
                     if (ev.ev_template.soc_interval_expired(charge_state, ev.data.get.soc_timestamp) or
-                            ev.data.get.force_soc_update):
-                        if ev.data.get.force_soc_update:
-                            ev.data.get.force_soc_update = False
-                            Pub().pub(f"openWB/set/vehicle/{ev.num}/get/force_soc_update", False)
+                            ev.data.get.force_soc_update or
+                            # Nach Abstecken abfragen, da zB für Zielladen der aktuelle SoC benötigt wird, um zu
+                            # entscheiden, ob die Ladung gestartet werden muss.
+                            plugged_in):
+                        self._reset_force_soc_update(ev)
                         # Es wird ein Zeitstempel gesetzt, unabhängig ob die Abfrage erfolgreich war, da einige
                         # Hersteller bei zu häufigen Abfragen Accounts sperren.
                         Pub().pub(f"openWB/set/vehicle/{ev.num}/get/soc_timestamp", timecheck.create_timestamp())
                         threads_set.append(threading.Thread(target=ev.soc_module.update,
                                                             args=(charge_state,), name=f"soc_ev{ev.num}"))
-                        threads_update.append(threading.Thread(target=ev.soc_module.store.update,
-                                                               args=(), name=f"soc_ev{ev.num}"))
+                        if hasattr(ev.soc_module, "store"):
+                            threads_update.append(threading.Thread(target=ev.soc_module.store.update,
+                                                                   args=(), name=f"soc_ev{ev.num}"))
             except Exception:
                 log.exception("Fehler im Main-Modul")
         return threads_set, threads_update
+
+    def _reset_force_soc_update(self, ev: Ev) -> None:
+        if ev.data.get.force_soc_update:
+            ev.data.get.force_soc_update = False
+            Pub().pub(f"openWB/set/vehicle/{ev.num}/get/force_soc_update", False)
+
+    def _get_ev_state(self, ev_num: int) -> Tuple[bool, bool]:
+        cp_data = copy.deepcopy(data.data.cp_data)
+        for cp in cp_data.values():
+            if not isinstance(cp, AllChargepoints):
+                if cp.data.set.charging_ev == ev_num:
+                    charge_state = cp.data.get.charge_state
+                    plugged_in = cp.data.get.plug_state is True and cp.plug_state_prev is False
+                    break
+        else:
+            charge_state = False
+            plugged_in = False
+        return charge_state, plugged_in

--- a/packages/modules/update_soc_test.py
+++ b/packages/modules/update_soc_test.py
@@ -1,0 +1,87 @@
+from typing import List, Optional, Tuple
+from unittest.mock import Mock
+
+import pytest
+
+from control import data
+from control.chargepoint import Chargepoint, Get, Set
+from control.ev import Ev, EvTemplate
+from modules.tesla.soc import Soc
+from modules.update_soc import UpdateSoc
+
+
+@pytest.fixture(autouse=True)
+def mock_data() -> None:
+    data.data_init(Mock())
+    data.data.cp_data["cp0"] = Mock(spec=Chargepoint,
+                                    id=id,
+                                    chargepoint_module=Mock(),
+                                    data=Mock(
+                                        get=Mock(spec=Get),
+                                        set=Mock(spec=Set)))
+
+
+@pytest.mark.parametrize(
+    "ev_num, set_charge_state, plug_state, plug_state_prev, expected_charge_state, expected_plugged_in",
+    [
+        pytest.param(1, False, False, False, False, False, id="ev not matched to cp"),
+        pytest.param(0, False, False, False, False, False, id="ev not plugged in"),
+        pytest.param(0, False, True, False, False, True, id="ev recently plugged in"),
+        pytest.param(0, False, True, True, False, False, id="ev plugged in, not charging"),
+        pytest.param(0, True, True, True, True, False, id="ev plugged in and charging"),
+    ])
+def test_get_ev_state(ev_num: int,
+                      set_charge_state: bool,
+                      plug_state: bool,
+                      plug_state_prev: bool,
+                      expected_charge_state: bool,
+                      expected_plugged_in: bool):
+    # setup
+    data.data.cp_data["cp0"].data.set.charging_ev = ev_num
+    data.data.cp_data["cp0"].data.get.charge_state = set_charge_state
+    data.data.cp_data["cp0"].data.get.plug_state = plug_state
+    data.data.cp_data["cp0"].plug_state_prev = plug_state_prev
+
+    # execution
+    charge_state, plugged_in = UpdateSoc()._get_ev_state(0)
+
+    # evaluation
+    assert charge_state == expected_charge_state
+    assert plugged_in == expected_plugged_in
+
+
+@pytest.mark.parametrize(
+    "soc_module, force_soc_update, soc_interval_expired, ev_state, expected_threads_set",
+    [
+        pytest.param(None, False, False, (False, False), [], id="soc module none"),
+        pytest.param(Mock(spec=Soc), False, True, (False, False), ["soc_ev0"], id="interval expired"),
+        pytest.param(Mock(spec=Soc), True, False, (False, False), ["soc_ev0"], id="force soc update"),
+        pytest.param(Mock(spec=Soc), False, False, (False, True), ["soc_ev0"], id="plugged in"),
+        pytest.param(Mock(spec=Soc), False, False, (False, False), [], id="no soc request needed"),
+    ]
+)
+def test_get_threads(soc_module: Optional[Soc],
+                     force_soc_update: bool,
+                     soc_interval_expired: bool,
+                     ev_state: Tuple[bool, bool],
+                     expected_threads_set: List[str],
+                     monkeypatch):
+    # setup
+    ev = Ev(0)
+    ev.soc_module = soc_module
+    ev.data.get.force_soc_update = force_soc_update
+    data.data.ev_data["ev0"] = ev
+    soc_interval_expired_mock = Mock(return_value=soc_interval_expired)
+    monkeypatch.setattr(EvTemplate, "soc_interval_expired", soc_interval_expired_mock)
+    get_ev_state_mock = Mock(return_value=(ev_state))
+    monkeypatch.setattr(UpdateSoc, "_get_ev_state", get_ev_state_mock)
+    monkeypatch.setattr(UpdateSoc, "_reset_force_soc_update", Mock())
+
+    # execution
+    threads_set, threads_update = UpdateSoc()._get_threads()
+
+    # evaluation
+    if threads_set:
+        assert threads_set[0].name == expected_threads_set[0]
+    else:
+        assert threads_set == expected_threads_set


### PR DESCRIPTION
Der SoC muss nach dem Abstecken abgefragt werden, da zB beim Zielladen geprüft wird, ob die Ladung gestartet werden muss.