### PR TITLE
Failed phase switches

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -257,6 +257,7 @@ class ChargepointData:
 class Chargepoint:
     """ geht alle Ladepunkte durch, prüft, ob geladen werden darf und ruft die Funktion des angesteckten Autos auf.
     """
+    MAX_FAILED_PHASE_SWITCHES = 3
 
     def __init__(self, index: int, event: Optional[threading.Event]):
         try:
@@ -529,7 +530,12 @@ class Chargepoint:
         except Exception:
             log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num))
 
-    def _is_phase_switch_required(self, charging_ev: Ev) -> bool:
+    def _is_phase_switch_failed(self) -> None:
+        if self.data.set.phases_to_use != self.data.get.phases_in_use:
+            self.data.control_parameter.failed_phase_switches += 1
+
+    def _is_phase_switch_required(self) -> bool:
+        phase_switch_required = False
         # Manche EVs brauchen nach der Umschaltung mehrere Zyklen, bis sie mit den drei Phasen laden. Dann darf
         # nicht zwischendurch eine neue Umschaltung getriggert werden.
         if (self.data.control_parameter.state == ChargepointState.CHARGING_ALLOWED or
@@ -544,15 +550,24 @@ class Chargepoint:
                     ((self.data.set.current != 0 and self.data.get.power != 0) or
                      (self.data.set.current != 0 and self.set_current_prev == 0) or
                      self.data.set.current == 0)):
-                return True
+                phase_switch_required = True
         if (self.data.control_parameter.state == ChargepointState.NO_CHARGING_ALLOWED and
             (self.data.set.phases_to_use != self.data.get.phases_in_use or
                 # Vorgegebene Phasenzahl hat sich geändert
              self.data.set.phases_to_use != self.data.control_parameter.phases) and
                 # Wenn der Ladevorgang gestartet wird, muss vor dem ersten Laden umgeschaltet werden.
                 self.data.set.current != 0):
-            return True
-        return False
+            phase_switch_required = True
+        if phase_switch_required:
+            if data.data.general_data.data.chargemode_config.retry_failed_phase_switches:
+                if self.data.control_parameter.failed_phase_switches <= self.MAX_FAILED_PHASE_SWITCHES:
+                    self._is_phase_switch_failed()
+                else:
+                    phase_switch_required = False
+                    self.set_state_and_log(
+                        "Keine Phasenumschaltung, da die maximale Anzahl an Fehlversuchen erreicht wurde. Die aktuelle "
+                        "Phasenzahl wird bis zum Abstecken beibehalten.")
+        return phase_switch_required
 
     STOP_CHARGING = ", dafür wird die Ladung unterbrochen."
 
@@ -607,7 +622,7 @@ class Chargepoint:
                     Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/phases_to_use",
                               self.data.control_parameter.phases)
                     self.data.set.phases_to_use = self.data.control_parameter.phases
-                if self._is_phase_switch_required(charging_ev):
+                if self._is_phase_switch_required():
                     # Wenn die Umschaltverzögerung aktiv ist, darf nicht umgeschaltet werden.
                     if (self.data.control_parameter.state != ChargepointState.PERFORMING_PHASE_SWITCH and
                             self.data.control_parameter.state != ChargepointState.WAIT_FOR_USING_PHASES):

--- a/packages/control/chargepoint/control_parameter.py
+++ b/packages/control/chargepoint/control_parameter.py
@@ -15,6 +15,9 @@ class ControlParameter:
     current_plan: Optional[str] = field(
         default=None,
         metadata={"topic": "control_parameter/current_plan", "mutable_by_algorithm": True})
+    failed_phase_switches: int = field(
+        default=0,
+        metadata={"topic": "control_parameter/failed_phase_switches", "mutable_by_algorithm": True})
     imported_at_plan_start: Optional[float] = field(
         default=None,
         metadata={"topic": "control_parameter/imported_at_plan_start", "mutable_by_algorithm": True})

