### PR TITLE
SOC Modul über SkodaConnect

### DIFF
--- a/packages/dataclass_utils/_dataclass_from_dict.py
+++ b/packages/dataclass_utils/_dataclass_from_dict.py
@@ -1,5 +1,6 @@
 import inspect
 from inspect import FullArgSpec
+import typing
 from typing import TypeVar, Type, Union
 
 T = TypeVar('T')
@@ -38,5 +39,16 @@ def _get_argument_value(arg_spec: FullArgSpec, index: int, parameters: dict):
 
 def _dataclass_from_dict_recurse(value, requested_type: Type[T]):
     return dataclass_from_dict(requested_type, value) \
-        if isinstance(value, dict) and not issubclass(requested_type, dict) \
+        if isinstance(value, dict) and not (
+            _is_optional_of_dict(requested_type) or
+            issubclass(requested_type, dict)) \
         else value
+
+
+def _is_optional_of_dict(requested_type):
+    # Optional[dict] is an alias for Union[dict, None]
+    if typing.get_origin(requested_type) == Union:
+        args = typing.get_args(requested_type)
+        if len(args) == 2:
+            return issubclass(args[0], dict) and issubclass(args[1], type(None))
+    return False

--- a/packages/dataclass_utils/_dataclass_from_dict_test.py
+++ b/packages/dataclass_utils/_dataclass_from_dict_test.py
@@ -1,4 +1,4 @@
-from typing import Type, TypeVar, Generic
+from typing import Generic, Optional, Type, TypeVar
 
 import pytest
 
@@ -27,6 +27,12 @@ class Base(Generic[T]):
 class Extends(Base[str]):
     def __init__(self, a: str):
         super().__init__(a)
+
+
+class Optionals:
+    def __init__(self, a: str, o: Optional[dict] = None):
+        self.a = a
+        self.o = o
 
 
 def test_from_dict_simple():
