### PR TITLE
fix phase switch in combination with storage

### DIFF
--- a/packages/control/algorithm/algorithm.py
+++ b/packages/control/algorithm/algorithm.py
@@ -33,7 +33,7 @@ class Algorithm:
             log.info("**Sollstrom setzen**")
             common.reset_current_to_target_current()
             self.additional_current.set_additional_current([0, 8])
-            counter.limit_raw_power_left_to_surplus(self.evu_counter.calc_surplus())
+            counter.limit_raw_power_left_to_surplus(self.evu_counter.calc_raw_surplus())
             self.surplus_controlled.check_switch_on()
             if self.evu_counter.data.set.surplus_power_left > 0:
                 log.info("**PV-geführten Strom setzen**")

--- a/packages/control/algorithm/surplus_controlled.py
+++ b/packages/control/algorithm/surplus_controlled.py
@@ -121,7 +121,7 @@ class SurplusControlled:
                     if (cp.data.set.charging_ev_data.ev_template.data.prevent_charge_stop is False and
                             phase_switch_neccessary() is False):
                         threshold = evu_counter.calc_switch_off_threshold(cp)[0]
-                        if evu_counter.calc_surplus() - cp.data.set.required_power < threshold:
+                        if evu_counter.calc_raw_surplus() - cp.data.set.required_power < threshold:
                             control_parameter.required_currents = [0]*3
                 else:
                     control_parameter.required_currents = [0]*3

--- a/packages/control/auto_phase_switch_test.py
+++ b/packages/control/auto_phase_switch_test.py
@@ -2,7 +2,7 @@ import threading
 import pytest
 from typing import List, Optional
 from unittest.mock import Mock
-from control.counter import Counter, CounterData, Get, Set
+from control.counter import Counter, CounterData, Set
 
 from control.pv_all import PvAll
 from control.bat_all import BatAll
@@ -33,7 +33,7 @@ class Params:
                  timestamp_auto_phase_switch: Optional[str],
                  phases_to_use: int,
                  required_current: float,
-                 evu_get_power: int,
+                 evu_surplus: int,
                  reserved_evu_overhang: int,
                  get_currents: List[float],
                  get_power: float,
@@ -48,7 +48,7 @@ class Params:
         self.timestamp_auto_phase_switch = timestamp_auto_phase_switch
         self.phases_to_use = phases_to_use
         self.required_current = required_current
-        self.available_power = evu_get_power
+        self.available_power = evu_surplus
         self.reserved_evu_overhang = reserved_evu_overhang
         self.get_currents = get_currents
         self.get_power = get_power
