### PR TITLE
move apt packages to separate script

### DIFF
--- a/data/config/apt/99openwb
+++ b/data/config/apt/99openwb
@@ -1,0 +1,7 @@
+# openwb-version:1
+# may speedup booting
+Acquire::http::Timeout "10";
+Acquire::ftp::Timeout "10";
+# keep system light and clean
+APT::Get::Install-Recommends "false";
+APT::Get::Install-Suggests "false";

--- a/openwb-install.sh
+++ b/openwb-install.sh
@@ -10,10 +10,14 @@ fi
 
 echo "installing openWB 2 into \"${OPENWBBASEDIR}\""
 
-echo "install required packages..."
-apt-get update
-apt-get -q -y install vim bc apache2 php php-gd php-curl php-xml php-json libapache2-mod-php jq git mosquitto mosquitto-clients socat python3-pip sshpass sudo ssl-cert
-echo "done"
+echo "tweaking apt configuration..."
+if [ -d "/etc/apt/apt.conf.d" ]; then
+	sudo cp "${OPENWBBASEDIR}/data/config/apt/99openwb" "/etc/apt/apt.conf.d/"
+	echo "done"
+else
+	echo "path '/etc/apt/apt.conf.d' is missing! unsupported system!"
+fi
+"${OPENWBBASEDIR}/runs/install_packages.sh"
 
 echo "create group $OPENWB_GROUP"
 # Will do nothing if group already exists:

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -40,6 +40,18 @@ chmod 666 "$LOGFILE"
 		sudo kill "$$"
 	) &
 
+	if [ -d "/etc/apt/apt.conf.d" ]; then
+		if versionMatch "${OPENWBBASEDIR}/data/config/apt/99openwb" "/etc/apt/apt.conf.d/99openwb"; then
+			echo "apt configuration already up to date"
+		else
+			echo "updating apt configuration"
+			sudo cp "${OPENWBBASEDIR}/data/config/apt/99openwb" "/etc/apt/apt.conf.d/99openwb"
+		fi
+	else
+		echo "path '/etc/apt/apt.conf.d' is missing! unsupported system!"
+	fi
+	"${OPENWBBASEDIR}/runs/install_packages.sh"
+
 	if versionMatch "${OPENWBBASEDIR}/data/config/openwb.cron" "/etc/cron.d/openwb"; then
 		echo "openwb.cron already up to date"
 	else
@@ -135,10 +147,6 @@ chmod 666 "$LOGFILE"
 		echo "done"
 	fi
 
-	# check for needed packages
-	echo "apt packages..."
-	# nothing here yet, all in install.sh
-
 	# check for mosquitto configuration
 	echo "check mosquitto installation..."
 	restartService=0
@@ -197,9 +205,10 @@ chmod 666 "$LOGFILE"
 	fi
 	echo "mosquitto done"
 
-	# check for other dependencies
-	echo "python packages..."
+	# check for python dependencies
+	echo "install required python packages with 'pip3'..."
 	pip3 install -r "${OPENWBBASEDIR}/requirements.txt"
+	echo "done"
 
 	# update version
 	# echo "version..."
@@ -254,7 +263,7 @@ chmod 666 "$LOGFILE"
 		ip="\"unknown\""
 	fi
 	echo "my IP: $ip"
-	mosquitto_pub -t "openWB/system/ip_address" -p 1886 -r -m $ip
+	mosquitto_pub -t "openWB/system/ip_address" -p 1886 -r -m "$ip"
 
 	# update current published versions
 	echo "load versions..."

--- a/runs/install_packages.sh
+++ b/runs/install_packages.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "install required packages with 'apt-get'..."
+sudo apt-get update
+sudo apt-get -q -y install \
+	vim bc jq socat sshpass sudo ssl-cert \
+	apache2 libapache2-mod-php \
+	php php-gd php-curl php-xml php-json \
+	git \
+	mosquitto mosquitto-clients \
+	python3-pip
+echo "done"


### PR DESCRIPTION
- move apt package check/installation to separate script to allow access from `openwb-install.sh` and `atreboot.sh`
- tweak apt configuration to keep system small by disabling install recommends and suggests
- tweak apt configuration to timeout after 10 seconds to prevent deadlock on boot if servers cannot be reached