### PR TITLE
fix check min max current

### DIFF
--- a/packages/control/algorithm/algorithm.py
+++ b/packages/control/algorithm/algorithm.py
@@ -79,7 +79,7 @@ class Algorithm:
                             cp.data.get.state_str = message
                         # Nachdem im Automatikmodus die Anzahl Phasen bekannt ist, Einhaltung des Maximalstroms
                         # prüfen.
-                        required_current = charging_ev.check_min_max_current(current, control_parameter.phases)
+                        required_current = cp.check_min_max_current(current, control_parameter.phases)
                         charging_ev.data.control_parameter.required_current = required_current
                         Pub().pub("openWB/set/vehicle/"+str(charging_ev.num) +
                                   "/control_parameter/required_current", required_current)

--- a/packages/control/chargepoint_test.py
+++ b/packages/control/chargepoint_test.py
@@ -1,7 +1,9 @@
 from typing import List
+from unittest.mock import Mock
 import pytest
 
-from control.chargepoint import Chargepoint
+from control.chargepoint import Chargepoint, CpTemplate
+from control.ev import Ev
 
 
 @pytest.mark.parametrize("phase_1, phases, expected_required_currents",
@@ -23,3 +25,26 @@ def test_get_raw_currents_left_min_current(phase_1: int, phases: int, expected_r
 
     # assertion
     assert cp.data.set.charging_ev_data.data.control_parameter.required_currents == expected_required_currents
+
+
+@pytest.mark.parametrize("required_current, phases, expected_required_current",
+                         [
+                             pytest.param(12, 1, 12, id="1-phasig, keine Überschreitung"),
+                             pytest.param(17, 1, 16, id="1-phasig, Überschreitung des Maximalstroms"),
+                             pytest.param(12, 3, 12, id="3-phasig, keine Überschreitung"),
+                             pytest.param(21, 3, 20, id="1-phasig, Überschreitung des Maximalstroms"),
+                             pytest.param(21, 2, 20, id="2-phasig, Überschreitung des Maximalstroms"),
+                         ])
+def test_check_min_max_current(required_current, phases, expected_required_current, monkeypatch):
+    # setup
+    cp = Chargepoint(0, None)
+    cp.template = CpTemplate()
+    cp.template.data.max_current_multi_phases = 20
+    cp.template.data.max_current_single_phase = 16
+    mock_ev_check_min_max_current = Mock(return_value=[required_current, None])
+    monkeypatch.setattr(Ev, "check_min_max_current", mock_ev_check_min_max_current)
+    # evaluation
+    ret = cp.check_min_max_current(required_current, phases)
+
+    # assertion
+    assert ret == expected_required_current

--- a/packages/control/process.py
+++ b/packages/control/process.py
@@ -77,7 +77,7 @@ class Process:
         current = round(chargepoint.data.set.current, 2)
         # Zur Sicherheit - nach dem der Algorithmus abgeschlossen ist - nochmal die Einhaltung der Stromstärken
         # prüfen.
-        current = charging_ev.check_min_max_current(current, charging_ev.data.control_parameter.phases)
+        current = chargepoint.check_min_max_current(current, charging_ev.data.control_parameter.phases)
 
         # Wenn bei einem EV, das keine Umschaltung verträgt, vor dem ersten Laden noch umgeschaltet wird, darf kein
         # Strom gesetzt werden.


### PR DESCRIPTION
- bei der Prüfung des minimal/maximal zulässigen Stroms wird auch der Maximalstrom des Ladepunkts berücksichtigt
- Ausgabe auf der Hauptseite, wenn Begrenzung erreicht wird