--- a/packages/control/general.py
+++ b/packages/control/general.py
@@ -71,6 +71,7 @@ def time_charging_factory() -> TimeCharging:
 class ChargemodeConfig:
     instant_charging: InstantCharging = field(default_factory=instant_charging_factory)
     pv_charging: PvCharging = field(default_factory=pv_charging_factory)
+    retry_failed_phase_switches = False
     scheduled_charging: ScheduledCharging = field(default_factory=scheduled_charging_factory)
     time_charging: TimeCharging = field(default_factory=time_charging_factory)
     unbalanced_load_limit: int = 18

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -535,6 +535,8 @@ class SetData:
                     self._validate_value(msg, float, [(6, 32), (0, 0)])
                 elif "/control_parameter/phases" in msg.topic:
                     self._validate_value(msg, int, [(0, 3)])
+                elif "/control_parameter/failed_phase_switches" in msg.topic:
+                    self._validate_value(msg, int, [(0, 4)])
                 elif ("/control_parameter/submode" in msg.topic or
                         "/control_parameter/limit" in msg.topic or
                         "/control_parameter/chargemode" in msg.topic):
@@ -710,7 +712,8 @@ class SetData:
                 self._validate_value(msg, bool)
             elif "openWB/set/general/chargemode_config/unbalanced_load_limit" in msg.topic:
                 self._validate_value(msg, int, [(10, 32)])
-            elif "openWB/set/general/chargemode_config/unbalanced_load" in msg.topic:
+            elif ("openWB/set/general/chargemode_config/unbalanced_load" in msg.topic or
+                  "openWB/set/general/chargemode_config/retry_failed_phase_switches" in msg.topic):
                 self._validate_value(msg, bool)
             elif ("openWB/set/general/chargemode_config/pv_charging/feed_in_yield" in msg.topic or
                     "openWB/set/general/chargemode_config/pv_charging/switch_on_threshold" in msg.topic or

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -8,6 +8,7 @@ import subprocess
 import time
 from typing import List
 from paho.mqtt.client import Client as MqttClient, MQTTMessage
+from control.general import ChargemodeConfig
 import dataclass_utils
 
 from control.chargepoint.chargepoint_template import get_chargepoint_template_default
@@ -176,6 +177,7 @@ class UpdateConfig:
         "^openWB/general/chargemode_config/pv_charging/rundown_soc$",
         "^openWB/general/chargemode_config/pv_charging/rundown_power$",
         "^openWB/general/chargemode_config/pv_charging/charging_power_reserve$",
+        "^openWB/general/chargemode_config/retry_failed_phase_switches$",
         "^openWB/general/chargemode_config/scheduled_charging/phases_to_use$",
         "^openWB/general/chargemode_config/instant_charging/phases_to_use$",
         "^openWB/general/chargemode_config/time_charging/phases_to_use$",
@@ -394,6 +396,8 @@ class UpdateConfig:
         ("openWB/general/chargemode_config/pv_charging/feed_in_yield", 15000),
         ("openWB/general/chargemode_config/pv_charging/phase_switch_delay", 7),
         ("openWB/general/chargemode_config/pv_charging/phases_to_use", 1),
+        ("openWB/general/chargemode_config/retry_failed_phase_switches",
+         ChargemodeConfig().retry_failed_phase_switches),
         ("openWB/general/chargemode_config/scheduled_charging/phases_to_use", 0),
         ("openWB/general/chargemode_config/time_charging/phases_to_use", 1),
         ("openWB/general/chargemode_config/unbalanced_load", False),


### PR DESCRIPTION
Wenn diese Option aktiviert ist, werden bis zu drei
Umschaltversuche vorgenommen, wenn die vorgegebene
und genutzte Phasenzahl nicht übereinstimmen. Wird
die Option deaktiviert, wird nur eine Umschaltung
durchgeführt.
Die gezählten Fehlversuche werden mit dem Abstecken
zurückgesetzt.

UI [https://github.com/openWB/openwb-ui-settings/pull/377](https://github.com/openWB/openwb-ui-settings/pull/377)