### PR TITLE
Create SOC Modul BMW

### DIFF
--- a/packages/modules/bmw/api.py
+++ b/packages/modules/bmw/api.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+
+from typing import Union
+import os
+import base64
+import json
+import random
+import requests
+import string
+import getpass
+import urllib
+
+import logging
+from modules.common.store import RAMDISK_PATH
+
+log = logging.getLogger("soc."+__name__)
+
+# ---------------Constants-------------------------------------------
+auth_server = 'customer.bmwgroup.com'
+api_server = 'cocoapi.bmwgroup.com'
+
+client_id = '31c357a0-7a1d-4590-aa99-33b97244d048'
+client_password = 'c0e3393d-70a2-4f6f-9d3c-8530af64d552'
+
+
+# ---------------Helper Function-------------------------------------------
+def get_random_string(length: int) -> str:
+    letters = string.ascii_letters
+    result_str = ''.join(random.choice(letters) for i in range(length))
+    return result_str
+
+
+def create_auth_string(client_id: str, client_password: str) -> str:
+    authstring = client_id + ':' + client_password
+    authbytes = authstring.encode("ascii")
+    b64bytes = base64.b64encode(authbytes)
+    authstring = 'Basic ' + b64bytes.decode("ascii")
+    return authstring
+
+
+# ---------------HTTP Function-------------------------------------------
+def getHTTP(url: str = '', headers: str = '', cookies: str = '', timeout: int = 30) -> str:
+    try:
+        response = requests.get(url, headers=headers, cookies=cookies, timeout=timeout)
+    except requests.Timeout:
+        log.error("bmw.getHTTP: Connection Timeout")
+        raise
+    except Exception as err:
+        log.error("bmw.getHTTP: HTTP Error" + f", {err=}, {type(err)=}")
+        raise
+
+    if response.status_code == 200 or response.status_code == 204:
+        return response.text
+    else:
+        log.error('bmw.getHTTP: Request failed, StatusCode: ' + str(response.status_code))
+        raise RuntimeError
+
+
+def postHTTP(url: str = '', data: str = '', headers: str = '', cookies: str = '',
+             timeout: int = 30, allow_redirects: bool = True) -> str:
+    try:
+        response = requests.post(url, data=data, headers=headers, cookies=cookies,
+                                 timeout=timeout, allow_redirects=allow_redirects)
+    except requests.Timeout:
+        log.error("bmw.postHTTP: Connection Timeout")
+        raise
+    except Exception as err:
+        log.error("bmw.postHTTP: HTTP Error" + f" {err=}, {type(err)=}")
+        raise
+
+    if response.status_code == 200 or response.status_code == 204:
+        return response.text
+    elif response.status_code == 302:
+        return response.headers["location"]
+    else:
+        log.error('bmw.postHTTP: Request failed, StatusCode: ' + str(response.status_code))
+        raise RuntimeError
+
+
+# ---------------Authentication Function-------------------------------------------
+def authStage1(username: str, password: str, code_challenge: str, state: str) -> str:
+    try:
+        url = 'https://' + auth_server + '/gcdm/oauth/authenticate'
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_3_1 like Mac OS X)\
+                    AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3 Mobile/15E148 Safari/604.1'}
+        data = {
+            'client_id': client_id,
+            'response_type': 'code',
+            'scope': 'openid profile email offline_access smacc vehicle_data perseus dlm\
+                    svds cesim vsapi remote_services fupo authenticate_user',
+            'redirect_uri': 'com.bmw.connected://oauth',
+            'state': state,
+            'nonce': 'login_nonce',
+            'code_challenge': code_challenge,
+            'code_challenge_method': 'plain',
+            'username': username,
+            'password': password,
+            'grant_type': 'authorization_code'}
+
+        response = json.loads(postHTTP(url, data, headers))
+        authcode = dict(urllib.parse.parse_qsl(response["redirect_to"]))["authorization"]
+    except Exception as err:
+        log.error("bmw.authStage1: Authentication stage 1 Error" + f" {err=}, {type(err)=}")
+        raise
+
+    return authcode
+
+
+def authStage2(authcode1: str, code_challenge: str, state: str) -> str:
+    try:
+        url = 'https://' + auth_server + '/gcdm/oauth/authenticate'
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_3_1 like Mac OS X)\
+                    AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3 Mobile/15E148 Safari/604.1'}
+        data = {
+            'client_id': client_id,
+            'response_type': 'code',
+            'scope': 'openid profile email offline_access smacc vehicle_data\
+                    perseus dlm svds cesim vsapi remote_services fupo authenticate_user',
+            'redirect_uri': 'com.bmw.connected://oauth',
+            'state': state,
+            'nonce': 'login_nonce',
+            'code_challenge': code_challenge,
+            'code_challenge_method': 'plain',
+            'authorization': authcode1}
+        cookies = {
+            'GCDMSSO': authcode1}
+
+        response = postHTTP(url, data, headers, cookies, allow_redirects=False)
+        authcode = dict(urllib.parse.parse_qsl(response.split("?", 1)[1]))["code"]
+    except Exception as err:
+        log.error("bmw.authStage2: Authentication stage 2 Error" + f" {err=}, {type(err)=}")
+        raise
+
+    return authcode
+
+
+def authStage3(authcode2: str, code_challenge: str) -> dict:
+    try:
+        url = 'https://' + auth_server + '/gcdm/oauth/token'
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'Authorization': create_auth_string(client_id, client_password)}
+        data = {
+            'code': authcode2,
+            'code_verifier': code_challenge,
+            'redirect_uri': 'com.bmw.connected://oauth',
+            'grant_type': 'authorization_code'}
+
+        response = postHTTP(url, data, headers, allow_redirects=False)
+        token = json.loads(response)
+    except Exception as err:
+        log.error("bmw.authStage3: Authentication stage 3 Error" + f" {err=}, {type(err)=}")
+        raise
+
+    return token
+
+
+def requestToken(username: str, password: str) -> dict:
+    try:
+        code_challenge = get_random_string(86)
+        state = get_random_string(22)
+
+        authcode1 = authStage1(username, password, code_challenge, state)
+        authcode2 = authStage2(authcode1, code_challenge, state)
+        token = authStage3(authcode2, code_challenge)
+    except Exception as err:
+        log.error("bmw.requestToken: Login Error" + f" {err=}, {type(err)=}")
+        raise
+
+    return token
+
+
+# ---------------Interface Function-------------------------------------------
+def requestData(token: str, vin: str) -> dict:
+    try:
+        if vin[:2] == 'WB':
+            brand = 'bmw'
+        elif vin[:2] == 'WM':
+            brand = 'mini'
+        else:
+            log.error("bmw.requestData: Unknown VIN, must start with WB or WM")
+            raise RuntimeError
+
+        url = 'https://' + api_server + '/eadrax-vcs/v2/vehicles/' + vin + '/state'
+        headers = {
+            'User-Agent': 'Dart/2.14 (dart:io)',
+            'x-user-agent': 'android(SP1A.210812.016.C1);' + brand + ';2.5.2(14945);row',
+            'Authorization': (token["token_type"] + " " + token["access_token"])}
+        body = getHTTP(url, headers)
+        response = json.loads(body)
+    except Exception as err:
+        log.error("bmw.requestData: Data Request Error" + f" {err=}, {type(err)=}")
+        raise
+
+    return response
+
+
+def fetch_soc(userid: str, password: str, vin: str, vehicle: int) -> Union[int, float]:
+    # log.debug("bmw:fetch_soc, userid=" + userid)
+    # log.debug("bmw:fetch_soc, password=" + password)
+    # log.debug("bmw:fetch_soc, vin=" + vin)
+    # log.debug("bmw: fetch_soc, vehicle=" + vehicle)
+    replyFile = str(RAMDISK_PATH) + '/soc_bmw_reply_vehicle_' + str(vehicle)
+
+    try:
+        token = requestToken(userid, password)
+        data = requestData(token, vin)
+        soc = int(data["state"]["electricChargingState"]["chargingLevelPercent"])
+        # todo: verify range value
+        range = float(data["state"]["electricChargingState"]["range"])
+        log.debug("bmw.fetch_soc: Download successful - vehicle: " +
+                  str(vehicle) + ", SoC: " + str(soc) + "%, Range: " + str(range))
+    except Exception as err:
+        log.error("bmw.fetch_soc: requestData Error, vehicle: " + str(vehicle) + f" {err=}, {type(err)=}")
+        raise
+
+    try:
+        f = open(replyFile, 'w', encoding='utf-8')
+    except Exception as e:
+        log.debug("bmw.fetch_soc: vehicle: " + vehicle +
+                  ", replyFile open exception: e=" + str(e) + "user: " + getpass.getuser())
+        log.debug("bmw.fetch_soc: vehicle " + vehicle + ", replyFile open Exception, remove existing file")
+        os.system("sudo rm " + replyFile)
+        f = open(replyFile, 'w', encoding='utf-8')
+        json.dump(data, f, ensure_ascii=False, indent=4)
+    f.close()
+    try:
+        os.chmod(replyFile, 0o777)
+    except Exception as e:
+        log.debug("bmw.fetch_soc: vehicle " + vehicle + ", chmod replyFile exception, e=" + str(e))
+        log.debug("bmw.fetch_soc: vehicle " + vehicle + ", use sudo, user: " + getpass.getuser())
+        os.system("sudo chmod 0777 " + replyFile)
+
+    log.debug("bmw.fetch_soc vehicle=" + vehicle + ", return: soc=" + str(soc) + ", range=" + str(range))
+    return soc, range
+
+# code from owb1 - keep for now - not sure about role of meterfile and statefile
+# ---------------Main Function-------------------------------------------
+# def main():
+#     try:
+#         argsStr = base64.b64decode(str(sys.argv[1])).decode('utf-8')
+#         argsDict = json.loads(argsStr)
+#
+#         username = str(argsDict["user"])
+#         password = str(argsDict["pass"])
+#         vin = str(argsDict["vin"]).upper()
+#         socfile = str(argsDict["socfile"])
+#         meterfile = str(argsDict["meterfile"])
+#         statefile = str(argsDict["statefile"])
+#     except:
+#         print("Parameters could not be processed")
+#         raise
+#
+#     try:
+#         token = requestToken(username, password)
+#         data = requestData(token, vin)
+#         soc = int(data["state"]["electricChargingState"]["chargingLevelPercent"])
+#         print("Download sucessful - SoC: " + str(soc) + "%")
+#     except:
+#         print("Request failed")
+#         raise
+#
+#     try:
+#         with open(socfile, 'w') as f:
+#             f.write(str(int(soc)))
+#         state = {}
+#         state["soc"] = int(soc)
+#         with open(meterfile, 'r') as f:
+#             state["meter"] = float(f.read())
+#         with open(statefile, 'w') as f:
+#             f.write(json.dumps(state))
+#     except:
+#         print("Saving SoC failed")
+#         raise
+#
+#
+# if __name__ == '__main__':
+#     main()
+#