@@ -86,3 +92,21 @@ def test_from_dict_fails_on_invalid_properties(type: Type[T], invalid_parameter:
         dataclass_from_dict(type, {"invalid": "dict"})
     assert str(e.value) == "Cannot determine value for parameter " + invalid_parameter + \
            ": not given in {'invalid': 'dict'} and no default value specified"
+
+
+def test_from_dict_wit_optional():
+    # execution
+    actual = dataclass_from_dict(Optionals, {"a": "aValue", "o": {"b": "bValue"}})
+
+    # evaluation
+    assert actual.a == "aValue"
+    assert actual.o == {"b": "bValue"}
+
+
+def test_from_dict_without_optional():
+    # execution
+    actual = dataclass_from_dict(Optionals, {"a": "aValue"})
+
+    # evaluation
+    assert actual.a == "aValue"
+    assert actual.o is None

--- a/packages/modules/conftest.py
+++ b/packages/modules/conftest.py
@@ -13,6 +13,8 @@ sys.modules['lxml'] = type(sys)('lxml')
 sys.modules['lxml.html'] = type(sys)('lxml.html')
 sys.modules['bs4'] = type(sys)('bs4')
 sys.modules['pkce'] = type(sys)('pkce')
+sys.modules['skodaconnect'] = type(sys)('skodaconnect')
+sys.modules['skodaconnect.Connection'] = type(sys)('skodaconnect.Connection')
 
 module = type(sys)('pymodbus.client.sync')
 module.ModbusSerialClient = Mock()

--- a/packages/modules/vehicles/skodaconnect/api.py
+++ b/packages/modules/vehicles/skodaconnect/api.py
@@ -27,8 +27,6 @@ class SkodaConnectApi():
         asyncio.set_event_loop(loop)
 
         soc, range = loop.run_until_complete(self._fetch_soc())
-        log.info(f"Battery level: {soc}")
-        log.info(f"Electric range: {range}")
         return soc, range
 
     async def _fetch_soc(self) -> Union[int, float]:

--- a/packages/modules/vehicles/skodaconnect/api.py
+++ b/packages/modules/vehicles/skodaconnect/api.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
 import logging
-from typing import Union
 import aiohttp
 import asyncio
 import sys
+from typing import Union
+from helpermodules.pub import Pub
 from modules.vehicles.skodaconnect.config import SkodaConnect
 
 log = logging.getLogger("soc."+__name__)
@@ -16,14 +17,29 @@ except ModuleNotFoundError as e:
     sys.exit(1)
 
 
-async def _fetch_soc(conf: SkodaConnect) -> Union[int, float]:
+async def _fetch_soc(conf: SkodaConnect, vehicle: int) -> Union[int, float]:
     async with aiohttp.ClientSession(headers={'Connection': 'keep-alive'}) as session:
         log.warning(f"Initiating new session to Skoda Connect with {conf.configuration.user_id} as username")
-        connection = Connection(session, conf.configuration.user_id, conf.configuration.password)
-        log.warning("Attempting to login to the Skoda Connect service")
-        if await connection.doLogin():
+        login_success = False
+        try:
+            connection = Connection(session, conf.configuration.user_id, conf.configuration.password)
+            if conf.configuration.refreshToken is not None:
+                log.warning("Attempting restore of tokens")
+                if await connection.restore_tokens(conf.configuration.refreshToken):
+                    log.warning("Token restore succeeded")
+                    login_success = True
+
+            if not login_success:
+                print("Attempting to login to the Skoda Connect service")
+                login_success = await connection.doLogin()
+        except Exception:
+            log.exception("Login failed!")
+            return 0, 0.0
+
+        if login_success:
             log.warning('Login success!')
-            log.warning('Fetching vehicles associated with account.')
+            tokens = await connection.save_tokens()
+            log.warning('Fetching charging data.')
             chargingState = await connection.getCharging(conf.configuration.vin)
             batteryState = chargingState.get('battery')
             log.warning(f"Battery level: {batteryState.get('stateOfChargeInPercent')}")
@@ -31,16 +47,37 @@ async def _fetch_soc(conf: SkodaConnect) -> Union[int, float]:
             log.warning(f"Electric range: {batteryState.get('cruisingRangeElectricInMeters')}")
             range = int(batteryState.get('cruisingRangeElectricInMeters'))/1000
 
+            if tokens:
+                _persist_refresh_tokens(conf, vehicle, tokens)
+
             return soc, range
+
+
+def _persist_refresh_tokens(conf, vehicle, tokens):
+    log.warning('Persist refresh tokens.')
+    confDict = conf.__dict__
+    confDict.pop('name')
+    confDict['configuration'] = conf.configuration.__dict__
+    _publish_refresh_tokens(
+                    "openWB/set/vehicle/" + vehicle + "/soc_module/config",
+                    tokens,
+                    conf.__dict__)
+
+
+def _publish_refresh_tokens(topic: str, tokens: str, config={}):
+    try:
+        config['configuration']['refreshToken'] = tokens
+        Pub().pub(topic, config)
+    except Exception as e:
+        log.exception('Token mqtt write exception ' + str(e))
 
 
 def fetch_soc(conf: SkodaConnect, vehicle: int) -> Union[int, float]:
     # prepare and call async method
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    # loop = asyncio.get_event_loop()
 
-    soc, range = loop.run_until_complete(_fetch_soc(conf))
+    soc, range = loop.run_until_complete(_fetch_soc(conf, vehicle))
     log.warning(f"Battery level: {soc}")
     log.warning(f"Electric range: {range}")
     return soc, range

--- a/packages/modules/vehicles/skodaconnect/api.py
+++ b/packages/modules/vehicles/skodaconnect/api.py
@@ -3,7 +3,6 @@
 import aiohttp
 import asyncio
 import logging
-from dataclass_utils import asdict
 from helpermodules.pub import Pub
 from modules.vehicles.skodaconnect.config import SkodaConnect, SkodaConnectConfiguration
 from skodaconnect import Connection
@@ -77,11 +76,9 @@ class SkodaConnectApi():
                 self.password,
                 self.vin,
                 tokens))
