### PR TITLE
Update clients.py

### DIFF
--- a/packages/modules/internal_chargepoint_handler/clients.py
+++ b/packages/modules/internal_chargepoint_handler/clients.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from pathlib import Path
 from typing import List, NamedTuple, Optional, Tuple, Union
 
@@ -78,6 +79,7 @@ class ClientHandler:
         except Exception:
             evse_check = False
         try:
+            time.sleep(0.1)
             if self.meter_client.get_voltages()[0] > 200:
                 meter_check = True
             else:


### PR DESCRIPTION
Bei meiner openWB series2 standard+ mit b23-Zähler scheint es ein Timingproblem beim Hardwarecheck zu geben. Im Log der internen Ladepunktes mit dem Eintrag:
"AttributeError: 'InternalChargepointHandler' object has no attribute 'cp0'"

Dies führt dazu, dass es zum Teil Stunden (viele Versuche im 5 Minuten Intervall) benötigt, bis der Zähler beim Hardwarecheck erkannt wird. Ein sleep von 0.1s vor dem Hardwarecheck des Zählers scheint das Problem bei mir zu lösen.

Getestet nur auf meiner openWB.