### PR TITLE
fix soc module startup error

### DIFF
--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -258,7 +258,8 @@ class SubData:
                     elif re.search("/vehicle/[0-9]+/set", msg.topic) is not None:
                         self.set_json_payload_class(var["ev"+index].data.set, msg)
                     elif re.search("/vehicle/[0-9]+/soc_module/interval_config", msg.topic) is not None:
-                        self.set_json_payload_class(var["ev"+index].soc_module.interval_config, msg)
+                        if var["ev"+index].soc_module is not None:
+                            self.set_json_payload_class(var["ev"+index].soc_module.interval_config, msg)
                     elif re.search("/vehicle/[0-9]+/soc_module/config$", msg.topic) is not None:
                         config = decode_payload(msg.payload)
                         if config["type"] is None:


### PR DESCRIPTION
Wenn kein SoC Modul aktiviert ist, kommt es beim Start zu folgender Meldung:
```
2023-07-03 12:29:01,669 - {helpermodules.subdata:278} - {ERROR:Thread-5} - Fehler im subdata-Modul
Traceback (most recent call last):
  File "/var/www/html/openWB/packages/helpermodules/subdata.py", line 261, in process_vehicle_topic
    self.set_json_payload_class(var["ev"+index].soc_module.interval_config, msg)
AttributeError: 'NoneType' object has no attribute 'interval_config'
```
Dieser PR fügt eine Prüfung hinzu, ob ein SoC Modul aktiviert ist.