-        confDict = asdict(conf)
-        confDict.pop('name')
-        self._publish_refresh_tokens(tokens, confDict)
+        self._publish_refresh_tokens(conf.as_dict())
 
-    def _publish_refresh_tokens(self, tokens: str, config={}) -> None:
+    def _publish_refresh_tokens(self, config={}) -> None:
         try:
             Pub().pub("openWB/set/vehicle/" + self.vehicle + "/soc_module/config", config)
         except Exception as e:

--- a/packages/modules/vehicles/skodaconnect/api.py
+++ b/packages/modules/vehicles/skodaconnect/api.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import logging
+from typing import Union
+import aiohttp
+import asyncio
+import sys
+from modules.vehicles.skodaconnect.config import SkodaConnect
+
+log = logging.getLogger("soc."+__name__)
+
+try:
+    from skodaconnect import Connection
+except ModuleNotFoundError as e:
+    log.exception(f"Unable to import library: {e}", e)
+    sys.exit(1)
+
+
+async def _fetch_soc(conf: SkodaConnect) -> Union[int, float]:
+    async with aiohttp.ClientSession(headers={'Connection': 'keep-alive'}) as session:
+        log.warning(f"Initiating new session to Skoda Connect with {conf.configuration.user_id} as username")
+        connection = Connection(session, conf.configuration.user_id, conf.configuration.password)
+        log.warning("Attempting to login to the Skoda Connect service")
+        if await connection.doLogin():
+            log.warning('Login success!')
+            log.warning('Fetching vehicles associated with account.')
+            chargingState = await connection.getCharging(conf.configuration.vin)
+            batteryState = chargingState.get('battery')
+            log.warning(f"Battery level: {batteryState.get('stateOfChargeInPercent')}")
+            soc = batteryState.get('stateOfChargeInPercent')
+            log.warning(f"Electric range: {batteryState.get('cruisingRangeElectricInMeters')}")
+            range = int(batteryState.get('cruisingRangeElectricInMeters'))/1000
+
+            return soc, range
+
+
+def fetch_soc(conf: SkodaConnect, vehicle: int) -> Union[int, float]:
+    # prepare and call async method
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    # loop = asyncio.get_event_loop()
+
+    soc, range = loop.run_until_complete(_fetch_soc(conf))
+    log.warning(f"Battery level: {soc}")
+    log.warning(f"Electric range: {range}")
+    return soc, range

--- a/packages/modules/vehicles/skodaconnect/api.py
+++ b/packages/modules/vehicles/skodaconnect/api.py
@@ -1,83 +1,88 @@
 #!/usr/bin/env python3
 
-import logging
 import aiohttp
 import asyncio
-import sys
-from typing import Union
+import logging
+from dataclass_utils import asdict
 from helpermodules.pub import Pub
-from modules.vehicles.skodaconnect.config import SkodaConnect
+from modules.vehicles.skodaconnect.config import SkodaConnect, SkodaConnectConfiguration
+from skodaconnect import Connection
+from typing import Union
+
 
 log = logging.getLogger("soc."+__name__)
 
-try:
-    from skodaconnect import Connection
-except ModuleNotFoundError as e:
-    log.exception(f"Unable to import library: {e}", e)
-    sys.exit(1)
 
+class SkodaConnectApi():
 
-async def _fetch_soc(conf: SkodaConnect, vehicle: int) -> Union[int, float]:
-    async with aiohttp.ClientSession(headers={'Connection': 'keep-alive'}) as session:
-        log.warning(f"Initiating new session to Skoda Connect with {conf.configuration.user_id} as username")
-        login_success = False
-        try:
-            connection = Connection(session, conf.configuration.user_id, conf.configuration.password)
-            if conf.configuration.refreshToken is not None:
-                log.warning("Attempting restore of tokens")
-                if await connection.restore_tokens(conf.configuration.refreshToken):
-                    log.warning("Token restore succeeded")
-                    login_success = True
+    def __init__(self, conf: SkodaConnect, vehicle: int) -> None:
+        self.user_id = conf.configuration.user_id
+        self.password = conf.configuration.password
+        self.vin = conf.configuration.vin
+        self.refresh_token = conf.configuration.refresh_token
+        self.vehicle = vehicle
 
