### PR TITLE
Soc in case of error

### DIFF
--- a/packages/control/chargepoint.py
+++ b/packages/control/chargepoint.py
@@ -813,6 +813,7 @@ class Chargepoint:
             # SoC nach Anstecken aktualisieren
             if self.data.get.plug_state is True and self.data.set.plug_state_prev is False:
                 Pub().pub(f"openWB/set/vehicle/{self.data.config.ev}/get/force_soc_update", True)
+                log.debug("SoC nach Anstecken")
             vehicle, message = self.prepare_cp()
             if vehicle != -1:
                 try:
@@ -916,6 +917,8 @@ class Chargepoint:
                 charging_ev.data.set.ev_template = charging_ev.ev_template
                 Pub().pub("openWB/set/vehicle/"+str(charging_ev.num) +
                           "/set/ev_template", asdict(charging_ev.data.set.ev_template.data))
+                Pub().pub(f"openWB/set/vehicle/{charging_ev.num}/get/force_soc_update", True)
+                log.debug("SoC nach EV-Wechsel")
             else:
                 # Altes EV beibehalten.
                 if self.data.set.charging_ev != -1:

--- a/packages/control/ev_test.py
+++ b/packages/control/ev_test.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from control.ev import EvTemplate
+from control.ev import Ev
 from helpermodules import timecheck
 
 
@@ -20,12 +20,13 @@ def test_soc_interval_expired(check_timestamp: bool,
                               expected_request_soc: bool,
                               monkeypatch):
     # setup
-    et = EvTemplate()
+    ev = Ev(0)
+    ev.data.get.soc_timestamp = soc_timestamp
     check_timestamp_mock = Mock(return_value=check_timestamp)
     monkeypatch.setattr(timecheck, "check_timestamp", check_timestamp_mock)
 
     # execution
-    request_soc = et.soc_interval_expired(charge_state, soc_timestamp)
+    request_soc = ev.soc_interval_expired(charge_state)
 
     # evaluation
     assert request_soc == expected_request_soc

--- a/packages/helpermodules/graph.py
+++ b/packages/helpermodules/graph.py
@@ -54,8 +54,7 @@ class Graph:
                     dataline.update({f"cp{cp.num}-power": _convert_to_kW(cp.data.get.power)})
             for ev in data.data.ev_data.values():
                 if ev.soc_module:
-                    if ev.data.get.fault_state < FaultStateLevel.ERROR:
-                        dataline.update({f"ev{ev.num}-soc": ev.data.get.soc})
+                    dataline.update({f"ev{ev.num}-soc": ev.data.get.soc})
             if data.data.bat_all_data.data.config.configured:
                 dataline.update({"bat-all-power": _convert_to_kW(data.data.bat_all_data.data.get.power)})
                 dataline.update({"bat-all-soc": data.data.bat_all_data.data.get.soc})

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -349,6 +349,8 @@ class SetData:
                 self._subprocess_vehicle_chargemode_topic(msg)
             elif "openWB/set/vehicle/set/vehicle_update_completed" in msg.topic:
                 self._validate_value(msg, bool)
+            elif "/set/soc_error_counter" in msg.topic:
+                self._validate_value(msg, int, [(0, float("inf"))])
             elif "/soc_module/config" in msg.topic:
                 self._validate_value(msg, "json")
             elif "/get/fault_state" in msg.topic:

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -220,6 +220,7 @@ class UpdateConfig:
                    "^openWB/vehicle/[0-9]+/control_parameter/used_amount_instant_charging$",
                    "^openWB/vehicle/[0-9]+/control_parameter/phases$",
                    "^openWB/vehicle/[0-9]+/set/ev_template$",
+                   "^openWB/vehicle/[0-9]+/set/soc_error_counter$",
 
                    "^openWB/system/boot_done$",
                    "^openWB/system/dataprotection_acknowledged$",

--- a/packages/modules/common/store/_car.py
+++ b/packages/modules/common/store/_car.py
@@ -24,9 +24,9 @@ class CarValueStoreBroker(ValueStore[CarState]):
 
     def update(self):
         try:
-            pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/soc", self.state.soc)
+            pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/soc", self.state.soc, 2)
             if self.state.range:
-                pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/range", self.state.range)
+                pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/range", self.state.range, 2)
         except Exception as e:
             raise FaultState.from_exception(e)
 

--- a/packages/modules/update_soc.py
+++ b/packages/modules/update_soc.py
@@ -50,7 +50,7 @@ class UpdateSoc:
                         else:
                             ev.data.set.soc_error_counter = 0
                         Pub().pub(f"openWB/set/vehicle/{ev.num}/set/soc_error_counter", ev.data.set.soc_error_counter)
-                        if ev.data.set.soc_error_counter > 3:
+                        if ev.data.set.soc_error_counter >= 3:
                             log.debug(
                                 f"EV{ev.num}: Nach dreimaliger erfolgloser SoC-Abfrage wird ein SoC von 0% angenommen.")
                             Pub().pub(f"openWB/set/vehicle/{ev.num}/get/soc", 0)

--- a/packages/modules/update_soc.py
+++ b/packages/modules/update_soc.py
@@ -30,7 +30,7 @@ class UpdateSoc:
                 threads_update, threads_store = self._get_threads()
                 thread_handler(threads_update)
             with ModuleUpdateCompletedContext(self.event_vehicle_update_completed, topic):
-                threads_store = self._filter_failed_store_threads(threads_store)
+                # threads_store = self._filter_failed_store_threads(threads_store)
                 thread_handler(threads_store)
         except Exception:
             log.exception("Fehler im update_soc-Modul")

