### PR TITLE
fix late bat values

### DIFF
--- a/packages/main.py
+++ b/packages/main.py
@@ -30,6 +30,7 @@ from helpermodules.utils import exit_after
 from modules import update_soc
 from modules.internal_chargepoint_handler.internal_chargepoint_handler import GeneralInternalChargepointHandler
 from modules.internal_chargepoint_handler.rfid import RfidReader
+from modules.utils import wait_for_module_update_completed
 from smarthome.smarthome import readmq, smarthome_handler
 
 logger.setup_logging()
@@ -51,6 +52,8 @@ class HandlerAlgorithm:
                     data.data.copy_data()
                     loadvars_.get_values()
                     changed_values_handler.pub_changed_values()
+                    wait_for_module_update_completed(loadvars_.event_module_update_completed,
+                                                     "openWB/set/system/device/module_update_completed")
                     data.data.copy_data()
                     changed_values_handler.store_inital_values()
                     self.heartbeat = True

--- a/packages/modules/update_soc.py
+++ b/packages/modules/update_soc.py
@@ -12,7 +12,7 @@ from helpermodules.constants import NO_ERROR
 from helpermodules.pub import Pub
 from helpermodules.utils import thread_handler
 from modules.common.abstract_vehicle import VehicleUpdateData
-from modules.utils import ModuleUpdateCompletedContext
+from modules.utils import wait_for_module_update_completed
 
 log = logging.getLogger(__name__)
 
@@ -28,12 +28,12 @@ class UpdateSoc:
             topic = "openWB/set/vehicle/set/vehicle_update_completed"
             try:
                 threads_update, threads_store = self._get_threads()
-                with ModuleUpdateCompletedContext(self.event_vehicle_update_completed, topic):
-                    threads_update, threads_store = self._get_threads()
-                    thread_handler(threads_update, 300)
-                with ModuleUpdateCompletedContext(self.event_vehicle_update_completed, topic):
-                    # threads_store = self._filter_failed_store_threads(threads_store)
-                    thread_handler(threads_store, data.data.general_data.data.control_interval/3)
+                threads_update, threads_store = self._get_threads()
+                thread_handler(threads_update, 300)
+                wait_for_module_update_completed(self.event_vehicle_update_completed, topic)
+                # threads_store = self._filter_failed_store_threads(threads_store)
+                thread_handler(threads_store, data.data.general_data.data.control_interval/3)
+                wait_for_module_update_completed(self.event_vehicle_update_completed, topic)
                 # Don't request faster than control interval
                 if len(threads_update) > 0:
                     time.sleep(5)

--- a/packages/modules/utils.py
+++ b/packages/modules/utils.py
@@ -7,18 +7,9 @@ from helpermodules import pub
 log = logging.getLogger(__name__)
 
 
-class ModuleUpdateCompletedContext:
-    def __init__(self, event_module_update_completed: threading.Event, topic: str):
-        self.event_module_update_completed = event_module_update_completed
-        self.topic = topic
-
-    def __enter__(self):
-        timeout = data.data.general_data.data.control_interval/2
-        if self.event_module_update_completed.wait(timeout) is False:
-            log.error("Daten wurden noch nicht vollständig empfangen. Timeout abgelaufen, fortsetzen der Regelung.")
-        return None
-
-    def __exit__(self, exception_type, exception, exception_traceback) -> bool:
-        self.event_module_update_completed.clear()
-        pub.Pub().pub(self.topic, True)
-        return True
+def wait_for_module_update_completed(event_module_update_completed: threading.Event, topic: str):
+    timeout = data.data.general_data.data.control_interval/2
+    event_module_update_completed.clear()
+    pub.Pub().pub(topic, True)
+    if event_module_update_completed.wait(timeout) is False:
+        log.error("Daten wurden noch nicht vollständig empfangen. Timeout abgelaufen, fortsetzen der Regelung.")


### PR DESCRIPTION
[https://openwb.de/forum/viewtopic.php?p=96174#p96174](https://openwb.de/forum/viewtopic.php?p=96174#p96174)

Die Werte werden in data.data Struktur kopiert, bevor sie aus dem pub_changed_values-Handler in der subdata gelandet sind. Jetzt wird auf diese Werte gewartet.