-            if not login_success:
-                print("Attempting to login to the Skoda Connect service")
-                login_success = await connection.doLogin()
-        except Exception:
-            log.exception("Login failed!")
+    def fetch_soc(self) -> Union[int, float]:
+        # prepare and call async method
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        soc, range = loop.run_until_complete(self._fetch_soc())
+        log.info(f"Battery level: {soc}")
+        log.info(f"Electric range: {range}")
+        return soc, range
+
+    async def _fetch_soc(self) -> Union[int, float]:
+        async with aiohttp.ClientSession(headers={'Connection': 'keep-alive'}) as session:
+            log.debug(f"Initiating new session to Skoda Connect with {self.user_id} as username")
+            login_success = False
+            try:
+                connection = Connection(session, self.user_id, self.password)
+                if self.refresh_token is not None:
+                    log.debug("Attempting restore of tokens")
+                    if await connection.restore_tokens(self.refresh_token):
+                        log.debug("Token restore succeeded")
+                        login_success = True
+
+                if not login_success:
+                    log.debug("Attempting to login to the Skoda Connect service")
+                    login_success = await connection.doLogin()
+            except Exception:
+                log.exception("Login failed!")
+
+            if login_success:
+                log.debug('Login success!')
+                tokens = await connection.save_tokens()
+                log.debug('Fetching charging data.')
+                chargingState = await connection.getCharging(self.vin)
+                if chargingState:
+                    batteryState = chargingState.get('battery')
+                    soc = batteryState.get('stateOfChargeInPercent')
+                    log.debug(f"Battery level: {soc}")
+                    range = int(batteryState.get('cruisingRangeElectricInMeters'))/1000
+                    log.debug(f"Electric range: {range}")
+                    if tokens:
+                        self._persist_refresh_tokens(tokens)
+                    return soc, range
+                elif self.refresh_token is not None:
+                    # token seems to be invalid
+                    self._persist_refresh_tokens(None)
             return 0, 0.0
 
-        if login_success:
-            log.warning('Login success!')
-            tokens = await connection.save_tokens()
-            log.warning('Fetching charging data.')
-            chargingState = await connection.getCharging(conf.configuration.vin)
-            batteryState = chargingState.get('battery')
-            log.warning(f"Battery level: {batteryState.get('stateOfChargeInPercent')}")
-            soc = batteryState.get('stateOfChargeInPercent')
-            log.warning(f"Electric range: {batteryState.get('cruisingRangeElectricInMeters')}")
-            range = int(batteryState.get('cruisingRangeElectricInMeters'))/1000
+    def _persist_refresh_tokens(self, tokens: dict) -> None:
+        log.debug('Persist refresh tokens.')
+        conf = SkodaConnect(
+            configuration=SkodaConnectConfiguration(
+                self.user_id,
+                self.password,
+                self.vin,
+                tokens))
+        confDict = asdict(conf)
+        confDict.pop('name')
+        self._publish_refresh_tokens(tokens, confDict)
 
-            if tokens:
-                _persist_refresh_tokens(conf, vehicle, tokens)
-
-            return soc, range
-
-
-def _persist_refresh_tokens(conf, vehicle, tokens):
-    log.warning('Persist refresh tokens.')
-    confDict = conf.__dict__
-    confDict.pop('name')
-    confDict['configuration'] = conf.configuration.__dict__
-    _publish_refresh_tokens(
-                    "openWB/set/vehicle/" + vehicle + "/soc_module/config",
-                    tokens,
-                    conf.__dict__)
-
-
-def _publish_refresh_tokens(topic: str, tokens: str, config={}):
-    try:
-        config['configuration']['refreshToken'] = tokens
-        Pub().pub(topic, config)
-    except Exception as e:
-        log.exception('Token mqtt write exception ' + str(e))
-
-
-def fetch_soc(conf: SkodaConnect, vehicle: int) -> Union[int, float]:
-    # prepare and call async method
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
-    soc, range = loop.run_until_complete(_fetch_soc(conf, vehicle))
-    log.warning(f"Battery level: {soc}")
-    log.warning(f"Electric range: {range}")
-    return soc, range
+    def _publish_refresh_tokens(self, tokens: str, config={}) -> None:
+        try:
+            Pub().pub("openWB/set/vehicle/" + self.vehicle + "/soc_module/config", config)
+        except Exception as e:
+            log.exception('Token mqtt write exception ' + str(e))

