### PR TITLE
smarthome zerlegung

### DIFF
--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 class UpdateConfig:
-    DATASTORE_VERSION = 8
+    DATASTORE_VERSION = 9
     valid_topic = ["^openWB/bat/config/configured$",
                    "^openWB/bat/set/charging_power_left$",
                    "^openWB/bat/set/switch_on_soc_reached$",
@@ -161,6 +161,13 @@ class UpdateConfig:
                    "^openWB/graph/alllivevaluesJson",
                    "^openWB/graph/lastlivevaluesJson$",
 
+                   "^openWB/internal_chargepoint/global_data$",
+                   "^openWB/internal_chargepoint/global_config$",
+                   "^openWB/internal_chargepoint/[0-1]/data/cp_interruption_duration$",
+                   "^openWB/internal_chargepoint/[0-1]/data/set_current$",
+                   "^openWB/internal_chargepoint/[0-1]/data/phases_to_use$",
+                   "^openWB/internal_chargepoint/[0-1]/data/parent_cp$",
+
                    "^openWB/set/log/request",
                    "^openWB/set/log/data",
 
@@ -175,6 +182,7 @@ class UpdateConfig:
                    "^openWB/optional/int_display/pin_active$",
                    "^openWB/optional/int_display/pin_code$",
                    "^openWB/optional/int_display/standby$",
+                   "^openWB/optional/int_display/rotation$",
                    "^openWB/optional/int_display/theme$",
                    "^openWB/optional/led/active$",
                    "^openWB/optional/rfid/active$",
@@ -326,6 +334,7 @@ class UpdateConfig:
                    "^openWB/system/configurable/devices_components$",
                    "^openWB/system/configurable/chargepoints$",
                    "^openWB/system/configurable/display_themes$",
+                   "^openWB/system/configurable/chargepoints_internal$",
                    "^openWB/system/mqtt/bridge/[0-9]+$",
                    "^openWB/system/current_branch",
                    "^openWB/system/current_commit",
@@ -391,6 +400,7 @@ class UpdateConfig:
         ("openWB/optional/int_display/pin_active", False),
         ("openWB/optional/int_display/pin_code", "0000"),
         ("openWB/optional/int_display/standby", 60),
+        ("openWB/optional/int_display/rotation", 0),
         ("openWB/optional/int_display/theme", dataclass_utils.asdict(CardsDisplayTheme())),
         ("openWB/optional/led/active", False),
         ("openWB/optional/rfid/active", False),
@@ -666,3 +676,18 @@ class UpdateConfig:
                     payload["keep_charge_active_duration"] = ev.EvTemplateData().keep_charge_active_duration
                     Pub().pub(topic.replace("openWB/", "openWB/set/"), payload)
         Pub().pub("openWB/set/system/datastore_version", 8)
+
+    def upgrade_datastore_8(self) -> None:
+        for topic, payload in self.all_received_topics.items():
+            if re.search("openWB/chargepoint/[0-9]+/config$", topic) is not None:
+                payload = decode_payload(payload)
+                if "connection_module" in payload:
+                    updated_payload = payload
+                    try:
+                        updated_payload["configuration"] = payload["connection_module"]["configuration"]
+                    except KeyError:
+                        updated_payload["configuration"] = {}
+                    updated_payload.pop("connection_module")
+                    updated_payload.pop("power_module")
+                    Pub().pub(topic.replace("openWB/", "openWB/set/"), payload)
+        Pub().pub("openWB/set/system/datastore_version", 9)

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 class UpdateConfig:
-    DATASTORE_VERSION = 9
+    DATASTORE_VERSION = 8
     valid_topic = ["^openWB/bat/config/configured$",
                    "^openWB/bat/set/charging_power_left$",
                    "^openWB/bat/set/switch_on_soc_reached$",
@@ -161,13 +161,6 @@ class UpdateConfig:
                    "^openWB/graph/alllivevaluesJson",
                    "^openWB/graph/lastlivevaluesJson$",
 
-                   "^openWB/internal_chargepoint/global_data$",
-                   "^openWB/internal_chargepoint/global_config$",
-                   "^openWB/internal_chargepoint/[0-1]/data/cp_interruption_duration$",
-                   "^openWB/internal_chargepoint/[0-1]/data/set_current$",
-                   "^openWB/internal_chargepoint/[0-1]/data/phases_to_use$",
-                   "^openWB/internal_chargepoint/[0-1]/data/parent_cp$",
-
                    "^openWB/set/log/request",
                    "^openWB/set/log/data",
 
@@ -182,7 +175,6 @@ class UpdateConfig:
                    "^openWB/optional/int_display/pin_active$",
                    "^openWB/optional/int_display/pin_code$",
                    "^openWB/optional/int_display/standby$",
-                   "^openWB/optional/int_display/rotation$",
                    "^openWB/optional/int_display/theme$",
                    "^openWB/optional/led/active$",
                    "^openWB/optional/rfid/active$",
@@ -236,14 +228,83 @@ class UpdateConfig:
                    "^openWB/vehicle/[0-9]+/set/ev_template$",
                    "^openWB/vehicle/[0-9]+/set/soc_error_counter$",
 
-                   "^openWB/LegacySmartHome/config/get/loglevel$",
+                   "^openWB/LegacySmartHome/config/get/logLevel$",
+                   "^openWB/LegacySmartHome/config/get/maxBatteryPower$",
+                   "^openWB/LegacySmartHome/Devices/[0-9]+/WHImported_temp$",
+                   "^openWB/LegacySmartHome/Devices/[0-9]+/RunningTimeToday$",
+                   "^openWB/LegacySmartHome/Devices/[0-9]+/oncountnor$",
+                   "^openWB/LegacySmartHome/Devices/[0-9]+/OnCntStandby$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_actor$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_acthortype$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_acthorpower$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_ausschaltschwelle$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_ausschalturl$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_ausschaltverzoegerung$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_configured$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_canSwitch$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_einschalturl$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_chan$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_dacport$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_deactivateper$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_deactivateWhileEvCharging$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_differentMeasurement$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_einschaltschwelle$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_einschaltverzoegerung$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_endTime$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_finishTime$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_homeConsumtion$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_idmnav$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_ip$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_lambdaueb$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_leistungurl$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_manwatt$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_maxeinschaltdauer$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_mindayeinschaltdauer$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_mineinschaltdauer$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measchan$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureavmusername$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureavmpassword$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureavmactor$",
                    "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureid$",
                    "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureip$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measuresmaage$"
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measuresmaser$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measurePortSdm$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureshauth$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureshusername$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureshpassword$",
                    "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureType$",
-                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_differentMeasurement$",
-                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_type$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureurl$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measureurlc$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measurejsonurl$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measurejsonpower$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_measurejsoncounter$",
                    "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_name$",
-                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_configured$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_nxdacxxtype$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_nxdacxxueb$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_nonewatt$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_offTime$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_onTime$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_onuntilTime$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_password$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_pbip$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_pbtype$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_setauto$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_shusername$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_shpassword$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_shauth$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_startTime$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_startupDetection$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_standbyPower$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_standbyDuration$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_startupMulDetection$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_stateurl$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_speichersocbeforestart$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_speichersocbeforestop$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_temperatur_configured$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_type$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_updatesec$",
+                   "^openWB/LegacySmartHome/config/get/Devices/[0-9]+/device_username$",
 
                    "^openWB/system/boot_done$",
                    "^openWB/system/dataprotection_acknowledged$",
@@ -265,7 +326,6 @@ class UpdateConfig:
                    "^openWB/system/configurable/devices_components$",
                    "^openWB/system/configurable/chargepoints$",
                    "^openWB/system/configurable/display_themes$",
-                   "^openWB/system/configurable/chargepoints_internal$",
                    "^openWB/system/mqtt/bridge/[0-9]+$",
                    "^openWB/system/current_branch",
                    "^openWB/system/current_commit",
@@ -331,7 +391,6 @@ class UpdateConfig:
         ("openWB/optional/int_display/pin_active", False),
         ("openWB/optional/int_display/pin_code", "0000"),
         ("openWB/optional/int_display/standby", 60),
-        ("openWB/optional/int_display/rotation", 0),
         ("openWB/optional/int_display/theme", dataclass_utils.asdict(CardsDisplayTheme())),
         ("openWB/optional/led/active", False),
         ("openWB/optional/rfid/active", False),
@@ -607,18 +666,3 @@ class UpdateConfig:
                     payload["keep_charge_active_duration"] = ev.EvTemplateData().keep_charge_active_duration
                     Pub().pub(topic.replace("openWB/", "openWB/set/"), payload)
         Pub().pub("openWB/set/system/datastore_version", 8)
-
-    def upgrade_datastore_8(self) -> None:
-        for topic, payload in self.all_received_topics.items():
-            if re.search("openWB/chargepoint/[0-9]+/config$", topic) is not None:
-                payload = decode_payload(payload)
-                if "connection_module" in payload:
-                    updated_payload = payload
-                    try:
-                        updated_payload["configuration"] = payload["connection_module"]["configuration"]
-                    except KeyError:
-                        updated_payload["configuration"] = {}
-                    updated_payload.pop("connection_module")
-                    updated_payload.pop("power_module")
-                    Pub().pub(topic.replace("openWB/", "openWB/set/"), payload)
-        Pub().pub("openWB/set/system/datastore_version", 9)

--- a/packages/smarthome/smarthome.py
+++ b/packages/smarthome/smarthome.py
@@ -1,446 +1,49 @@
 #!/usr/bin/python3
-from modules.smarthome.ratiotherm.smartratiotherm import Sratiotherm
-from modules.smarthome.viessmann.smartviessmann import Sviessmann
-from modules.smarthome.tasmota.smarttasmota import Stasmota
-from modules.smarthome.lambda_.smartlambda import Slambda
-from modules.smarthome.vampair.smartvampair import Svampair
-from modules.smarthome.stiebel.smartstiebel import Sstiebel
-from modules.smarthome.shelly.smartshelly import Sshelly
-from modules.smarthome.mystrom.smartmystrom import Smystrom
-from modules.smarthome.mqtt.smartmqtt import Smqtt
-from modules.smarthome.http.smarthttp import Shttp
-from modules.smarthome.idm.smartidm import Sidm
-from modules.smarthome.elwa.smartelwa import Selwa
-from modules.smarthome.nxdacxx.smartnxdacxx import Snxdacxx
-from modules.smarthome.acthor.smartacthor import Sacthor
-from modules.smarthome.avmhomeautomation.smartavm import Savm
-from smarthome.smartbase import Sbase
-from threading import Thread
-import paho.mqtt.client as mqtt
-import time
-import re
-import os
+from smarthome.smartcommon import mainloop, initparam
 import logging
-import math
+from threading import Thread
 from helpermodules.subdata import SubData
-log = logging.getLogger(__name__)
+log = logging.getLogger()
 
-mqtt_cache = {}
-mydevices = []
+#
+#  openwb 2.0 spec
+mqttcg = 'openWB/LegacySmartHome/config/get/'
+mqttcs = 'openWB/LegacySmartHome/config/set/'
+mqttsdevstat = 'openWB/LegacySmartHome/Devices'
+mqttsglobstat = 'openWB/LegacySmartHome/Status/'
+mqtttopicdisengageable = 'openWB/set/counter/set/disengageable_smarthome_power'
+ramdiskwrite = False
+mqttport = 1886
+#
+
 bp = '/var/www/html/openWB'
-numberOfSupportedDevices = 9  # limit number of SmartHome devices
 
 
-def on_connect(client, userdata, flags, rc):
-    client.subscribe("openWB/LegacySmartHome/config/get/Devices/#", 2)
-    client.subscribe("openWB/LegacySmartHome/Devices/#", 2)
+def readmq() -> None:
+    logging.getLogger("smarthome").setLevel(logging.DEBUG)
+    log.info("*** Smarthome openWB readmq Start ***")
 
 
-def on_message(client, userdata, msg):
-    # wenn exception hier wird mit nächster msg weitergemacht
-    # macht paho unter python 3 immer so
-    global parammqtt
-    devicenumb = re.sub(r'\D', '', msg.topic)
-    input = msg.payload.decode("utf-8")
-    if ("openWB/LegacySmartHome/config/get/Devices" in msg.topic):
-        keyword = re.sub('openWB/LegacySmartHome/config/get/Devices/'
-                         + str(devicenumb) + '/', '', msg.topic)
-    if ("openWB/LegacySmartHome/Devices" in msg.topic):
-        keyword = re.sub('openWB/LegacySmartHome/Devices/'
-                         + str(devicenumb) + '/', '', msg.topic)
-    value = str(input)
-    if (("/" in keyword) or (int(devicenumb) < 1) or
-       (int(devicenumb) > numberOfSupportedDevices)):
-        # falsches topic
-        log.warning("(" + str(devicenumb) + ") skipped Key " +
-                    str(keyword) + " Msg " + str(msg.topic) +
-                    " Value " + str(value))
-    else:
-        # richtig  topic
-        log.info("(" + str(devicenumb) + ") Key " +
-                 str(keyword) + " Value " + str(value))
-        parammqtt.append([devicenumb, keyword, value])
-
-# Lese aus der Ramdisk Regelrelevante Werte ein
-
-
-def loadregelvars():
-    global uberschuss
-    global uberschussoffset
-    global speicherleistung
-    global speichersoc
-    global speichervorhanden
-    global wattbezug
-    global numberOfSupportedDevices
-    global maxspeicher
-    global mydevices
-    try:
-        if len(SubData.bat_data) > 1:
-            speicherleistung = SubData.bat_data["all"].data.get.power
-            speichersoc = SubData.bat_data["all"].data.get.soc
-        else:
-            speicherleistung = 0
-            speichersoc = 100
-    except Exception:
-        log.exception("Fehler beim Auslesen der Ramdisk " +
-                      "(speichervorhanden,speicherleistung,speichersoc): ")
-        speichervorhanden = 0
-        speicherleistung = 0
-        speichersoc = 100
-    try:
-        wattbezug = SubData.counter_data[f"counter{SubData.counter_all_data.get_id_evu_counter()}"].data.get.power * -1
-    except Exception:
-        log.exception("Fehler beim Auslesen der Ramdisk (wattbezug):")
-        wattbezug = 0
-    uberschuss = wattbezug + speicherleistung
-    try:
-        with open(bp+'/ramdisk/smarthomehandlermaxbatterypower', 'r') as value:
-            maxspeicher = int(value.read())
-    except Exception:
-        log.exception("Fehler beim Auslesen der Ramdisk " +
-                      "(smarthomehandlermaxbatterypower): ")
-    maxspeicher = 0
-    uberschussoffset = wattbezug + speicherleistung - maxspeicher
-    log.info("EVU Bezug(-)/Einspeisung(+): " + str(wattbezug) +
-             " max Speicherladung: " + str(maxspeicher))
-    log.info("Uberschuss: " + str(uberschuss) +
-             " Uberschuss mit Offset: " + str(uberschussoffset))
-    log.info("Speicher Entladung(-)/Ladung(+): " +
-             str(speicherleistung) + " SpeicherSoC: " + str(speichersoc))
-
-    reread = 0
-    try:
-        with open(bp+'/ramdisk/rereadsmarthomedevices', 'r') as value:
-            reread = int(value.read())
-    except Exception:
-        reread = 1
-    if (reread == 1):
-        with open(bp+'/ramdisk/rereadsmarthomedevices', 'w') as f:
-            f.write(str(0))
-        readmq()
-
-    for i in range(1, (numberOfSupportedDevices+1)):
+def smarthome_handler() -> None:
+    def handler() -> None:
         try:
-            with open(bp+'/ramdisk/smarthome_device_manual_'
-                      + str(i), 'r') as value:
-                for mydevice in mydevices:
-                    if (str(i) == str(mydevice.device_nummer)):
-                        mydevice.device_manual = int(value.read())
-        except Exception:
-            pass
-        try:
-            with open(bp+'/ramdisk/smarthome_device_manual_control_'
-                      + str(i), 'r') as value:
-                for mydevice in mydevices:
-                    if (str(i) == str(mydevice.device_nummer)):
-                        mydevice.device_manual_control = int(value.read())
-        except Exception:
-            pass
-
-
-def getdevicevalues():
-    global mydevices
-    global uberschuss
-    global uberschussoffset
-    totalwatt = 0
-    totalwattot = 0
-    totalminhaus = 0
-    # dyn daten einschaltgruppe
-    Sbase.ausschaltwatt = 0
-    Sbase.einrelais = 0
-    Sbase.eindevstatus = 0
-    mqtt_all = {}
-    for mydevice in mydevices:
-        mydevice.getwatt(uberschuss, uberschussoffset)
-        watt = mydevice.newwatt
-        wattk = mydevice.newwattk
-        relais = mydevice.relais
-        # temp0 = mydevice.temp0
-        # temp1 = mydevice.temp1
-        # temp2 = mydevice.temp2
-        if ((mydevice.abschalt == 1) and (relais == 1)
-           and (mydevice.device_manual != 1)):
-            totalwatt = totalwatt + watt
-        else:
-            totalwattot = totalwattot + watt
-        if (mydevice.device_homeconsumtion == 0):
-            totalminhaus = totalminhaus + watt
-        log.info("(" + str(mydevice.device_nummer) + ") " +
-                 str(mydevice.device_name) + " rel: " + str(relais) +
-                 " oncnt/onstandby/time: " + str(mydevice.oncountnor) + "/"
-                 + str(mydevice.oncntstandby) + "/" +
-                 str(mydevice.runningtime) + " Status/Üeb: " +
-                 str(mydevice.devstatus) + "/" +
-                 str(mydevice.ueberschussberechnung) + " akt: " + str(watt) +
-                 " Z: " + str(wattk))
-        mqtt_all.update(mydevice.mqtt_param)
-    # device_total_watt is needed for calculation the proper überschuss
-    # (including switchable smarthomedevices)
-
-    # with open(bp+'/ramdisk/devicetotal_watt', 'w') as f:
-    #     f.write(str(totalwatt))
-    # with open(bp+'/ramdisk/devicetotal_watt_other', 'w') as f:
-    #     f.write(str(totalwattot))
-    # with open(bp+'/ramdisk/devicetotal_watt_hausmin', 'w') as f:
-    #     f.write(str(totalminhaus))
-    log.info("Total Watt abschaltbarer smarthomedevices: " +
-             str(totalwatt))
-    log.info("Total Watt nichtabschaltbarer smarthomedevices: "
-             + str(totalwattot))
-    log.info("Total Watt nicht im Hausverbrauch: " +
-             str(totalminhaus))
-    log.info("Anzahl devices in Auschaltgruppe: " +
-             str(Sbase.ausdevices) + " akt: " + str(Sbase.ausschaltwatt) +
-             " Anzahl devices in Einschaltgruppe: " + str(Sbase.eindevices)
-             )
-    nurhh = math.floor(Sbase.nureinschaltinsec / 3600)
-    nurmm = math.floor((Sbase.nureinschaltinsec - (nurhh * 3600)) / 60)
-    nurss = (Sbase.nureinschaltinsec - (nurhh * 3600) - (nurmm * 60))
-    log.info("Einschaltgruppe rel: " + str(Sbase.einrelais) +
-             " Summe Einschaltschwelle: " +
-             str(Sbase.einschwelle) + " max Einschaltverzögerung " +
-             str(Sbase.einverz) + " nur Einschaltgruppe prüfen bis: " +
-             str('%.2d' % nurhh) + ":" + str('%.2d' % nurmm) + ":" +
-             str('%.2d' % nurss) +
-             " in Total sec " + str(Sbase.nureinschaltinsec)
-             )
-    mqtt_all['openWB/LegacySmartHome/Status/maxspeicherladung'] = maxspeicher
-    mqtt_all['openWB/set/counter/set/disengageable_smarthome_power'] = totalwatt
-    mqtt_all['openWB/LegacySmartHome/Status/wattnichtschalt'] = totalwattot
-    mqtt_all['openWB/LegacySmartHome/Status/wattnichtHaus'] = totalminhaus
-    mqtt_all['openWB/LegacySmartHome/Status/uberschuss'] = uberschuss
-    mqtt_all['openWB/LegacySmartHome/Status/uberschussoffset'] = uberschussoffset
-    sendmq(mqtt_all)
-
-
-def sendmq(mqtt_input):
-    global mqtt_cache
-    client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
-    client.connect("localhost", 1886)
-    for key, value in mqtt_input.items():
-        valueold = mqtt_cache.get(key, 'not in cache')
-        if (valueold == value):
-            pass
-        else:
-            log.info("Mq pub " + str(key) + "=" +
-                     str(value) + " old " + str(valueold))
-            mqtt_cache[key] = value
-            client.publish(key, payload=value, qos=0, retain=True)
-            client.loop(timeout=2.0)
-    client.disconnect()
-
-
-def conditions():
-    global mydevices
-    global speichersoc
-    for mydevice in mydevices:
-        mydevice.conditions(speichersoc)
-
-
-def update_devices():
-    global parammqtt
-    global mydevices
-    global mqtt_cache
-    client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
-    client.connect("localhost")
-    # statische daten einschaltgruppe
-    Sbase.ausdevices = 0
-    Sbase.eindevices = 0
-    Sbase.einverz = 0
-    Sbase.einschwelle = 0
-    # Nur einschaltgruppe in Sekunden
-    Sbase.nureinschaltinsec = 0
-    for i in range(1, numberOfSupportedDevices+1):
-        device_configured = 0
-        device_type = 'none'
-        input_param = {}
-        input_param['device_nummer'] = str(i)
-        for devicenumb, keyword, value in parammqtt:
-            if (str(i) == str(devicenumb)):
-                if (keyword == 'device_configured'):
-                    device_configured = value
-                if (keyword == 'device_type'):
-                    device_type = value
-                input_param[keyword] = value
-        if (device_configured == "1"):
-            createnew = 1
-            for mydevice in mydevices:
-                if (str(i) == str(mydevice.device_nummer)):
-                    log.info("(" + str(i) + ") " +
-                             "Device bereits erzeugt")
-                    if (device_type == mydevice.device_type):
-                        log.info("(" + str(i) + ") " +
-                                 "Typ gleich, nur Parameter update")
-                        createnew = 0
-                        mydevice.updatepar(input_param)
-                    else:
-                        log.info("(" + str(i) + ") " +
-                                 "Typ ungleich " + mydevice.device_type)
-                        mydevice.device_nummer = 0
-                        mydevice._device_configured = '9'
-                        # del mydevice
-                        mydevices.remove(mydevice)
-                        log.info("(" + str(i) + ") " +
-                                 "Device gelöscht")
-                    break
-            if (createnew == 1):
-                log.info("(" + str(i) +
-                         ") Neues Devices oder Typänderung: " +
-                         str(device_type))
-                if (device_type == 'shelly'):
-                    mydevice = Sshelly()
-                elif (device_type == 'stiebel'):
-                    mydevice = Sstiebel()
-                elif (device_type == 'vampair'):
-                    mydevice = Svampair()
-                elif (device_type == 'lambda'):
-                    mydevice = Slambda()
-                elif (device_type == 'ratiotherm'):
-                    mydevice = Sratiotherm()
-                elif (device_type == 'tasmota'):
-                    mydevice = Stasmota()
-                elif (device_type == 'avm'):
-                    mydevice = Savm()
-                elif (device_type == 'viessmann'):
-                    mydevice = Sviessmann()
-                elif (device_type == 'acthor'):
-                    mydevice = Sacthor()
-                elif (device_type == 'NXDACXX'):
-                    mydevice = Snxdacxx()
-                elif (device_type == 'elwa'):
-                    mydevice = Selwa()
-                elif (device_type == 'idm'):
-                    mydevice = Sidm()
-                elif (device_type == 'mqtt'):
-                    mydevice = Smqtt()
-                elif (device_type == 'http'):
-                    mydevice = Shttp()
-                elif (device_type == 'mystrom'):
-                    mydevice = Smystrom()
+            try:
+                if len(SubData.bat_data) > 1:
+                    speicherleistung = SubData.bat_data["all"].data.get.power
+                    speichersoc = SubData.bat_data["all"].data.get.soc
                 else:
-                    mydevice = Sbase()
-                mydevice.updatepar(input_param)
-                mydevices.append(mydevice)
-        else:
-            log.info("(" + str(i) + ") " +
-                     "Device nicht (länger) definiert")
-            for mydevice in mydevices:
-                if (str(i) == str(mydevice.device_nummer)):
-                    # cleant up mqtt
-                    for key, value in mydevice.mqtt_param_del.items():
-                        valueold = mqtt_cache.pop(key, 'not in cache')
-                        log.info("Mq pub " + str(key) + "=" +
-                                 str(value) + " old " + str(valueold))
-                        client.publish(key, payload=value, qos=0, retain=True)
-                        client.loop(timeout=2.0)
-                    mydevice.device_nummer = 0
-                    mydevice._device_configured = '9'
-                    # del mydevice
-                    mydevices.remove(mydevice)
-                    log.info("(" + str(i) + ") " +
-                             "Device gelöscht")
-    client.disconnect()
-
-
-def readmq():
-    global parammqtt
-    global mydevices
-    log.info("Config reRead start")
-    parammqtt = []
-    client = mqtt.Client("openWB-mqttsmarthome")
-    client.on_connect = on_connect
-    client.on_message = on_message
-    startTime = time.time()
-    waitTime = 5
-    client.connect("localhost", 1886)
-    while True:
-        client.loop()
-        elapsedTime = time.time() - startTime
-        if elapsedTime > waitTime:
-            client.disconnect()
-            break
-    update_devices()
-    log.info("Config reRead done")
-
-
-def resetmaxeinschaltdauerfunc():
-    global resetmaxeinschaltdauer
-    global numberOfSupportedDevices
-    global mydevices
-    mqtt_reset = {}
-    hour = time.strftime("%H")
-    if (int(hour) == 0):
-        if (int(resetmaxeinschaltdauer) == 0):
-            for i in range(1, (numberOfSupportedDevices+1)):
-                for mydevice in mydevices:
-                    if (str(i) == str(mydevice.device_nummer)):
-                        pref = 'openWB/LegacySmartHome/Devices/' + str(i) + '/'
-                        mydevice.runningtime = 0
-                        mqtt_reset[pref + 'RunningTimeToday'] = '0'
-                        log.info("(" + str(i) +
-                                 ") RunningTime auf 0 gesetzt")
-                        mydevice.oncountnor = '0'
-                        mqtt_reset[pref + 'oncountnor'] = '0'
-                # Sofern Anlauferkennung laueft counter nicht zuruecksetzen
-                        if (mydevice.devstatus != 20):
-                            mydevice.oncntstandby = '0'
-                            mqtt_reset[pref + 'OnCntStandby'] = '0'
-                        mydevice.c_oldstampeinschaltdauer = 0
-                        mydevice.c_oldstampeinschaltdauer_f = 'N'
-                        if ((mydevice.device_setauto == 1) and
-                           (mydevice.device_manual == 1)):
-                            log.info("(" + str(i) +
-                                     ") Umschaltung auf automatisch Modus ")
-                            mqtt_reset[pref + 'mode'] = '0'
-            resetmaxeinschaltdauer = 1
-            # Nur einschaltgruppe in Sekunden für neuen Tag zurücksetzten
-            Sbase.nureinschaltinsec = 0
-            sendmq(mqtt_reset)
-    if (int(hour) == 1):
-        resetmaxeinschaltdauer = 0
-
-
-def smarthome_handler():
-    def handler():
-        try:
-            #        update_devices()
-            mqtt_man = {}
-            sendmess = 0
-            loadregelvars()
-            resetmaxeinschaltdauerfunc()
-            getdevicevalues()
-            conditions()
-            # do the manual stuff
-            for i in range(1, (numberOfSupportedDevices+1)):
-                for mydevice in mydevices:
-                    if (str(i) == str(mydevice.device_nummer)):
-                        if (mydevice.device_manual == 1):
-                            if (mydevice.device_manual_control == 0):
-                                if (mydevice.relais == 1):
-                                    mydevice.turndevicerelais(0, 0, 1)
-                            if (mydevice.device_manual_control == 1):
-                                if (mydevice.relais == 0):
-                                    mydevice.turndevicerelais(1, 0, 1)
-                            mydevice.c_mantime_f = 'Y'
-                            mydevice.c_mantime = time.time()
-                            log.info("(" + str(i) + ") " +
-                                     mydevice.device_name +
-                                     " manueller Modus aktiviert, keine Regelung")
-            for i in range(1, (numberOfSupportedDevices+1)):
-                pref = 'openWB/config/set/SmartHome/Devices/' + str(i) + '/'
-                for mydevice in mydevices:
-                    if (str(i) == str(mydevice.device_nummer)):
-                        mydevice.updatebutton()
-                        if (mydevice.btchange == 1):
-                            sendmess = 1
-                            mqtt_man[pref + 'mode'] = mydevice.newdevice_manual
-                        if (mydevice.btchange == 2):
-                            sendmess = 1
-                            workman = mydevice.newdevice_manual_control
-                            mqtt_man[pref + 'device_manual_control'] = workman
-            if (sendmess == 1):
-                sendmq(mqtt_man)
+                    speicherleistung = 0
+                    speichersoc = 100
+            except Exception:
+                log.exception("Fehler beim Auslesen der Ramdisk " +
+                              "(speichervorhanden,speicherleistung,speichersoc): ")
+                speicherleistung = 0
+                speichersoc = 100
+            watt = SubData.counter_data[f"counter{SubData.counter_all_data.get_id_evu_counter()}"].data.get.power * -1
+            mainloop(watt, speicherleistung, speichersoc)
+            #  time.sleep(5)
         except Exception:
             log.exception("Fehler im Smarthome-Handler")
     # run as thread for logging reasons
+    initparam(mqttcg, mqttcs, mqttsdevstat, mqttsglobstat, mqtttopicdisengageable, ramdiskwrite, mqttport)
     Thread(target=handler, args=(), name="smarthome").start()

--- a/packages/smarthome/smartlog.py
+++ b/packages/smarthome/smartlog.py
@@ -1,0 +1,13 @@
+import logging
+
+
+def initlog(name: str, devicenumber: int) -> None:
+    log = logging.getLogger(name)
+    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+    log.setLevel(logging.DEBUG)
+    fname = '/var/www/html/openWB/ramdisk/smarthome_device_'
+    fname += str(devicenumber) + '_' + str(name) + '.log'
+    fh = logging.FileHandler(fname, encoding='utf8')
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(formatter)
+    log.addHandler(fh)

--- a/web/settings/modules/legacy_smart_home/smarthomeconfig.php
+++ b/web/settings/modules/legacy_smart_home/smarthomeconfig.php
@@ -34,9 +34,9 @@ $numDevices = 9;
 		<header>
 			<!-- Fixed navbar -->
 			<nav class="navbar navbar-expand-sm bg-dark navbar-dark fixed-top">
-				<a class="navbar-brand" href="./">
-					<span>openWB</span>
-				</a>
+				<div class="navbar-brand">
+					openWB
+				</div>
 			</nav>
 		</header>
 
@@ -330,9 +330,9 @@ $numDevices = 9;
 												Die hier angegebene URL wird aufgerufen, um die aktuelle Leistung des Geräts zu erhalten.<br>
 												<span class="text-info">Wenn in der URL ein Prozentzeichen "%" enthalten ist, muss dieses durch ein weiteres "%" ergänzt werden ("%" -> "%%"), da ansonsten die Daten nicht gespeichert werden können.</span><br>
 												Falls keine URL vorhanden ist, kann eine der folgenden angegeben werden:<br>
-												127.0.0.1/openWB/modules/smarthome/http/dummyurl.php. Diese URL gibt immer den Wert 0 zurück.(Device immer aus)<br>
-												127.0.0.1/openWB/modules/smarthome/http/dummyurl1.php?d=nummerdevice. Diese URL gibt den Wert 0 oder 100 zurück. Je nachdem ob das Smarthomedevice gerade läuft<br>
-												127.0.0.1/openWB/modules/smarthome/http/dummyurl2.php. Diese URL gibt immer den Wert 100 zurück. (Device immer an)<br>
+												127.0.0.1/openWB/packages/modules/smarthome/http/dummyurl.php. Diese URL gibt immer den Wert 0 zurück.(Device immer aus)<br>
+												127.0.0.1/openWB/packages/modules/smarthome/http/dummyurl1.php?d=nummerdevice. Diese URL gibt den Wert 0 oder 100 zurück. Je nachdem ob das Smarthomedevice gerade läuft<br>
+												127.0.0.1/openWB/packages/modules/smarthome/http/dummyurl2.php. Diese URL gibt immer den Wert 100 zurück. (Device immer an)<br>
 												In der URL kann ein Parameter angegeben werden, der den aktuellen Überschuss an das Gerät übermittelt. Hierzu ist folgender Platzhalter in der URL zu verwenden (inklusive der spitzen Klammern):<br>
 												<span class="text-info">&lt;openwb-ueberschuss&gt;</span>
 											</span>
@@ -465,6 +465,13 @@ $numDevices = 9;
 											<div class="col">
 												<input id="device_mineinschaltdauerDevices<?php echo $devicenum; ?>" name="device_mineinschaltdauer" class="form-control naturalNumber" type="number" inputmode="decimal" required min="0" max="10000" data-default="0" value="0" data-topicprefix="openWB/LegacySmartHome/config/get/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
 												<span class="form-text small">Parameter in Minuten, wie lange das Gerät nach Einschalten mindestens aktiviert bleibt.</span>
+											</div>
+										</div>
+										<div class="form-row mb-1">
+											<label for="device_mindayeinschaltdauerDevices<?php echo $devicenum; ?>" class="col-md-4 col-form-label">Mindesteinschaltdauer pro Tag</label>
+											<div class="col">
+												<input id="device_mindayeinschaltdauerDevices<?php echo $devicenum; ?>" name="device_mindayeinschaltdauer" class="form-control naturalNumber" type="number" inputmode="decimal" required min="0" max="10000" data-default="0" value="0" data-topicprefix="openWB/LegacySmartHome/config/get/" data-topicsubgroup="Devices/<?php echo $devicenum; ?>/">
+												<span class="form-text small">Parameter in Minuten, wie lange das Gerät pro Tag mindestens aktiviert bleibt. Siehe auch "Spätestens fertig um"</span>
 											</div>
 										</div>
 										<div class="form-row mb-1">

--- a/web/settings/modules/legacy_smart_home/topicsToSubscribe_smarthomeconfig.js
+++ b/web/settings/modules/legacy_smart_home/topicsToSubscribe_smarthomeconfig.js
@@ -83,5 +83,6 @@ var topicsToSubscribe = [
 	["openWB/LegacySmartHome/config/get/Devices/+/device_shpassword", 0],
 	["openWB/LegacySmartHome/config/get/Devices/+/device_shauth", 0],
 	["openWB/LegacySmartHome/config/get/Devices/+/device_measureshauth", 0],
+	["openWB/LegacySmartHome/config/get/Devices/+/device_mindayeinschaltdauer", 0],	
 	["openWB/LegacySmartHome/config/get/Devices/+/device_measuresmaage", 0]
 ];


### PR DESCRIPTION
Ersetzt 894 komplett.
Update_config.py  mit smarthome mqtt topics ergänzt. (8-Tung Master ist weiter) smarthome.py enthält nur den openwb 2.0 teil
smartlog.py wird neu auch gebraucht (login für .../packages/smarthome/Shelly /.... das hier erzeugt Logging sollte weder in die Smarthome.log und auch nicht in den Main.log sonderen nur auf dir Ramdisk smarthomeconfig..php / topicsToSubscripe zusätzliche Gui Parameter ergänzt (anpassung an 1.9) Der menueeintrag für Smarthome unter Konfiguration ist nach dem letzten upgrade weg, bitte wieder einbauen