--- a/packages/modules/update_soc.py
+++ b/packages/modules/update_soc.py
@@ -30,9 +30,8 @@ class UpdateSoc:
                 threads_update, threads_store = self._get_threads()
                 thread_handler(threads_update)
             with ModuleUpdateCompletedContext(self.event_vehicle_update_completed, topic):
-                threads_store, threads_failed = self._filter_failed_store_threads(threads_store)
+                threads_store = self._filter_failed_store_threads(threads_store)
                 thread_handler(threads_store)
-                self._reset_failed_soc_request(threads_failed)
         except Exception:
             log.exception("Fehler im update_soc-Modul")
 
@@ -44,9 +43,18 @@ class UpdateSoc:
             try:
                 if ev.soc_module is not None:
                     soc_update_data = self._get_soc_update_data(ev.num)
-                    if (ev.ev_template.soc_interval_expired(soc_update_data.charge_state, ev.data.get.soc_timestamp) or
-                            ev.data.get.force_soc_update):
+                    if (ev.soc_interval_expired(soc_update_data.charge_state) or ev.data.get.force_soc_update):
                         self._reset_force_soc_update(ev)
+                        if ev.data.get.fault_state == 2:
+                            ev.data.set.soc_error_counter += 1
+                        else:
+                            ev.data.set.soc_error_counter = 0
+                        Pub().pub(f"openWB/set/vehicle/{ev.num}/set/soc_error_counter", ev.data.set.soc_error_counter)
+                        if ev.data.set.soc_error_counter > 3:
+                            log.debug(
+                                f"EV{ev.num}: Nach dreimaliger erfolgloser SoC-Abfrage wird ein SoC von 0% angenommen.")
+                            Pub().pub(f"openWB/set/vehicle/{ev.num}/get/soc", 0)
+                            Pub().pub(f"openWB/set/vehicle/{ev.num}/get/range", 0)
                         # Es wird ein Zeitstempel gesetzt, unabhängig ob die Abfrage erfolgreich war, da einige
                         # Hersteller bei zu häufigen Abfragen Accounts sperren.
                         Pub().pub(f"openWB/set/vehicle/{ev.num}/get/soc_timestamp", timecheck.create_timestamp())
@@ -74,9 +82,8 @@ class UpdateSoc:
             charge_state = False
         return SocUpdateData(charge_state=charge_state)
 
-    def _filter_failed_store_threads(self, threads_store: List[Thread]) -> Tuple[List[Thread], List[Thread]]:
+    def _filter_failed_store_threads(self, threads_store: List[Thread]) -> List[Thread]:
         ev_data = copy.deepcopy(subdata.SubData.ev_data)
-        threads_failed = []
         # Alle Autos durchgehen, deren SoC gerade aktualisiert wurde
         for ev_thread in threads_store:
             try:
@@ -84,20 +91,7 @@ class UpdateSoc:
                 if ev.soc_module is not None:
                     if hasattr(ev.soc_module, "store"):
                         if ev.data.get.fault_state == 2:
-                            threads_failed.append(ev_thread)
                             threads_store.remove(ev_thread)
             except Exception:
                 log.exception("Fehler im update_soc-Modul")
-        return threads_store, threads_failed
-
-    def _reset_failed_soc_request(self, threads_failed: List[Thread]) -> None:
-        ev_data = copy.deepcopy(subdata.SubData.ev_data)
-        # Alle Autos durchgehen, deren SoC gerade aktualisiert wurde
-        for ev_thread in threads_failed:
-            try:
-                ev = ev_data[f"ev{ev_thread.getName()[6:]}"]
-                log.debug(f"Zurücksetzen des SoC für EV{ev.num}, da ein Fehler vorliegt.")
-                Pub().pub(f"openWB/set/vehicle/{ev.num}/get/soc", 0)
-                Pub().pub(f"openWB/set/vehicle/{ev.num}/get/range", 0)
-            except Exception:
-                log.exception("Fehler im update_soc-Modul")
+        return threads_store

--- a/packages/modules/update_soc_test.py
+++ b/packages/modules/update_soc_test.py
@@ -5,7 +5,7 @@ import pytest
 
 from control import data
 from control.chargepoint import Chargepoint, Get, Set
-from control.ev import Ev, EvTemplate
+from control.ev import Ev
 from modules.common.abstract_soc import SocUpdateData
 from modules.vehicles.tesla.soc import Soc
 from modules.update_soc import UpdateSoc
@@ -63,7 +63,7 @@ def test_get_threads(soc_module: Optional[Soc],
     ev.data.get.force_soc_update = force_soc_update
     data.data.ev_data["ev0"] = ev
     soc_interval_expired_mock = Mock(return_value=soc_interval_expired)
-    monkeypatch.setattr(EvTemplate, "soc_interval_expired", soc_interval_expired_mock)
+    monkeypatch.setattr(Ev, "soc_interval_expired", soc_interval_expired_mock)
     get_soc_update_data_mock = Mock(return_value=SocUpdateData())
     monkeypatch.setattr(UpdateSoc, "_get_soc_update_data", get_soc_update_data_mock)
     monkeypatch.setattr(UpdateSoc, "_reset_force_soc_update", Mock())


### PR DESCRIPTION
- Verbesserung SoC-Abfrage nach Anstecken
- Fehlerzähler: bei einer fehlgeschlagenen Abfrage wird noch dreimal alle 5 Min der SoC abgefragt, wenn es nicht klappt auf 0% gesetzt und im regulären Intervall erneut versucht
[https://openwb.de/forum/viewtopic.php?p=80076#p80076](https://openwb.de/forum/viewtopic.php?p=80076#p80076)