--- a/packages/modules/vehicles/skodaconnect/api.py
+++ b/packages/modules/vehicles/skodaconnect/api.py
@@ -3,6 +3,7 @@
 import aiohttp
 import asyncio
 import logging
+from dataclass_utils import asdict
 from helpermodules.pub import Pub
 from modules.vehicles.skodaconnect.config import SkodaConnect, SkodaConnectConfiguration
 from skodaconnect import Connection
@@ -79,7 +80,7 @@ class SkodaConnectApi():
                 self.password,
                 self.vin,
                 tokens))
-        self._publish_refresh_tokens(conf.as_dict())
+        self._publish_refresh_tokens(asdict(conf))
 
     def _publish_refresh_tokens(self, config={}) -> None:
         try:

--- a/packages/modules/vehicles/skodaconnect/config.py
+++ b/packages/modules/vehicles/skodaconnect/config.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from dataclass_utils import asdict
 
 
 class SkodaConnectConfiguration:
@@ -22,3 +23,8 @@ class SkodaConnect:
         self.name = name
         self.type = type
         self.configuration = configuration or SkodaConnectConfiguration()
+
+    def as_dict(self) -> dict:
+        confDict = asdict(self)
+        confDict.pop('name')
+        return confDict

--- a/packages/modules/vehicles/skodaconnect/config.py
+++ b/packages/modules/vehicles/skodaconnect/config.py
@@ -2,10 +2,16 @@ from typing import Optional
 
 
 class SkodaConnectConfiguration:
-    def __init__(self, user_id: Optional[str] = None, password: Optional[str] = None, vin: Optional[str] = None):
+    def __init__(self,
+                 user_id: Optional[str] = None,        # show in UI
+                 password: Optional[str] = None,       # show in UI
+                 vin: Optional[str] = None,            # show in UI
+                 refreshToken: Optional[dict] = None   # DON'T show in UI!
+                 ):
         self.user_id = user_id
         self.password = password
         self.vin = vin
+        self.refreshToken = refreshToken
 
 
 class SkodaConnect:

--- a/packages/modules/vehicles/skodaconnect/config.py
+++ b/packages/modules/vehicles/skodaconnect/config.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+
+class SkodaConnectConfiguration:
+    def __init__(self, user_id: Optional[str] = None, password: Optional[str] = None, vin: Optional[str] = None):
+        self.user_id = user_id
+        self.password = password
+        self.vin = vin
+
+
+class SkodaConnect:
+    def __init__(self,
+                 name: str = "SkodaConnect",
+                 type: str = "skodaconnect",
+                 configuration: SkodaConnectConfiguration = None) -> None:
+        self.name = name
+        self.type = type
+        self.configuration = configuration or SkodaConnectConfiguration()

--- a/packages/modules/vehicles/skodaconnect/config.py
+++ b/packages/modules/vehicles/skodaconnect/config.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from dataclass_utils import asdict
 
 
 class SkodaConnectConfiguration:
@@ -23,7 +22,3 @@ class SkodaConnect:
         self.name = name
         self.type = type
         self.configuration = configuration or SkodaConnectConfiguration()
-
-    def as_dict(self) -> dict:
-        confDict = asdict(self)
-        return confDict

