### PR TITLE
fix soc set to 0

### DIFF
--- a/packages/modules/common/configurable_vehicle.py
+++ b/packages/modules/common/configurable_vehicle.py
@@ -68,8 +68,7 @@ class ConfigurableVehicle(Generic[T_VEHICLE_CONFIG]):
 
             if source != SocSource.CALCULATION:
                 # Wenn nicht berechnet wurde, SoC als Start merken.
-                if self.calculated_soc_state.soc_start != car_state.soc:
-                    self.calculated_soc_state.imported_start = vehicle_update_data.imported
+                self.calculated_soc_state.imported_start = vehicle_update_data.imported
                 self.calculated_soc_state.soc_start = car_state.soc
                 Pub().pub(f"openWB/set/vehicle/{self.vehicle}/soc_module/calculated_soc_state",
                           asdict(self.calculated_soc_state))


### PR DESCRIPTION
[https://openwb.de/forum/viewtopic.php?p=97387#p97387](https://openwb.de/forum/viewtopic.php?p=97387#p97387)
Issue #1097 
Wenn der SoC bereits vor dem Anstecken/Zuordnen zum Ladepunkt den gleichen Wert wie bei der nach Anstecken/Zuordnen getriggerten Abfrage, wurde imported_start nicht aktualisiert.