### PR TITLE
validate positive values for pv power as true

### DIFF
--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -564,10 +564,10 @@ class SetData:
                 elif "/get/exported" in msg.topic:
                     self._validate_value(msg, float, [(0, float("inf"))])
                 elif "/get/power" in msg.topic:
-                    self._validate_value(msg, float, [(float("-inf"), 0)])
+                    self._validate_value(msg, float)
                 elif "/get/currents" in msg.topic:
                     self._validate_value(
-                        msg, float, [(float("-inf"), 0)], collection=list)
+                        msg, float, collection=list)
                 else:
                     self.__unknown_topic(msg)
             else:


### PR DESCRIPTION
Manche WR liefern positive Leistungen, zB wenn in einem SMA-System mit 2 WR der Speicher aus beiden WR geladen wird.