### PR TITLE
fix pro rfid enabling

### DIFF
--- a/packages/control/chargepoint/chargepoint_template.py
+++ b/packages/control/chargepoint/chargepoint_template.py
@@ -90,9 +90,13 @@ class CpTemplate:
             if data.data.optional_data.data.rfid.active and rfid is not None:
                 vehicle = ev_module.get_ev_to_rfid(rfid)
                 if vehicle is None:
-                    num = -1
-                    message = "Keine Ladung, da dem RFID-Tag " + \
-                        str(rfid)+" kein Fahrzeug-Profil zugeordnet werden kann."
+                    if self.data.rfid_enabling:
+                        num = -1
+                        message = (
+                            f"Keine Ladung, da dem RFID-Tag {rfid} kein Fahrzeug-Profil zugeordnet werden kann. Eine "
+                            "Freischaltung ist nur per RFID/Fahrzeugerkennung möglich.")
+                    else:
+                        num = assigned_ev
                 else:
                     num = vehicle
             else:


### PR DESCRIPTION
#41119024
[https://openwb.de/forum/viewtopic.php?t=7771](https://openwb.de/forum/viewtopic.php?t=7771)
Wenn Freischaltung durch RFID deaktiviert ist und der gescannte Tag/erkannte Fahrzeug-Mac nicht zugeordnet werden kann, kann per Hand ein anderes Profil ausgewählt werden, solange noch nicht geladen wurde bzw im bereits ausgewählten geladen werden.