### PR TITLE
redirect instead of iframe

### DIFF
--- a/web/display/index.html
+++ b/web/display/index.html
@@ -13,7 +13,7 @@
 				// load mqtt library
 				'js/mqttws31.js',
 				// functions for processing messages
-				'display/processAllMqttMsg.js?ver=20230825',
+				'display/processAllMqttMsg.js?ver=20230925',
 				// functions performing mqtt and start mqtt-service
 				'display/setupMqttServices.js?ver=20230825',
 			];

--- a/web/display/processAllMqttMsg.js
+++ b/web/display/processAllMqttMsg.js
@@ -56,11 +56,12 @@ function setIframeSource() {
 			destination = `${location.protocol}//${host}/openWB/web/display/?${query.toString()}`;
 			if (destination != iframe.src) {
 				addLog(`all done, loading theme from primary`);
-				iframe.src = destination;
+				// iframe.src = destination;
 			}
 			setTimeout(() => {
-				startup.classList.add("hide");
-				iframe.classList.remove("hide");
+				// startup.classList.add("hide");
+				// iframe.classList.remove("hide");
+				location.href = destination;
 			}, 2000);
 		} else {
 			host = location.host;


### PR DESCRIPTION
Using an iframe for displaying the primary display will trigger third party cookie handling and this is blocked for some installations. This PR will drop the local wrapper and redirect to the primary display.

Unfortunately this will break display updates necessary for local changes on the secondary. This will be fixed later.