### PR TITLE
Kostal Plenticore device.py für Hybrid-WR geändert

### DIFF
--- a/packages/modules/devices/kostal_plenticore/device.py
+++ b/packages/modules/devices/kostal_plenticore/device.py
@@ -36,34 +36,9 @@ def update(
     bat_state = battery.read_state(reader) if battery else None
     for component in components:
         if isinstance(component, KostalPlenticoreInverter):
-            inverter_state = component.read_state(reader)
-            if bat_state:
-                dc_in = component.dc_in_string_1_2(reader)
-                if dc_in >= 0:
-                    # Wird PV-DC-Leistung erzeugt, müssen die Wandlungsverluste betrachtet werden.
-                    # Kostal liefert nur DC-seitige Werte.
-                    if bat_state.power < 0:
-                        # Wird die Batterie entladen, werden die Wandlungsverluste anteilig an der DC-Leistung auf PV
-                        # und Batterie verteilt. Dazu muss der Divisor Total_DC_power != 0 sein.
-                        power_gross = dc_in - bat_state.power
-                        pv_state = InverterState(power=dc_in / power_gross * inverter_state.power,
-                                                 exported=inverter_state.exported)
-                    else:
-                        # Wenn die Batterie geladen wird, dann ist PV-Leistung die Wechselrichter-AC-Leistung + die
-                        # Ladeleistung der Batterie. Die PV-Leistung ist die Summe aus verlustbehafteter
-                        # AC-Leistungsabgabe des WR und der DC-Ladeleistung. Die Wandlungsverluste werden also nur
-                        # in der PV-Leistung ersichtlich.
-                        pv_state = InverterState(power=inverter_state.power - bat_state.power,
-                                                 exported=inverter_state.exported)
-                    # https://github.com/snaptec/openWB/pull/2440#discussion_r996275286
-                    # power_gross = bat_state.power + dc_in
-                    # bat_state_gross = BatteryState(power=bat_state_net.power / power_gross * inverter_state.power)
-                    # pv_state = InverterState(power=inverter_state.power - bat_state_gross.power)
-                else:
-                    inverter_state.power = 0
-                    pv_state = inverter_state
-            else:
-                pv_state = inverter_state
+            # Fürs erste nur die WR-Werte nutzen ohne Verlustberechnung.
+            inverter_state = component.read_state(reader)    #power=R575(inverter generation power (actual)), exported=R320 (Total yield)
+            pv_state = inverter_state
             if set_inverter_state:
                 component.update(pv_state)
         elif isinstance(component, KostalPlenticoreCounter):

--- a/packages/modules/devices/kostal_plenticore/device.py
+++ b/packages/modules/devices/kostal_plenticore/device.py
@@ -37,7 +37,9 @@ def update(
     for component in components:
         if isinstance(component, KostalPlenticoreInverter):
             # Fürs erste nur die WR-Werte nutzen ohne Verlustberechnung.
-            inverter_state = component.read_state(reader)    #power=R575(inverter generation power (actual)), exported=R320 (Total yield)
+            # power: R575(inverter generation power (actual))
+            # exported: R320 (Total yield)
+            inverter_state = component.read_state(reader)
             pv_state = inverter_state
             if set_inverter_state:
                 component.update(pv_state)


### PR DESCRIPTION
Siehe auch Issue #1201.
Bisher musste die Batterie für einen Kostal Plenticore in der Struktur parallel zum Inverter angeordnet werden, damit die Leistungen passen. Dann stimmen allerdings die Zähler nicht und in der Auswertung wird Batterieentladung nachts als PV-Leistung angezeigt.
Durch einfaches Durchreichen von inverter_status nach pv_status stimmen beide Sachverhalte, sofern der Speicher als Untergerät vom Wechselrichter angeordnet wird wie im Wiki beschrieben.

Möglicherweise müssen die Leistungen noch korrigiert werden, ich nehme an, die weggefallenen Korrekturen hatten einen Grund. Ich konnte allerdings bisher keine Probleme oder Unstimmigkeiten feststellen.

--mein erster Pull-Request--