### PR TITLE
catch: no cp behind counter

### DIFF
--- a/packages/control/counter_all.py
+++ b/packages/control/counter_all.py
@@ -189,7 +189,10 @@ class CounterAll:
                 self.data.get.hierarchy[0],
                 int(counter[7:]),
                 self.__get_entry_of_element)
-        self._get_all_cp_connected_to_counter(counter_object)
+        try:
+            self._get_all_cp_connected_to_counter(counter_object)
+        except KeyError:
+            log.debug(f"Kein Ladepunkt unter Zähler {counter}.")
         return self.connected_chargepoints
 
     def _get_all_cp_connected_to_counter(self, child: Dict) -> None:


### PR DESCRIPTION
Der LP wird gesperrt, weil der Zähler keine Daten liefert. Wie vorgeschlagen, konfiguriert der Kunde einen virtuellen Zähler und schiebt die LP darunter und den vorhandenen Zähler auf der gleichen Ebene unterhalb des virtuellen Zählers. Der virtueller Zähler ist dann EVU-Zähler, aber wegen einer Fehlermeldung konnte nicht geladen werden. Wenn man den vorhandenen Zähler nicht löschen muss, kann man sehen, wenn wieder Daten kommen.
#84271997