--- a/packages/modules/bmw/config.py
+++ b/packages/modules/bmw/config.py
@@ -1,0 +1,15 @@
+class BMWConfiguration:
+    def __init__(self, userid: str = "", password: str = "", vin: str = ""):
+        self.userid = userid
+        self.password = password
+        self.vin = vin
+
+
+class BMW:
+    def __init__(self,
+                 name: str = "BMW",
+                 type: str = "bmw",
+                 configuration: BMWConfiguration = None) -> None:
+        self.name = name
+        self.type = type
+        self.configuration = configuration or BMWConfiguration()

--- a/packages/modules/bmw/soc.py
+++ b/packages/modules/bmw/soc.py
@@ -1,0 +1,47 @@
+from typing import Union, List
+
+import logging
+
+from dataclass_utils import dataclass_from_dict
+from helpermodules.cli import run_using_positional_cli_args
+from modules.common import store
+from modules.common.abstract_device import DeviceDescriptor
+from modules.common.abstract_soc import AbstractSoc
+from modules.common.component_context import SingleComponentUpdateContext
+from modules.common.component_state import CarState
+from modules.common.fault_state import ComponentInfo
+from modules.bmw import api
+from modules.bmw.config import BMW, BMWConfiguration
+
+
+log = logging.getLogger("soc."+__name__)
+
+
+class Soc(AbstractSoc):
+    def __init__(self, device_config: Union[dict, BMW], vehicle: int):
+        self.config = dataclass_from_dict(BMW, device_config)
+        self.vehicle = vehicle
+        self.store = store.get_car_value_store(self.vehicle)
+        self.component_info = ComponentInfo(self.vehicle, self.config.name, "vehicle")
+
+    def update(self, charge_state: bool = False) -> None:
+        with SingleComponentUpdateContext(self.component_info):
+            soc, range = api.fetch_soc(
+                self.config.configuration.userid,
+                self.config.configuration.password,
+                self.config.configuration.vin,
+                self.vehicle)
+            log.info("bmw: vehicle="+str(self.vehicle) + ", return: soc=" + str(soc)+", range=" + str(range))
+            self.store.set(CarState(soc, range))
+
+
+def bmw_update(userid: str, password: str, vin: str, charge_point: int):
+    log.debug("bmw: userid="+userid+"vin="+vin+"charge_point="+str(charge_point))
+    Soc(BMW(configuration=BMWConfiguration(charge_point, userid, password, vin)), charge_point).update(False)
+
+
+def main(argv: List[str]):
+    run_using_positional_cli_args(bmw_update, argv)
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=BMW)


### PR DESCRIPTION
SOC Module for BMW-i3/Mini.
Ported from owb1 module soc_i3.
Fetches soc and range from BMW Server.
Files:
api.py:       former i3soc.py, changes: 
- main replaced by fetch_soc. 
- use logging to soc.log instead of print.

soc.py       owb2 soc runtime interface - calls api.py.fetch_soc, writes CarState.
config.py: owb2 module configuration

Note: This module is not (yet) tested against a valid BMW account.