### PR TITLE
add unused evse current for pv charging

### DIFF
--- a/packages/control/algorithm/surplus_controlled.py
+++ b/packages/control/algorithm/surplus_controlled.py
@@ -51,6 +51,7 @@ class SurplusControlled:
             current = common.get_current_to_set(cp.data.set.current, available_for_cp, cp.data.set.target_current)
             self._set_loadmangement_message(current, limit, cp, counter)
             limited_current = self._limit_adjust_current(cp, current)
+            self._add_unused_evse_current(limited_current, cp)
             common.set_current_counterdiff(
                 limited_current - cp.data.set.charging_ev_data.ev_template.data.min_current,
                 limited_current,
@@ -103,6 +104,16 @@ class SurplusControlled:
                     msg = "Es darf um max 5A über den aktuell genutzten Strom geregelt werden."
             chargepoint.set_state_and_log(msg)
             return max(current, chargepoint.data.set.charging_ev_data.ev_template.data.min_current)
+
+    def _add_unused_evse_current(self, limited_current, chargepoint: Chargepoint) -> float:
+        """Wenn Autos nicht die volle Ladeleistung nutzen, wird unnötig eingespeist. Dann kann um den noch nicht
+        genutzten Sollstrom hochgeregelt werden."""
+        if chargepoint.data.get.evse_current:
+            current_with_offset = limited_current + \
+                max(chargepoint.data.get.evse_current - max(chargepoint.data.get.currents), 0)
+            return min(current_with_offset, chargepoint.data.control_parameter.required_current)
+        else:
+            return limited_current
 
     def check_submode_pv_charging(self) -> None:
         evu_counter = data.data.counter_all_data.get_evu_counter()

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -133,7 +133,7 @@ class Get:
     currents: List[float] = field(default_factory=currents_list_factory)
     daily_imported: float = 0
     daily_exported: float = 0
-    evse_current: float = 0
+    evse_current: Optional[float] = None
     exported: float = 0
     fault_str: str = "Kein Fehler."
     fault_state: int = 0


### PR DESCRIPTION
[PV - Ausregelung mit 2.X](https://openwb.de/forum/viewtopic.php?t=7635)
In 1.9 wurde berücksichtigt, wenn bei PV-Laden das Auto nicht die gesamte Sollstromstärke genutzt hat. Dann wird um den noch nicht genutzten Sollstrom hochgeregelt.