### PR TITLE
Fix parent cp

### DIFF
--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -794,7 +794,7 @@ class ProcessBrokerBranch:
                 topic = type_to_topic_mapping(payload["type"])
                 data.data.counter_all_data.hierarchy_remove_item(payload["id"])
                 client.subscribe(f'openWB/{topic}/{payload["id"]}/#', 2)
-            elif "openWB/chargepoint/" in msg.topic and "/config" in msg.topic:
+            elif re.search("openWB/chargepoint/[0-9]+/config$", msg.topic) is not None:
                 payload = decode_payload(msg.payload)
                 if payload["type"] == "external_openwb":
                     pub_single(

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -18,7 +18,7 @@ from helpermodules.data_migration.data_migration import MigrateData
 from helpermodules.measurement_logging.process_log import get_daily_log, get_monthly_log, get_yearly_log
 from helpermodules.messaging import MessageType, pub_user_message, pub_error_global
 from helpermodules.parse_send_debug import parse_send_debug_data
-from helpermodules.pub import Pub
+from helpermodules.pub import Pub, pub_single
 from helpermodules.subdata import SubData
 from helpermodules.utils.topic_parser import decode_payload
 from control import bat, bridge, chargelog, data, ev, counter, counter_all, pv
@@ -794,6 +794,13 @@ class ProcessBrokerBranch:
                 topic = type_to_topic_mapping(payload["type"])
                 data.data.counter_all_data.hierarchy_remove_item(payload["id"])
                 client.subscribe(f'openWB/{topic}/{payload["id"]}/#', 2)
+            elif "openWB/chargepoint/" in msg.topic and "/config" in msg.topic:
+                payload = decode_payload(msg.payload)
+                if payload["type"] == "external_openwb":
+                    pub_single(
+                        f'openWB/set/internal_chargepoint/{payload["configuration"]["duo_num"]}/data/parent_cp',
+                        None,
+                        hostname=payload["configuration"]["ip_address"])
 
     def __on_message_max_id(self, client, userdata, msg):
         self.received_topics.append(msg.topic)

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -1022,10 +1022,16 @@ class SetData:
             if "data/cp_interruption_duration" in msg.topic:
                 self._validate_value(msg, int, [(0, float("inf"))])
             elif "data/parent_cp" in msg.topic:
-                for cp in subdata.SubData.cp_data.values():
-                    if cp.chargepoint.data.config.type == "internal_openwb":
-                        if int(get_index(msg.topic)) == cp.chargepoint.data.config.configuration["duo_num"]:
-                            self._validate_value(msg, str)
+                if decode_payload(msg.payload) is None:
+                    self._validate_value(msg, str)
+                else:
+                    for cp in subdata.SubData.cp_data.values():
+                        if cp.chargepoint.data.config.type == "internal_openwb":
+                            if int(get_index(msg.topic)) == cp.chargepoint.data.config.configuration["duo_num"]:
+                                self._validate_value(msg, str)
+                                break
+                    else:
+                        log.error("Kein interner Ladepunkt konfiguriert, dem ein parent_cp zugeordnet werden kann.")
             elif "data/set_current" in msg.topic:
                 self._validate_value(msg, float, [(0, 0), (6, 32)])
             elif "data/phases_to_use" in msg.topic:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -1024,7 +1024,7 @@ class SetData:
             elif "data/parent_cp" in msg.topic:
                 for cp in subdata.SubData.cp_data.values():
                     if cp.chargepoint.data.config.type == "internal_openwb":
-                        if get_index(msg.topic) == cp.chargepoint.data.config.configuration.duo_num:
+                        if int(get_index(msg.topic)) == cp.chargepoint.data.config.configuration["duo_num"]:
                             self._validate_value(msg, str)
             elif "data/set_current" in msg.topic:
                 self._validate_value(msg, float, [(0, 0), (6, 32)])

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -1022,7 +1022,10 @@ class SetData:
             if "data/cp_interruption_duration" in msg.topic:
                 self._validate_value(msg, int, [(0, float("inf"))])
             elif "data/parent_cp" in msg.topic:
-                self._validate_value(msg, str)
+                for cp in subdata.SubData.cp_data.values():
+                    if cp.chargepoint.data.config.type == "internal_openwb":
+                        if get_index(msg.topic) == cp.chargepoint.data.config.configuration.duo_num:
+                            self._validate_value(msg, str)
             elif "data/set_current" in msg.topic:
                 self._validate_value(msg, float, [(0, 0), (6, 32)])
             elif "data/phases_to_use" in msg.topic:


### PR DESCRIPTION
Eine ID für parent_cp wird nur als gültig erkannt, wenn ein entsprechender interner Ladepunkt konfiguriert ist.
parent_cp wird beim Löschen des externen Ladepunkts auf der primary auf der secondary auf None gesetzt.