### PR TITLE
ev-soc: add optional field ev_timestamp

### DIFF
--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -368,6 +368,8 @@ class SetData:
                 self._validate_value(msg, float, [(0, 100)])
             elif "/get/range" in msg.topic:
                 self._validate_value(msg, float, [(0, 1000)])
+            elif "/get/ev_timestamp" in msg.topic:
+                self._validate_value(msg, str)
             elif "/get/force_soc_update" in msg.topic:
                 self._validate_value(msg, bool)
             elif "/control_parameter/required_current" in msg.topic:
@@ -564,10 +566,10 @@ class SetData:
                 elif "/get/exported" in msg.topic:
                     self._validate_value(msg, float, [(0, float("inf"))])
                 elif "/get/power" in msg.topic:
-                    self._validate_value(msg, float)
+                    self._validate_value(msg, float, [(float("-inf"), 0)])
                 elif "/get/currents" in msg.topic:
                     self._validate_value(
-                        msg, float, collection=list)
+                        msg, float, [(float("-inf"), 0)], collection=list)
                 else:
                     self.__unknown_topic(msg)
             else:

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -97,14 +97,17 @@ class InverterState:
 
 @auto_str
 class CarState:
-    def __init__(self, soc: float, range: Optional[float] = None, soc_timestamp: str = ""):
+    def __init__(self, soc: float, range: Optional[float] = None,
+                 ev_timestamp: Optional[str] = "", soc_timestamp: str = ""):
         """Args:
             soc: actual state of charge in percent
             range: actual range in km
             soc_timestamp: timestamp of last request in %m/%d/%Y, %H:%M:%S
+            ev_timestamp: timestamp of last update from ev to server as str
         """
         self.soc = soc
         self.range = range
+        self.ev_timestamp = ev_timestamp
         self.soc_timestamp = soc_timestamp
 
 

--- a/packages/modules/common/store/_car.py
+++ b/packages/modules/common/store/_car.py
@@ -27,6 +27,8 @@ class CarValueStoreBroker(ValueStore[CarState]):
             pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/soc", self.state.soc)
             if self.state.range:
                 pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/range", self.state.range)
+            if self.state.ev_timestamp:
+                pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/ev_timestamp", self.state.ev_timestamp)
         except Exception as e:
             raise FaultState.from_exception(e)
 


### PR DESCRIPTION
add new optional str attribute ev_timestamp to CarState
ev_timestamp shall contain timestamp when soc was reported from EV to car manufacturer server.
This is valuable information when looking into EV soc issues.
Currently ev_timestamp is stored in vehicle structure along with soc, range, soc_timestamp.
Once it is in MQTT it could be displayed in Status/EV if defined.
