### PR TITLE
Switch to multiple phases if soc < min_soc during in automatic mode

### DIFF
--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -400,8 +400,8 @@ class Ev:
                              all_surplus > self.ev_template.data.min_current * max_phases_ev * 230
                              - get_power) or limit == LimitingValue.UNBALANCED_LOAD.value) and
                             phases_in_use == 1)
-        condition_3_to_1 = (min_soc == 0 or (min_soc != 0 and soc >= min_soc)) and
-                            max(get_currents) < min_current and all_surplus <= 0 and phases_in_use > 1
+        condition_3_to_1 = ((min_soc == 0 or (min_soc != 0 and soc >= min_soc)) and
+                            max(get_currents) < min_current and all_surplus <= 0 and phases_in_use > 1)
         if condition_1_to_3 or condition_3_to_1:
             return True, None
         else:

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -397,10 +397,11 @@ class Ev:
         log.debug(f'min_soc: {min_soc}%, soc: {soc}%')
         condition_1_to_3 = ((min_soc != 0 and soc < min_soc) or
                             ((max(get_currents) > max_current and
-                            all_surplus > self.ev_template.data.min_current * max_phases_ev * 230
-                            - get_power) or limit == LimitingValue.UNBALANCED_LOAD.value) and
+                             all_surplus > self.ev_template.data.min_current * max_phases_ev * 230
+                             - get_power) or limit == LimitingValue.UNBALANCED_LOAD.value) and
                             phases_in_use == 1)
-        condition_3_to_1 = (min_soc == 0 or (min_soc != 0 and soc >= min_soc)) and max(get_currents) < min_current and all_surplus <= 0 and phases_in_use > 1
+        condition_3_to_1 = (min_soc == 0 or (min_soc != 0 and soc >= min_soc)) and
+                            max(get_currents) < min_current and all_surplus <= 0 and phases_in_use > 1
         if condition_1_to_3 or condition_3_to_1:
             return True, None
         else:


### PR DESCRIPTION
During pv charging all allowed phases should be used if soc < min_soc and number of phases is set to automatic.