### PR TITLE
specify supported GoodWe devices

### DIFF
--- a/packages/modules/devices/good_we/config.py
+++ b/packages/modules/devices/good_we/config.py
@@ -11,7 +11,7 @@ class GoodWeConfiguration:
 
 class GoodWe:
     def __init__(self,
-                 name: str = "GoodWe",
+                 name: str = "GoodWe ET-Serie (5-10kW)",
                  type: str = "good_we",
                  id: int = 0,
                  configuration: GoodWeConfiguration = None) -> None:


### PR DESCRIPTION
#98188555
Nur GoodWe ET-Serie (5-10kW) bietet eine Modbus-Schnittstelle an. Geräte mit 15-30kW können nicht per Modbus abgefragt werden, da diese keine Modbus-Schnittstelle bereit stellen.