### PR TITLE
ignore node_modules folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .ftp*
 .vscode/*
 __pycache__/
+node_modules/
 data/log/*
 data/charge_log/*
 data/daily_log/*


### PR DESCRIPTION
In preparation of main and display themes we ignore any `node_modules` folders.