@@ -62,37 +62,37 @@ class Params:
 
 cases = [
     Params("1to3, enough power, start timer", max_current_single_phase=16, timestamp_auto_phase_switch=None,
-           phases_to_use=1, required_current=6, evu_get_power=-800, reserved_evu_overhang=0, get_currents=[15.6, 0, 0],
+           phases_to_use=1, required_current=6, evu_surplus=800, reserved_evu_overhang=0, get_currents=[15.6, 0, 0],
            get_power=3450, state=ChargepointState.CHARGING_ALLOWED, expected_phases_to_use=1, expected_current=6,
            expected_message="Umschaltverzögerung von 1 auf 3 Phasen für 7.0 Min aktiv.",
            expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52",
            expected_state=ChargepointState.PHASE_SWITCH_DELAY),
     Params("1to3, not enough power, start timer", max_current_single_phase=16, timestamp_auto_phase_switch=None,
-           phases_to_use=1, required_current=6, evu_get_power=-300, reserved_evu_overhang=0, get_currents=[15.6, 0, 0],
+           phases_to_use=1, required_current=6, evu_surplus=300, reserved_evu_overhang=0, get_currents=[15.6, 0, 0],
            get_power=3450, state=ChargepointState.CHARGING_ALLOWED, expected_phases_to_use=1, expected_current=6,
            expected_state=ChargepointState.CHARGING_ALLOWED),
     Params("1to3, enough power, timer not expired", max_current_single_phase=16,
            timestamp_auto_phase_switch="05/16/2022, 08:35:52", phases_to_use=1, required_current=6,
-           evu_get_power=-1200, reserved_evu_overhang=460, get_currents=[15.6, 0, 0], get_power=3450,
+           evu_surplus=1200, reserved_evu_overhang=460, get_currents=[15.6, 0, 0], get_power=3450,
            state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=1, expected_current=6,
            expected_message="Umschaltverzögerung von 1 auf 3 Phasen für 7.0 Min aktiv.",
            expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52",
            expected_state=ChargepointState.PHASE_SWITCH_DELAY),
     Params("1to3, not enough power, timer not expired", max_current_single_phase=16,
            timestamp_auto_phase_switch="05/16/2022, 08:35:52", phases_to_use=1, required_current=6,
-           evu_get_power=500, reserved_evu_overhang=460, get_currents=[15.6, 0, 0], get_power=3450,
+           evu_surplus=0, reserved_evu_overhang=460, get_currents=[15.6, 0, 0], get_power=3450,
            state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=1, expected_current=6,
            expected_message="Umschaltverzögerung von 1 auf 3 Phasen abgebrochen.",
            expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52",
            expected_state=ChargepointState.CHARGING_ALLOWED),
     Params("1to3, enough power, timer expired", max_current_single_phase=16,
            timestamp_auto_phase_switch="05/16/2022, 08:32:52", phases_to_use=1, required_current=6,
-           evu_get_power=-1200, reserved_evu_overhang=460, get_currents=[15.6, 0, 0], get_power=3450,
+           evu_surplus=1200, reserved_evu_overhang=460, get_currents=[15.6, 0, 0], get_power=3450,
            state=ChargepointState.PHASE_SWITCH_DELAY,
            expected_phases_to_use=3, expected_current=6, expected_state=ChargepointState.PHASE_SWITCH_DELAY_EXPIRED),
 
     Params("3to1, not enough power, start timer", max_current_single_phase=16, timestamp_auto_phase_switch=None,
-           phases_to_use=3, required_current=6, evu_get_power=100, reserved_evu_overhang=0,
+           phases_to_use=3, required_current=6, evu_surplus=0, reserved_evu_overhang=0,
            get_currents=[4.5, 4.4, 5.8], get_power=3381, state=ChargepointState.CHARGING_ALLOWED,
            expected_phases_to_use=3, expected_current=6,
            expected_message="Umschaltverzögerung von 3 auf 1 Phasen für 9.0 Min aktiv.",
@@ -100,7 +100,7 @@ cases = [
            expected_state=ChargepointState.PHASE_SWITCH_DELAY),
     Params("3to1, not enough power, timer not expired", max_current_single_phase=16,
            timestamp_auto_phase_switch="05/16/2022, 08:35:52",
-           phases_to_use=3, required_current=6, evu_get_power=100, reserved_evu_overhang=-460,
+           phases_to_use=3, required_current=6, evu_surplus=0, reserved_evu_overhang=-460,
            get_currents=[4.5, 4.4, 5.8], get_power=3381, state=ChargepointState.PHASE_SWITCH_DELAY,
            expected_phases_to_use=3, expected_current=6,
            expected_message="Umschaltverzögerung von 3 auf 1 Phasen für 9.0 Min aktiv.",
@@ -108,14 +108,14 @@ cases = [
            expected_state=ChargepointState.PHASE_SWITCH_DELAY),
     Params("3to1, enough power, timer not expired", max_current_single_phase=16,
            timestamp_auto_phase_switch="05/16/2022, 08:35:52", phases_to_use=3, required_current=6,
-           evu_get_power=-860, reserved_evu_overhang=0, get_currents=[4.5, 4.4, 5.8],
+           evu_surplus=860, reserved_evu_overhang=0, get_currents=[4.5, 4.4, 5.8],
            get_power=3381, state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=3, expected_current=6,
            expected_message="Umschaltverzögerung von 3 auf 1 Phasen abgebrochen.",
            expected_timestamp_auto_phase_switch="05/16/2022, 08:40:52",
            expected_state=ChargepointState.CHARGING_ALLOWED),
     Params("3to1, not enough power, timer expired", max_current_single_phase=16,
            timestamp_auto_phase_switch="05/16/2022, 08:29:52", phases_to_use=3, required_current=6,
-           evu_get_power=100, reserved_evu_overhang=-460, get_currents=[4.5, 4.4, 5.8],
+           evu_surplus=0, reserved_evu_overhang=-460, get_currents=[4.5, 4.4, 5.8],
            get_power=3381, state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=1, expected_current=16,
            expected_state=ChargepointState.PHASE_SWITCH_DELAY_EXPIRED),
 ]
@@ -126,10 +126,11 @@ def test_auto_phase_switch(monkeypatch, vehicle: Ev, params: Params):
     # setup
     mock_evu = Mock(spec=Counter, data=Mock(spec=CounterData,
                                             set=Mock(spec=Set, reserved_surplus=params.reserved_evu_overhang,
-                                                     released_surplus=0),
-                                            get=Mock(spec=Get, power=params.available_power)))
+                                                     released_surplus=0)))
     mock_get_evu_counter = Mock(name="power_for_bat_charging", return_value=mock_evu)
     monkeypatch.setattr(data.data.counter_all_data, "get_evu_counter", mock_get_evu_counter)
+    mock_evu_counter_surplus = Mock(return_value=params.available_power)
+    monkeypatch.setattr(mock_evu, "calc_surplus", mock_evu_counter_surplus)
 
     vehicle.ev_template.data.max_current_single_phase = params.max_current_single_phase
     vehicle.data.control_parameter.timestamp_auto_phase_switch = params.timestamp_auto_phase_switch

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -459,8 +459,8 @@ class Ev:
             feed_in_yield = 0
         evu_counter = data.data.counter_all_data.get_evu_counter()
         # verbleibender EVU-Überschuss unter Berücksichtigung der Einspeisegrenze und Speicherleistung
-        all_surplus = -(evu_counter.data.get.power + evu_counter.data.set.released_surplus -
-                        evu_counter.data.set.reserved_surplus + feed_in_yield)
+        all_surplus = (evu_counter.calc_surplus() - evu_counter.data.set.released_surplus +
+                       evu_counter.data.set.reserved_surplus - feed_in_yield)
         if phases_in_use == 1:
             direction_str = "Umschaltverzögerung von 1 auf 3"
             delay = pv_config.phase_switch_delay * 60


### PR DESCRIPTION
Bei der Phasenumschaltung bei vorhandenem Speicher muss neben dem Überschuss am EVU-Punkt auch die verbleibende Speicherleistung berücksichtigt werden. Da durch die Regelung des Speichers am EVU-Punkt immer mal wieder geringer Bezug anliegen kann und dann nicht umgeschaltet wird.

[https://openwb.de/forum/viewtopic.php?p=85315#p85315](https://openwb.de/forum/viewtopic.php?p=85315#p85315)