### PR TITLE
rct sends data even if it is in fault state

### DIFF
--- a/packages/control/bat_all.py
+++ b/packages/control/bat_all.py
@@ -104,10 +104,10 @@ class BatAll:
                         soc_count += 1
                         if self.data.get.fault_state < battery.data.get.fault_state:
                             self.data.get.fault_state = battery.data.get.fault_state
-                            self.data.get.fault_str = ("Speicher-Leistung wird nicht in der Regelung berücksichtigt, da"
-                                                       " in einer der Batterie-Komponenten eine Warnung oder ein Fehler"
-                                                       " aufgetreten ist. Bitte die Status-Meldungen der "
-                                                       "Batterie-Komponenten prüfen.")
+                            self.data.get.fault_str = (
+                                "Speicher-Leistung wird nicht in der Regelung berücksichtigt, da in einer der "
+                                "Batterie-Komponenten eine Warnung (zB während der Kalibrierung) oder ein Fehler "
+                                "aufgetreten ist. Bitte die Status-Meldungen der Batterie-Komponenten prüfen.")
                     except Exception:
                         log.exception(f"Fehler im Bat-Modul {battery.num}")
                 self.data.get.soc = int(soc_sum / soc_count)

--- a/packages/helpermodules/changed_values_handler.py
+++ b/packages/helpermodules/changed_values_handler.py
@@ -74,6 +74,7 @@ class ChangedValuesHandler:
 
     def pub_changed_values(self):
         # publishen der geänderten Werte
+        self._update_value("openWB/set/bat/", self.prev_data.bat_all_data.data.get, data.data.bat_all_data.data.get)
         for key, value in data.data.cp_data.items():
             self._update_value(f"openWB/set/chargepoint/{value.num}/", self.prev_data.cp_data[key].data, value.data)
 

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -666,6 +666,10 @@ class SetData:
                     "openWB/set/bat/get/daily_exported" in msg.topic or
                     "openWB/set/bat/get/daily_imported" in msg.topic):
                 self._validate_value(msg, float, [(0, float("inf"))])
+            elif "openWB/set/bat/get/fault_state" in msg.topic:
+                self._validate_value(msg, int, [(0, 2)])
+            elif "openWB/set/bat/get/fault_str" in msg.topic:
+                self._validate_value(msg, str)
             elif "/config" in msg.topic:
                 self._validate_value(msg, "json")
             elif "/get/power" in msg.topic:

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -34,6 +34,8 @@ class UpdateConfig:
         "^openWB/bat/config/configured$",
         "^openWB/bat/set/charging_power_left$",
         "^openWB/bat/set/switch_on_soc_reached$",
+        "^openWB/bat/get/fault_state$",
+        "^openWB/bat/get/fault_str$",
         "^openWB/bat/get/soc$",
         "^openWB/bat/get/power$",
         "^openWB/bat/get/imported$",

--- a/packages/main.py
+++ b/packages/main.py
@@ -50,6 +50,7 @@ class HandlerAlgorithm:
                 if (data.data.general_data.data.control_interval / 10) == self.interval_counter:
                     data.data.copy_data()
                     loadvars_.get_values()
+                    changed_values_handler.pub_changed_values()
                     data.data.copy_data()
                     changed_values_handler.store_inital_values()
                     self.heartbeat = True
@@ -231,6 +232,7 @@ try:
     event_update_config_completed.wait(300)
     Pub().pub("openWB/set/system/boot_done", True)
     Path(Path(__file__).resolve().parents[1]/"ramdisk"/"bootdone").touch()
+    changed_values_handler.store_inital_values()
     schedule_jobs()
 except Exception:
     log.exception("Fehler im Main-Modul")

--- a/packages/modules/devices/rct/bat.py
+++ b/packages/modules/devices/rct/bat.py
@@ -36,13 +36,11 @@ class RctBat:
             imported=watt2.value,
             exported=watt3.value
         )
+        self.store.set(bat_state)
         if (stat1.value + stat2.value + stat3.value) > 0:
-            log.debug(f"BatState: {bat_state}")
-            raise FaultState.error(
+            raise FaultState.warning(
                 f"Alarm Status Speicher ist ungleich 0. Status 1: {stat1.value}, Status 2: {stat2.value}, "
                 f"Status 3: {stat3.value},")
-
-        self.store.set(bat_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=RctBatSetup)

--- a/packages/modules/devices/rct/bat.py
+++ b/packages/modules/devices/rct/bat.py
@@ -38,6 +38,7 @@ class RctBat:
         )
         self.store.set(bat_state)
         if (stat1.value + stat2.value + stat3.value) > 0:
+            # Werte werden trotz Fehlercode übermittelt.
             raise FaultState.warning(
                 f"Alarm Status Speicher ist ungleich 0. Status 1: {stat1.value}, Status 2: {stat2.value}, "
                 f"Status 3: {stat3.value},")

--- a/packages/modules/devices/rct/counter.py
+++ b/packages/modules/devices/rct/counter.py
@@ -46,13 +46,11 @@ class RctCounter:
             powers=[power1.value, power2.value, power3.value],
             voltages=[volt1.value, volt2.value, volt3.value]
         )
+        self.store.set(counter_state)
         if (stat1.value + stat2.value + stat3.value + stat4.value) > 0:
-            log.debug(f"CounterState: {counter_state}")
-            raise FaultState.error(
+            raise FaultState.warning(
                 f"Alarm Status Speicher ist ungleich 0. Status 1: {stat1.value}, Status 2: {stat2.value}, "
                 f"Status 3: {stat3.value}, Status 4: {stat4.value},")
-
-        self.store.set(counter_state)
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=RctCounterSetup)

--- a/packages/modules/devices/rct/counter.py
+++ b/packages/modules/devices/rct/counter.py
@@ -48,6 +48,7 @@ class RctCounter:
         )
         self.store.set(counter_state)
         if (stat1.value + stat2.value + stat3.value + stat4.value) > 0:
+            # Werte werden trotz Fehlercode übermittelt.
             raise FaultState.warning(
                 f"Alarm Status Speicher ist ungleich 0. Status 1: {stat1.value}, Status 2: {stat2.value}, "
                 f"Status 3: {stat3.value}, Status 4: {stat4.value},")


### PR DESCRIPTION
RCT liefert auch während der Kalibrierung aktuelle Werte.
[https://github.com/openWB/core/commit/d60c4bb9b4469e653a875d5f13af6164ac8bdd62#commitcomment-131063954](https://github.com/openWB/core/commit/d60c4bb9b4469e653a875d5f13af6164ac8bdd62#commitcomment-131063954)
#80397182
Bei Warnung oder Fehlerfall, zB durch Kalibierungs-Meldung, Speicher-Leistung nicht in der Regelung berücksichtigen.
UI [https://github.com/openWB/openwb-ui-settings/pull/376](https://github.com/openWB/openwb-ui-settings/pull/376)