### PR TITLE
don't change rfid tag after charge start

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -741,24 +741,28 @@ class Chargepoint:
         msg = ""
         if self.data.get.rfid is not None:
             if data.data.optional_data.data.rfid.active:
-                rfid = self.data.get.rfid
-                if self.data.get.rfid_timestamp is None:
-                    self.data.get.rfid_timestamp = timecheck.create_timestamp()
-                    Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp",
-                              self.data.get.rfid_timestamp)
-                    return
-                else:
-                    if (timecheck.check_timestamp(self.data.get.rfid_timestamp, 300) or
-                            self.data.get.plug_state is True):
+                if (self.data.set.log.imported_at_plugtime == 0 or
+                        self.data.set.log.imported_at_plugtime == self.data.get.imported):
+                    rfid = self.data.get.rfid
+                    if self.data.get.rfid_timestamp is None:
+                        self.data.get.rfid_timestamp = timecheck.create_timestamp()
+                        Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp",
+                                  self.data.get.rfid_timestamp)
                         return
                     else:
-                        self.data.get.rfid_timestamp = None
-                        if rfid in self.template.data.valid_tags or len(self.template.data.valid_tags) == 0:
-                            Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp", None)
-                            msg = "Es ist in den letzten 5 Minuten kein EV angesteckt worden, dem " \
-                                f"der RFID-Tag/Code {rfid} zugeordnet werden kann. Daher wird dieser verworfen."
+                        if (timecheck.check_timestamp(self.data.get.rfid_timestamp, 300) or
+                                self.data.get.plug_state is True):
+                            return
                         else:
-                            msg = f"Der Tag {rfid} ist an diesem Ladepunkt nicht gültig."
+                            self.data.get.rfid_timestamp = None
+                            if rfid in self.template.data.valid_tags or len(self.template.data.valid_tags) == 0:
+                                Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp", None)
+                                msg = "Es ist in den letzten 5 Minuten kein EV angesteckt worden, dem " \
+                                    f"der RFID-Tag/Code {rfid} zugeordnet werden kann. Daher wird dieser verworfen."
+                            else:
+                                msg = f"Der Tag {rfid} ist an diesem Ladepunkt nicht gültig."
+                else:
+                    msg = "Nach Ladestart wird kein anderer RFID-Tag akzeptiert."
             else:
                 msg = "RFID ist nicht aktiviert."
             self.data.get.rfid = None


### PR DESCRIPTION
[https://openwb.de/forum/viewtopic.php?p=93374#p93374](https://openwb.de/forum/viewtopic.php?p=93374#p93374)

> D.h. wenn jemand während eines Ladevorganges einen unbekannten RFID-Code scannt, bringt der den Ladevorgang aus dem tritt.
Das sollte natürlich nicht so sein, der sollte einfach ignoriert werden, der Ladevorgang sollte dadurch nicht beeinflusst werden.