### PR TITLE
split rct requests by module

### DIFF
--- a/packages/modules/devices/rct/bat.py
+++ b/packages/modules/devices/rct/bat.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
@@ -6,6 +7,8 @@ from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_bat_value_store
 from modules.devices.rct.config import RctBatSetup
 from modules.devices.rct.rct_lib import RCT
+
+log = logging.getLogger(__name__)
 
 
 class RctBat:
@@ -27,15 +30,18 @@ class RctBat:
         # read all parameters
         rct_client.read(my_tab)
 
-        if (stat1.value + stat2.value + stat3.value) > 0:
-            raise FaultState.error("Alarm Status Speicher ist ungleich 0.")
-
         bat_state = BatState(
             power=watt1.value * -1,
             soc=socx.value * 100,
             imported=watt2.value,
             exported=watt3.value
         )
+        if (stat1.value + stat2.value + stat3.value) > 0:
+            log.debug(f"BatState: {bat_state}")
+            raise FaultState.error(
+                f"Alarm Status Speicher ist ungleich 0. Status 1: {stat1.value}, Status 2: {stat2.value}, "
+                f"Status 3: {stat3.value},")
+
         self.store.set(bat_state)
 
 

--- a/packages/modules/devices/rct/counter.py
+++ b/packages/modules/devices/rct/counter.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
@@ -6,6 +7,8 @@ from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 from modules.devices.rct.config import RctCounterSetup
 from modules.devices.rct.rct_lib import RCT
+
+log = logging.getLogger(__name__)
 
 
 class RctCounter:
@@ -35,9 +38,6 @@ class RctCounter:
         # read all parameters
         rct_client.read(my_tab)
 
-        if (stat1.value + stat2.value + stat3.value + stat4.value) > 0:
-            raise FaultState.error("Alarm Status Zähler ist ungleich 0.")
-
         counter_state = CounterState(
             imported=imported.value,
             exported=exported.value*-1.0,
@@ -46,6 +46,12 @@ class RctCounter:
             powers=[power1.value, power2.value, power3.value],
             voltages=[volt1.value, volt2.value, volt3.value]
         )
+        if (stat1.value + stat2.value + stat3.value + stat4.value) > 0:
+            log.debug(f"CounterState: {counter_state}")
+            raise FaultState.error(
+                f"Alarm Status Speicher ist ungleich 0. Status 1: {stat1.value}, Status 2: {stat2.value}, "
+                f"Status 3: {stat3.value}, Status 4: {stat4.value},")
+
         self.store.set(counter_state)
 
 

--- a/packages/modules/devices/rct/device.py
+++ b/packages/modules/devices/rct/device.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import logging
-from typing import Iterable, Optional, Union, List
+from typing import Callable, Optional, List
 
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import DeviceDescriptor
-from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
+from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, IndependentComponentUpdater
 from modules.devices.rct import bat, counter, inverter, rct_lib
 from modules.devices.rct.bat import RctBat
 from modules.devices.rct.config import Rct, RctConfiguration, RctBatSetup, RctCounterSetup, RctInverterSetup
@@ -24,12 +24,11 @@ def create_device(device_config: Rct):
     def create_inverter_component(component_config: RctInverterSetup):
         return RctInverter(component_config)
 
-    def update_components(components: Iterable[Union[RctBat, RctCounter, RctInverter]]):
+    def update_component(update_func: Callable[[rct_lib.RCT], None]):
         try:
             rct = rct_lib.RCT(device_config.configuration.ip_address)
             if rct.connect_to_server():
-                for component in components:
-                    component.update(rct)
+                update_func(rct)
         except Exception:
             raise
         finally:
@@ -42,7 +41,7 @@ def create_device(device_config: Rct):
             counter=create_counter_component,
             inverter=create_inverter_component,
         ),
-        component_updater=MultiComponentUpdater(update_components)
+        component_updater=IndependentComponentUpdater(lambda component: update_component(component.update)),
     )
 
 


### PR DESCRIPTION
[https://openwb.de/forum/viewtopic.php?t=7645](https://openwb.de/forum/viewtopic.php?t=7645)
- RCT-Komponenten werden unabhänging voneinander abgefragt, d.h. es wird nacheinander je Komponente eine Verbindung zum RCT aufgebaut und wieder geschlossen.
- Loggen des Fehlercodes
- Loggen der Werte, die vor dem Fehlercode abgefragt wurden.