--- a/packages/modules/vehicles/skodaconnect/config.py
+++ b/packages/modules/vehicles/skodaconnect/config.py
@@ -26,5 +26,4 @@ class SkodaConnect:
 
     def as_dict(self) -> dict:
         confDict = asdict(self)
-        confDict.pop('name')
         return confDict

--- a/packages/modules/vehicles/skodaconnect/config.py
+++ b/packages/modules/vehicles/skodaconnect/config.py
@@ -6,12 +6,12 @@ class SkodaConnectConfiguration:
                  user_id: Optional[str] = None,        # show in UI
                  password: Optional[str] = None,       # show in UI
                  vin: Optional[str] = None,            # show in UI
-                 refreshToken: Optional[dict] = None   # DON'T show in UI!
+                 refresh_token: Optional[dict] = None   # DON'T show in UI!
                  ):
         self.user_id = user_id
         self.password = password
         self.vin = vin
-        self.refreshToken = refreshToken
+        self.refresh_token = refresh_token
 
 
 class SkodaConnect:

--- a/packages/modules/vehicles/skodaconnect/soc.py
+++ b/packages/modules/vehicles/skodaconnect/soc.py
@@ -36,10 +36,10 @@ class Soc(AbstractSoc):
                 log.error("Result not stored: soc=" + str(soc)+", range=" + str(range))
 
 
-def skodaconnect_update(user_id: str, password: str, vin: str, charge_point: int):
+def skodaconnect_update(user_id: str, password: str, vin: str, refreshToken: str, charge_point: int):
     log.debug("skodaconnect: userid="+user_id+"vin="+vin+"charge_point="+str(charge_point))
     Soc(
-        SkodaConnect(configuration=SkodaConnectConfiguration(user_id, password, vin)),
+        SkodaConnect(configuration=SkodaConnectConfiguration(user_id, password, vin, refreshToken)),
         charge_point).update(False)
 
 

--- a/packages/modules/vehicles/skodaconnect/soc.py
+++ b/packages/modules/vehicles/skodaconnect/soc.py
@@ -8,7 +8,6 @@ from modules.common import store
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.abstract_soc import AbstractSoc
 from modules.common.component_context import SingleComponentUpdateContext
-from modules.common.component_state import CarState
 from modules.common.fault_state import ComponentInfo
 from modules.vehicles.skodaconnect.api import SkodaConnectApi
 from modules.vehicles.skodaconnect.config import SkodaConnect, SkodaConnectConfiguration

--- a/packages/modules/vehicles/skodaconnect/soc.py
+++ b/packages/modules/vehicles/skodaconnect/soc.py
@@ -10,7 +10,7 @@ from modules.common.abstract_soc import AbstractSoc
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import CarState
 from modules.common.fault_state import ComponentInfo
-from modules.vehicles.skodaconnect import api
+from modules.vehicles.skodaconnect.api import SkodaConnectApi
 from modules.vehicles.skodaconnect.config import SkodaConnect, SkodaConnectConfiguration
 
 
@@ -26,9 +26,7 @@ class Soc(AbstractSoc):
 
     def update(self, charge_state: bool = False) -> None:
         with SingleComponentUpdateContext(self.component_info):
-            soc, range = api.fetch_soc(
-                self.config,
-                self.vehicle)
+            soc, range = SkodaConnectApi(self.config, self.vehicle).fetch_soc()
             log.info("Result: soc=" + str(soc)+", range=" + str(range))
             if soc > 0 and range > 0.0:
                 self.store.set(CarState(soc, range))
@@ -36,11 +34,11 @@ class Soc(AbstractSoc):
                 log.error("Result not stored: soc=" + str(soc)+", range=" + str(range))
 
 
-def skodaconnect_update(user_id: str, password: str, vin: str, refreshToken: str, charge_point: int):
+def skodaconnect_update(user_id: str, password: str, vin: str, refresh_token: str, charge_point: int):
     log.debug("skodaconnect: userid="+user_id+"vin="+vin+"charge_point="+str(charge_point))
     Soc(
-        SkodaConnect(configuration=SkodaConnectConfiguration(user_id, password, vin, refreshToken)),
-        charge_point).update(False)
+        SkodaConnect(configuration=SkodaConnectConfiguration(user_id, password, vin, refresh_token)),
+        charge_point).update()
 
 
 def main(argv: List[str]):

