### PR TITLE
configurable soc request interval

### DIFF
--- a/data/config/openwb_local.conf
+++ b/data/config/openwb_local.conf
@@ -1,4 +1,4 @@
-# openwb-version:10
+# openwb-version:11
 listener 1886 localhost
 allow_anonymous true
 
@@ -11,6 +11,7 @@ topic openWB/LegacySmartHome/config/set/# both 2
 
 topic openWB/vehicle/+/name out 2
 topic openWB/vehicle/+/soc_module/config out 2
+topic openWB/vehicle/+/soc_module/interval_config out 2
 topic openWB/vehicle/+/tag_id out 2
 topic openWB/vehicle/+/charge_template out 2
 topic openWB/vehicle/+/ev_template out 2

--- a/packages/control/ev_test.py
+++ b/packages/control/ev_test.py
@@ -4,6 +4,9 @@ import pytest
 
 from control.ev import Ev
 from helpermodules import timecheck
+from modules.common.abstract_soc import SocUpdateData
+from modules.vehicles.mqtt.config import MqttSocSetup
+from modules.vehicles.mqtt.soc import create_vehicle
 
 
 @pytest.mark.parametrize(
@@ -21,12 +24,13 @@ def test_soc_interval_expired(check_timestamp: bool,
                               monkeypatch):
     # setup
     ev = Ev(0)
+    ev.soc_module = create_vehicle(MqttSocSetup(), 0)
     ev.data.get.soc_timestamp = soc_timestamp
     check_timestamp_mock = Mock(return_value=check_timestamp)
     monkeypatch.setattr(timecheck, "check_timestamp", check_timestamp_mock)
 
     # execution
-    request_soc = ev.soc_interval_expired(charge_state)
+    request_soc = ev.soc_interval_expired(SocUpdateData(charge_state=charge_state))
 
     # evaluation
     assert request_soc == expected_request_soc

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -25,6 +25,7 @@ from modules.chargepoints.internal_openwb.chargepoint_module import ChargepointM
 from modules.chargepoints.internal_openwb.config import InternalChargepointMode
 from modules.common.component_type import ComponentType, special_to_general_type_mapping, type_to_topic_mapping
 import dataclass_utils
+from modules.common.configurable_vehicle import IntervalConfig
 
 log = logging.getLogger(__name__)
 
@@ -511,6 +512,7 @@ class Command:
         for default in vehicle_default:
             Pub().pub(f"openWB/set/vehicle/{new_id}/{default}", vehicle_default[default])
         Pub().pub(f"openWB/set/vehicle/{new_id}/soc_module/config", {"type": None, "configuration": {}})
+        Pub().pub(f"openWB/set/vehicle/{new_id}/soc_module/interval_config", dataclass_utils.asdict(IntervalConfig()))
         self.max_id_vehicle = self.max_id_vehicle + 1
         Pub().pub("openWB/set/command/max_id/vehicle", self.max_id_vehicle)
         # Default-Mäßig werden die Templates 0 zugewiesen, wenn diese noch nicht existieren -> anlegen

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -396,7 +396,8 @@ class SetData:
                 self._validate_value(msg, int, [(0, float("inf"))])
             elif "/soc_module/configuration/soc_start" in msg.topic:
                 self._validate_value(msg, float, [(0, 100)], pub_json=True)
-            elif "/soc_module/config" in msg.topic:
+            elif ("/soc_module/config" in msg.topic or
+                  "/soc_module/interval_config" in msg.topic):
                 self._validate_value(msg, "json")
             elif "/get/fault_state" in msg.topic:
                 self._validate_value(msg, int, [(0, 2)])

--- a/packages/modules/common/abstract_soc.py
+++ b/packages/modules/common/abstract_soc.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 @dataclass
 class SocUpdateData:
+    plug_state: bool = False
     charge_state: bool = False
     imported_since_plugged: float = 0
     battery_capacity: float = 82

--- a/packages/modules/common/configurable_vehicle.py
+++ b/packages/modules/common/configurable_vehicle.py
@@ -9,13 +9,25 @@ from modules.common.fault_state import ComponentInfo
 T_VEHICLE_CONFIG = TypeVar("T_VEHICLE_CONFIG")
 
 
+class IntervalConfig:
+    def __init__(self,
+                 request_interval_charging: int = 5,
+                 request_interval_not_charging: int = 720,
+                 request_only_plugged: bool = False) -> None:
+        self.request_interval_charging = request_interval_charging
+        self.request_interval_not_charging = request_interval_not_charging
+        self.request_only_plugged = request_only_plugged
+
+
 class ConfigurableVehicle(Generic[T_VEHICLE_CONFIG]):
     def __init__(self,
                  vehicle_config: T_VEHICLE_CONFIG,
                  component_updater: Callable[[T_VEHICLE_CONFIG, SocUpdateData], CarState],
-                 vehicle: int) -> None:
+                 vehicle: int,
+                 interval_config: IntervalConfig = IntervalConfig()) -> None:
         self.__component_updater = component_updater
         self.vehicle_config = vehicle_config
+        self.interval_config = interval_config
         self.vehicle = vehicle
         self.store = store.get_car_value_store(self.vehicle)
         self.component_info = ComponentInfo(self.vehicle, self.vehicle_config.name, "vehicle")

--- a/packages/modules/update_soc.py
+++ b/packages/modules/update_soc.py
@@ -43,7 +43,7 @@ class UpdateSoc:
             try:
                 if ev.soc_module is not None:
                     soc_update_data = self._get_soc_update_data(ev.num)
-                    if (ev.soc_interval_expired(soc_update_data.charge_state) or ev.data.get.force_soc_update):
+                    if (ev.soc_interval_expired(soc_update_data) or ev.data.get.force_soc_update):
                         self._reset_force_soc_update(ev)
                         if ev.data.get.fault_state == 2:
                             ev.data.set.soc_error_counter += 1
@@ -76,15 +76,18 @@ class UpdateSoc:
         for cp in list(data.data.cp_data.values()):
             if not isinstance(cp, AllChargepoints):
                 if cp.data.set.charging_ev == ev_num:
+                    plug_state = cp.data.get.plug_state
                     charge_state = cp.data.get.charge_state
                     imported_since_plugged = cp.data.set.log.imported_since_plugged
                     battery_capacity = cp.data.set.charging_ev_data.ev_template.data.battery_capacity
                     break
         else:
+            plug_state = False
             charge_state = False
             imported_since_plugged = 0
             battery_capacity = 0
-        return SocUpdateData(charge_state=charge_state,
+        return SocUpdateData(plug_state=plug_state,
+                             charge_state=charge_state,
                              imported_since_plugged=imported_since_plugged,
                              battery_capacity=battery_capacity)
 


### PR DESCRIPTION
basiert auf #969 
Schnittstelle fürs UI: 'openWB/vehicle/0/soc_module/interval_config', Payload `{'request_interval_charging': 5, 'request_interval_not_charging': 720, 'request_only_plugged': False}`