### PR TITLE
change flake 8 version

### DIFF
--- a/.github/workflows/github-actions-python.yml
+++ b/.github/workflows/github-actions-python.yml
@@ -19,6 +19,7 @@ jobs:
         uses: TrueBrain/actions-flake8@v2.1
         with:
           path: packages
+          flake8_version: 5.0.4
       - name: Test with pytest
         run: |
           PYTHONPATH=packages python -m pytest packages


### PR DESCRIPTION
Seit dem gestrigen [Update von pyflake](https://github.com/PyCQA/pyflakes/blob/main/NEWS.rst) werden Typing-Kommentare nicht mehr akzeptiert. Type-Annotiations für Variablen werden aber erst ab Python 3.6 unterstützt. Der Code im Modules-Ordner muss aber Python 3.5 kompatibel sein. Daher wird mit diesem PR die alte Flake8-Version beibehalten.