### PR TITLE
set soc to 0% in case of error

### DIFF
--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -4,11 +4,11 @@ from typing import List
 
 from control import data
 from modules import ripple_control_receiver
+from modules.utils import ModuleUpdateCompletedContext
 from modules.common.abstract_device import AbstractDevice
 from modules.common.component_type import ComponentType, type_to_topic_mapping
 from modules.common.store import update_values
 from modules.common.utils.component_parser import get_component_obj_by_id
-from helpermodules import pub
 from helpermodules.utils import thread_handler
 
 log = logging.getLogger(__name__)
@@ -94,20 +94,3 @@ class Loadvars:
             log.exception("Fehler im loadvars-Modul")
         finally:
             return threads
-
-
-class ModuleUpdateCompletedContext:
-    def __init__(self, event_module_update_completed: threading.Event):
-        self.event_module_update_completed = event_module_update_completed
-
-    def __enter__(self):
-        timeout = data.data.general_data.data.control_interval/2
-        if self.event_module_update_completed.wait(timeout) is False:
-            log.error(
-                "Modul-Daten wurden noch nicht vollständig empfangen. Timeout abgelaufen, fortsetzen der Regelung.")
-        return None
-
-    def __exit__(self, exception_type, exception, exception_traceback) -> bool:
-        self.event_module_update_completed.clear()
-        pub.Pub().pub("openWB/set/system/device/module_update_completed", True)
-        return True

--- a/packages/modules/update_soc.py
+++ b/packages/modules/update_soc.py
@@ -1,15 +1,17 @@
 import logging
 from typing import List, Tuple
 import copy
-import threading
+from threading import Event, Thread
 
 from control import data
 from control.chargepoint import AllChargepoints
 from control.ev import Ev
+from helpermodules import subdata
 from helpermodules import timecheck
 from helpermodules.pub import Pub
-from helpermodules.utils import exit_after, thread_handler
+from helpermodules.utils import thread_handler
 from modules.common.abstract_soc import SocUpdateData
+from modules.utils import ModuleUpdateCompletedContext
 
 log = logging.getLogger("soc."+__name__)
 
@@ -17,18 +19,23 @@ log = logging.getLogger("soc."+__name__)
 class UpdateSoc:
     def __init__(self) -> None:
         self.heartbeat = False
+        self.event_module_update_completed = Event()
 
-    @exit_after(10)
     def update(self) -> None:
         try:
-            threads_set, threads_update = self._get_threads()
-            thread_handler(threads_set)
-            thread_handler(threads_update)
+            threads_update, threads_store = self._get_threads()
+            with ModuleUpdateCompletedContext(self.event_module_update_completed):
+                threads_update, threads_store = self._get_threads()
+                thread_handler(threads_update)
+            with ModuleUpdateCompletedContext(self.event_module_update_completed):
+                threads_store, threads_failed = self._filter_failed_store_threads(threads_store)
+                thread_handler(threads_store)
+                self._reset_failed_soc_request(threads_failed)
         except Exception:
-            log.exception("Fehler im Main-Modul")
+            log.exception("Fehler im update_soc-Modul")
 
-    def _get_threads(self) -> Tuple[List[threading.Thread], List[threading.Thread]]:
-        threads_set, threads_update = [], []
+    def _get_threads(self) -> Tuple[List[Thread], List[Thread]]:
+        threads_update, threads_store = [], []
         ev_data = copy.deepcopy(data.data.ev_data)
         # Alle Autos durchgehen
         for ev in ev_data.values():
@@ -41,14 +48,14 @@ class UpdateSoc:
                         # Es wird ein Zeitstempel gesetzt, unabhängig ob die Abfrage erfolgreich war, da einige
                         # Hersteller bei zu häufigen Abfragen Accounts sperren.
                         Pub().pub(f"openWB/set/vehicle/{ev.num}/get/soc_timestamp", timecheck.create_timestamp())
-                        threads_set.append(threading.Thread(target=ev.soc_module.update,
-                                                            args=(soc_update_data,), name=f"soc_ev{ev.num}"))
+                        threads_update.append(Thread(target=ev.soc_module.update,
+                                                     args=(soc_update_data,), name=f"soc_ev{ev.num}"))
                         if hasattr(ev.soc_module, "store"):
-                            threads_update.append(threading.Thread(target=ev.soc_module.store.update,
-                                                                   args=(), name=f"soc_ev{ev.num}"))
+                            threads_store.append(Thread(target=ev.soc_module.store.update,
+                                                        args=(), name=f"soc_ev{ev.num}"))
             except Exception:
-                log.exception("Fehler im Main-Modul")
-        return threads_set, threads_update
+                log.exception("Fehler im update_soc-Modul")
+        return threads_update, threads_store
 
     def _reset_force_soc_update(self, ev: Ev) -> None:
         if ev.data.get.force_soc_update:
@@ -56,8 +63,7 @@ class UpdateSoc:
             Pub().pub(f"openWB/set/vehicle/{ev.num}/get/force_soc_update", False)
 
     def _get_soc_update_data(self, ev_num: int) -> SocUpdateData:
-        cp_data = copy.deepcopy(data.data.cp_data)
-        for cp in cp_data.values():
+        for cp in list(data.data.cp_data.values()):
             if not isinstance(cp, AllChargepoints):
                 if cp.data.set.charging_ev == ev_num:
                     charge_state = cp.data.get.charge_state
@@ -65,3 +71,31 @@ class UpdateSoc:
         else:
             charge_state = False
         return SocUpdateData(charge_state=charge_state)
+
+    def _filter_failed_store_threads(self, threads_store: List[Thread]) -> Tuple[List[Thread], List[Thread]]:
+        ev_data = copy.deepcopy(subdata.SubData.ev_data)
+        threads_failed = []
+        # Alle Autos durchgehen, deren SoC gerade aktualisiert wurde
+        for ev_thread in threads_store:
+            try:
+                ev = ev_data[f"ev{ev_thread.getName()[6:]}"]
+                if ev.soc_module is not None:
+                    if hasattr(ev.soc_module, "store"):
+                        if ev.data.get.fault_state == 2:
+                            threads_failed.append(ev_thread)
+                            threads_store.remove(ev_thread)
+            except Exception:
+                log.exception("Fehler im update_soc-Modul")
+        return threads_store, threads_failed
+
+    def _reset_failed_soc_request(self, threads_failed: List[Thread]) -> None:
+        ev_data = copy.deepcopy(subdata.SubData.ev_data)
+        # Alle Autos durchgehen, deren SoC gerade aktualisiert wurde
+        for ev_thread in threads_failed:
+            try:
+                ev = ev_data[f"ev{ev_thread.getName()[6:]}"]
+                log.debug(f"Zurücksetzen des SoC für EV{ev.num}, da ein Fehler vorliegt.")
+                Pub().pub(f"openWB/set/vehicle/{ev.num}/get/soc", 0)
+                Pub().pub(f"openWB/set/vehicle/{ev.num}/get/range", 0)
+            except Exception:
+                log.exception("Fehler im update_soc-Modul")

--- a/packages/modules/update_soc_test.py
+++ b/packages/modules/update_soc_test.py
@@ -44,7 +44,7 @@ def test_get_ev_state(ev_num: int,
 
 
 @pytest.mark.parametrize(
-    "soc_module, force_soc_update, soc_interval_expired, expected_threads_set",
+    "soc_module, force_soc_update, soc_interval_expired, expected_threads_update",
     [
         pytest.param(None, False, False, [], id="soc module none"),
         pytest.param(Mock(spec=Soc), False, True, ["soc_ev0"], id="interval expired"),
@@ -55,7 +55,7 @@ def test_get_ev_state(ev_num: int,
 def test_get_threads(soc_module: Optional[Soc],
                      force_soc_update: bool,
                      soc_interval_expired: bool,
-                     expected_threads_set: List[str],
+                     expected_threads_update: List[str],
                      monkeypatch):
     # setup
     ev = Ev(0)
@@ -69,10 +69,10 @@ def test_get_threads(soc_module: Optional[Soc],
     monkeypatch.setattr(UpdateSoc, "_reset_force_soc_update", Mock())
 
     # execution
-    threads_set, threads_update = UpdateSoc()._get_threads()
+    threads_update = UpdateSoc()._get_threads()[0]
 
     # evaluation
-    if threads_set:
-        assert threads_set[0].name == expected_threads_set[0]
+    if threads_update:
+        assert threads_update[0].name == expected_threads_update[0]
     else:
-        assert threads_set == expected_threads_set
+        assert threads_update == expected_threads_update

--- a/packages/modules/utils.py
+++ b/packages/modules/utils.py
@@ -1,0 +1,24 @@
+import logging
+import threading
+
+from control import data
+from helpermodules import pub
+
+log = logging.getLogger(__name__)
+
+
+class ModuleUpdateCompletedContext:
+    def __init__(self, event_module_update_completed: threading.Event):
+        self.event_module_update_completed = event_module_update_completed
+
+    def __enter__(self):
+        timeout = data.data.general_data.data.control_interval/2
+        if self.event_module_update_completed.wait(timeout) is False:
+            log.error(
+                "Modul-Daten wurden noch nicht vollständig empfangen. Timeout abgelaufen, fortsetzen der Regelung.")
+        return None
+
+    def __exit__(self, exception_type, exception, exception_traceback) -> bool:
+        self.event_module_update_completed.clear()
+        pub.Pub().pub("openWB/set/system/device/module_update_completed", True)
+        return True


### PR DESCRIPTION
Wenn der SoC bei konfiguriertem SoC-Modul nicht abgefragt werden kann, wird der SoC auf 0 gesetzt, damit das Auto in jedem Fall lädt und man nicht mit einem leeren Auto da steht, weil der SoC vom letzten Vollladen erhalten geblieben ist.