--- a/packages/modules/vehicles/skodaconnect/soc.py
+++ b/packages/modules/vehicles/skodaconnect/soc.py
@@ -27,11 +27,6 @@ class Soc(AbstractSoc):
     def update(self, charge_state: bool = False) -> None:
         with SingleComponentUpdateContext(self.component_info):
             soc, range = SkodaConnectApi(self.config, self.vehicle).fetch_soc()
-            log.info("Result: soc=" + str(soc)+", range=" + str(range))
-            if soc > 0 and range > 0.0:
-                self.store.set(CarState(soc, range))
-            else:
-                log.error("Result not stored: soc=" + str(soc)+", range=" + str(range))
 
 
 def skodaconnect_update(user_id: str, password: str, vin: str, refresh_token: str, charge_point: int):

--- a/packages/modules/vehicles/skodaconnect/soc.py
+++ b/packages/modules/vehicles/skodaconnect/soc.py
@@ -1,0 +1,50 @@
+from typing import Union, List
+
+import logging
+
+from dataclass_utils import dataclass_from_dict
+from helpermodules.cli import run_using_positional_cli_args
+from modules.common import store
+from modules.common.abstract_device import DeviceDescriptor
+from modules.common.abstract_soc import AbstractSoc
+from modules.common.component_context import SingleComponentUpdateContext
+from modules.common.component_state import CarState
+from modules.common.fault_state import ComponentInfo
+from modules.vehicles.skodaconnect import api
+from modules.vehicles.skodaconnect.config import SkodaConnect, SkodaConnectConfiguration
+
+
+log = logging.getLogger("soc."+__name__)
+
+
+class Soc(AbstractSoc):
+    def __init__(self, device_config: Union[dict, SkodaConnect], vehicle: int):
+        self.config = dataclass_from_dict(SkodaConnect, device_config)
+        self.vehicle = vehicle
+        self.store = store.get_car_value_store(self.vehicle)
+        self.component_info = ComponentInfo(self.vehicle, self.config.name, "vehicle")
+
+    def update(self, charge_state: bool = False) -> None:
+        with SingleComponentUpdateContext(self.component_info):
+            soc, range = api.fetch_soc(
+                self.config,
+                self.vehicle)
+            log.info("Result: soc=" + str(soc)+", range=" + str(range))
+            if soc > 0 and range > 0.0:
+                self.store.set(CarState(soc, range))
+            else:
+                log.error("Result not stored: soc=" + str(soc)+", range=" + str(range))
+
+
+def skodaconnect_update(user_id: str, password: str, vin: str, charge_point: int):
+    log.debug("skodaconnect: userid="+user_id+"vin="+vin+"charge_point="+str(charge_point))
+    Soc(
+        SkodaConnect(configuration=SkodaConnectConfiguration(user_id, password, vin)),
+        charge_point).update(False)
+
+
+def main(argv: List[str]):
+    run_using_positional_cli_args(skodaconnect_update, argv)
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=SkodaConnect)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ PyJWT==2.6.0
 ipparser==0.3.8
 bs4==0.0.1
 pkce==1.0.3
-skodaconnect==1.3.0
+skodaconnect==1.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ PyJWT==2.6.0
 ipparser==0.3.8
 bs4==0.0.1
 pkce==1.0.3
+skodaconnect==1.3.0


### PR DESCRIPTION
Das SOC Modul nutzt die Bibliothek [Skoda Connect](https://github.com/lendy007/skodaconnect).
Getestet habe ich mir meinem Skoda Enyaq, aber auch andere BEVs des Hersteller werden durch die Bibliothek unterstützt.

Im Dataclass_util wurde das Handling für Optional[dict] ergänzt, um in der SOC Modulkonfiguration optionale dict-Parameter zu ermöglichen.