### PR TITLE
soc_smarteq: fix issue: comparison of old/new tokens failed

### DIFF
--- a/packages/modules/vehicles/smarteq/api.py
+++ b/packages/modules/vehicles/smarteq/api.py
@@ -14,6 +14,7 @@ import os
 import time
 import datetime
 import pickle
+import copy
 
 date_fmt = '%Y-%m-%d %H:%M:%S'
 # refreshToken_exp_days = 7    # 7 days before refreshToken expires a new refreshToken shall be stored
@@ -73,7 +74,7 @@ class Api:
         self.session = req.get_http_session()
 
         self.load_store()
-        self.oldTokens = self.store['Tokens']
+        self.oldTokens = copy.deepcopy(self.store['Tokens'])
         self.init = True
 
     def load_store(self):
@@ -411,7 +412,6 @@ class Api:
 
         if self.store['Tokens'] != self.oldTokens:
             self.log.debug("reconnect: tokens changed, store token file")
-            self.store['refresh_timestamp'] = int(time.time())
             self.write_store()
 
         return soc, range

--- a/packages/modules/vehicles/smarteq/api.py
+++ b/packages/modules/vehicles/smarteq/api.py
@@ -84,6 +84,11 @@ class Api:
                 if 'Tokens' not in self.store:
                     self.store['Tokens'] = {}
                     self.store['refresh_timestamp'] = int(0)
+        except FileNotFoundError:
+            log.warning("init: no store file found; full connect required")
+            self.store = {}
+            self.store['Tokens'] = {}
+            self.store['refresh_timestamp'] = int(0)
         except Exception:
             log.exception("init: loading stored data failed, file: " + self.storeFile)
             self.store = {}


### PR DESCRIPTION
oldTokens needs to be a real (deep) copy of tokens 