### PR TITLE
Fault state handling

### DIFF
--- a/docs/samples/sample_modbus/bat.py
+++ b/docs/samples/sample_modbus/bat.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -15,7 +15,7 @@ class SampleBat:
         self.component_config = dataclass_from_dict(SampleBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_) -> None:
         power = client.read_holding_registers(reg, ModbusDataType.INT_32, unit=unit)

--- a/docs/samples/sample_modbus/counter.py
+++ b/docs/samples/sample_modbus/counter.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -15,7 +15,7 @@ class SampleCounter:
         self.component_config = dataclass_from_dict(SampleCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_):
         power = client.read_holding_registers(reg, ModbusDataType.INT_32, unit=unit)

--- a/docs/samples/sample_modbus/device.py
+++ b/docs/samples/sample_modbus/device.py
@@ -29,7 +29,7 @@ def create_device(device_config: Sample):
     def update_components(components: Iterable[Union[SampleBat, SampleCounter, SampleInverter]]):
         with client as c:
             for component in components:
-                with SingleComponentUpdateContext(component.component_info):
+                with SingleComponentUpdateContext(component.fault_state):
                     component.update(c)
 
     try:

--- a/docs/samples/sample_modbus/inverter.py
+++ b/docs/samples/sample_modbus/inverter.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -15,7 +15,7 @@ class SampleInverter:
         self.component_config = dataclass_from_dict(SampleInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_) -> None:
         power = client.read_holding_registers(reg, ModbusDataType.INT_32, unit=unit)

--- a/docs/samples/sample_request_by_component/bat.py
+++ b/docs/samples/sample_request_by_component/bat.py
@@ -3,7 +3,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sample_request_by_component.config import SampleBatSetup, SampleConfiguration
@@ -16,7 +16,7 @@ class SampleBat:
         self.ip_address = ip_address
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         resp = req.get_http_session().get(self.ip_address)

--- a/docs/samples/sample_request_by_component/counter.py
+++ b/docs/samples/sample_request_by_component/counter.py
@@ -3,7 +3,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.sample_request_by_component.config import SampleCounterSetup, SampleConfiguration
@@ -16,7 +16,7 @@ class SampleCounter:
         self.ip_address = ip_address
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         resp = req.get_http_session().get(self.ip_address)

--- a/docs/samples/sample_request_by_component/inverter.py
+++ b/docs/samples/sample_request_by_component/inverter.py
@@ -3,7 +3,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.sample_request_by_component.config import SampleInverterSetup, SampleConfiguration
@@ -16,7 +16,7 @@ class SampleInverter:
         self.ip_address = ip_address
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         resp = req.get_http_session().get(self.ip_address)

--- a/docs/samples/sample_request_by_device/bat.py
+++ b/docs/samples/sample_request_by_device/bat.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sample_request_by_device.config import SampleBatSetup
@@ -14,7 +14,7 @@ class SampleBat:
         self.component_config = dataclass_from_dict(SampleBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         # hier die Werte aus der response parsen

--- a/docs/samples/sample_request_by_device/counter.py
+++ b/docs/samples/sample_request_by_device/counter.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.sample_request_by_device.config import SampleCounterSetup
@@ -14,7 +14,7 @@ class SampleCounter:
         self.component_config = dataclass_from_dict(SampleCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response):
         # hier die Werte aus der response parsen

--- a/docs/samples/sample_request_by_device/inverter.py
+++ b/docs/samples/sample_request_by_device/inverter.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.sample_request_by_device.config import SampleInverterSetup
@@ -14,7 +14,7 @@ class SampleInverter:
         self.component_config = dataclass_from_dict(SampleInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         # hier die Werte aus der response parsen

--- a/packages/helpermodules/exceptions/registry.py
+++ b/packages/helpermodules/exceptions/registry.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Type, Optional, Callable, TypeVar, Generic, List, Union, Any
 
-from modules.common import fault_state
+from modules.common.fault_state_level import FaultStateLevel
 
 T = TypeVar("T", bound=Exception)
 
@@ -22,16 +22,14 @@ class RegistryEntry(Generic[T]):
 class ExceptionRegistry:
     registry = []  # type: List[RegistryEntry]
 
-    def translate_exception(self, exception: Exception) -> "fault_state.FaultState":
+    def translate_exception(self, exception: Exception) -> [str, FaultStateLevel]:
         entry = self.find_registry_entry(exception)
         if entry is None:
-            return fault_state.FaultState.error("{} {}".format(type(exception), exception))
+            return "{} {}".format(type(exception), exception), FaultStateLevel.ERROR
         if isinstance(entry.handler, str):
-            return fault_state.FaultState.error(entry.handler)
+            return entry.handler, FaultStateLevel.ERROR
         result = entry.handler(exception)
-        if isinstance(result, fault_state.FaultState):
-            return result
-        return fault_state.FaultState.error(str(result))
+        return result, FaultStateLevel.ERROR
 
     def find_registry_entry(self, exception: Exception) -> Optional[RegistryEntry]:
         score = sys.maxsize

--- a/packages/helpermodules/exceptions/registry_test.py
+++ b/packages/helpermodules/exceptions/registry_test.py
@@ -49,7 +49,7 @@ def test_uses_exact_match_if_available(exception: Type, expected_message: str):
     actual = registry.translate_exception(exception())
 
     # evaluation
-    assert actual.fault_str == expected_message
+    assert actual[0] == expected_message
 
 
 @pytest.mark.parametrize("handler", [
@@ -66,5 +66,5 @@ def test_accepts_all_supported_formats(handler):
     actual = registry.translate_exception(Exception())
 
     # evaluation
-    assert isinstance(actual, FaultState)
-    assert actual.fault_str == "msg"
+    assert isinstance(actual[0], str)
+    assert actual[0] == "msg"

--- a/packages/modules/chargepoints/external_openwb/chargepoint_module.py
+++ b/packages/modules/chargepoints/external_openwb/chargepoint_module.py
@@ -7,22 +7,22 @@ from modules.chargepoints.external_openwb.config import OpenWBSeries
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_context import SingleComponentUpdateContext
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 
 
 class ChargepointModule(AbstractChargepoint):
     def __init__(self, config: OpenWBSeries) -> None:
         self.config = config
-        self.component_info = ComponentInfo(
+        self.fault_state = FaultState(ComponentInfo(
             self.config.id,
-            "Ladepunkt", "chargepoint")
+            "Ladepunkt", "chargepoint"))
         self.__client_error_context = ErrorCounterContext(
             "Anhaltender Fehler beim Auslesen des Ladepunkts. Soll-Stromstärke wird zurückgesetzt.")
 
     def set_current(self, current: float) -> None:
         if self.__client_error_context.error_counter_exceeded():
             current = 0
-        with SingleComponentUpdateContext(self.component_info, False):
+        with SingleComponentUpdateContext(self.fault_state, False):
             with self.__client_error_context:
                 if self.config.configuration.duo_num == 0:
                     pub.pub_single("openWB/set/internal_chargepoint/0/data/set_current", current,
@@ -36,7 +36,7 @@ class ChargepointModule(AbstractChargepoint):
                                    hostname=self.config.configuration.ip_address)
 
     def get_values(self) -> None:
-        with SingleComponentUpdateContext(self.component_info, update_always=False):
+        with SingleComponentUpdateContext(self.fault_state, update_always=False):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 num = self.config.id
@@ -59,7 +59,7 @@ class ChargepointModule(AbstractChargepoint):
                 self.__client_error_context.reset_error_counter()
 
     def switch_phases(self, phases_to_use: int, duration: int) -> None:
-        with SingleComponentUpdateContext(self.component_info, False):
+        with SingleComponentUpdateContext(self.fault_state, False):
             with self.__client_error_context:
                 pub.pub_single(
                     f"openWB/set/internal_chargepoint/{self.config.configuration.duo_num}/data/phases_to_use",
@@ -74,7 +74,7 @@ class ChargepointModule(AbstractChargepoint):
                 time.sleep(6+duration-1)
 
     def interrupt_cp(self, duration: int) -> None:
-        with SingleComponentUpdateContext(self.component_info, False):
+        with SingleComponentUpdateContext(self.fault_state, False):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 if (self.config.configuration.duo_num == 1):
@@ -88,7 +88,7 @@ class ChargepointModule(AbstractChargepoint):
                 time.sleep(duration)
 
     def clear_rfid(self) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 pub.pub_single("openWB/set/isss/ClearRfid", 1, hostname=ip_address)

--- a/packages/modules/chargepoints/mqtt/chargepoint_module.py
+++ b/packages/modules/chargepoints/mqtt/chargepoint_module.py
@@ -4,7 +4,7 @@ from modules.chargepoints.mqtt.config import Mqtt
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_context import SingleComponentUpdateContext
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 
 log = logging.getLogger(__name__)
 
@@ -12,16 +12,17 @@ log = logging.getLogger(__name__)
 class ChargepointModule(AbstractChargepoint):
     def __init__(self, config: Mqtt) -> None:
         self.config = config
-        self.component_info = ComponentInfo(
+        self.fault_state = FaultState(ComponentInfo(
             self.config.id,
-            "Ladepunkt", "chargepoint")
+            "Ladepunkt", "chargepoint"))
+        self.a = 5
 
     def set_current(self, current: float) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             log.debug("MQTT-Ladepunkte abonnieren die Soll-Stromstärke direkt vom Broker.")
 
     def get_values(self) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             log.debug("MQTT-Ladepunkte müssen nicht ausgelesen werden.")
 
     def switch_phases(self, phases_to_use: int, duration: int) -> None:

--- a/packages/modules/chargepoints/openwb_pro/chargepoint_module.py
+++ b/packages/modules/chargepoints/openwb_pro/chargepoint_module.py
@@ -7,7 +7,8 @@ from modules.chargepoints.openwb_pro.config import OpenWBPro
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_context import SingleComponentUpdateContext
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
+from modules.common.hardware_check import check_meter_values
 from modules.common.store import get_chargepoint_value_store
 from modules.common.component_state import ChargepointState
 from modules.common import req
@@ -19,14 +20,14 @@ class ChargepointModule(AbstractChargepoint):
     def __init__(self, config: OpenWBPro) -> None:
         self.config = config
         self.store = get_chargepoint_value_store(self.config.id)
-        self.component_info = ComponentInfo(
+        self.fault_state = FaultState(ComponentInfo(
             self.config.id,
-            "Ladepunkt", "chargepoint")
+            "Ladepunkt", "chargepoint"))
         self.__session = req.get_http_session()
         self.__client_error_context = ErrorCounterContext(
             "Anhaltender Fehler beim Auslesen des Ladepunkts. Sollstromstärke wird zurückgesetzt.")
 
-        with SingleComponentUpdateContext(self.component_info, False):
+        with SingleComponentUpdateContext(self.fault_state, False):
             with self.__client_error_context:
                 self.__session.post(
                     'http://' + self.config.configuration.ip_address + '/connect.php',
@@ -35,13 +36,13 @@ class ChargepointModule(AbstractChargepoint):
     def set_current(self, current: float) -> None:
         if self.__client_error_context.error_counter_exceeded():
             current = 0
-        with SingleComponentUpdateContext(self.component_info, False):
+        with SingleComponentUpdateContext(self.fault_state, False):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 self.__session.post('http://'+ip_address+'/connect.php', data={'ampere': current})
 
     def get_values(self) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 json_rsp = self.__session.get('http://'+ip_address+'/connect.php').json()
@@ -60,6 +61,9 @@ class ChargepointModule(AbstractChargepoint):
                 )
 
                 if json_rsp.get("voltages"):
+                    meter_msg = check_meter_values(json_rsp["voltages"])
+                    if meter_msg:
+                        self.fault_state.warning(meter_msg)
                     chargepoint_state.voltages = json_rsp["voltages"]
                 if json_rsp.get("soc_value"):
                     chargepoint_state.soc = json_rsp["soc_value"]
@@ -76,7 +80,7 @@ class ChargepointModule(AbstractChargepoint):
                 self.__client_error_context.reset_error_counter()
 
     def switch_phases(self, phases_to_use: int, duration: int) -> None:
-        with SingleComponentUpdateContext(self.component_info, False):
+        with SingleComponentUpdateContext(self.fault_state, False):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 response = self.__session.get('http://'+ip_address+'/connect.php')

--- a/packages/modules/chargepoints/openwb_series2_satellit/chargepoint_module.py
+++ b/packages/modules/chargepoints/openwb_series2_satellit/chargepoint_module.py
@@ -12,9 +12,9 @@ from modules.chargepoints.openwb_series2_satellit.config import OpenWBseries2Sat
 from modules.common import modbus
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.abstract_device import DeviceDescriptor
-from modules.common.chargepoint_context import HardwareCheckContext
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.fault_state import ComponentInfo, FaultState
+from modules.common.hardware_check_context import SeriesHardwareCheckContext
 from modules.common.store import get_chargepoint_value_store
 from modules.common.component_state import ChargepointState
 from modules.internal_chargepoint_handler.clients import EVSE_ID_CP0, EVSE_ID_ONE_BUS_CP1, ClientHandler
@@ -29,9 +29,9 @@ class ChargepointModule(AbstractChargepoint):
 
     def __init__(self, config: OpenWBseries2Satellit) -> None:
         self.config = config
-        self.component_info = ComponentInfo(self.config.id, "Ladepunkt", "chargepoint")
+        self.fault_state = FaultState(ComponentInfo(self.config.id, "Ladepunkt", "chargepoint"))
         self.version: Optional[bool] = None
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             self.delay_second_cp(self.CP0_DELAY_STARTUP)
             self.store = get_chargepoint_value_store(self.config.id)
             self.__client_error_context = ErrorCounterContext(
@@ -50,7 +50,8 @@ class ChargepointModule(AbstractChargepoint):
         self._client = ClientHandler(
             self.config.configuration.duo_num,
             modbus.ModbusTcpClient_(self.config.configuration.ip_address, 8899),
-            EVSE_ID_CP0 if self.config.configuration.duo_num == 0 else EVSE_ID_ONE_BUS_CP1)
+            EVSE_ID_CP0 if self.config.configuration.duo_num == 0 else EVSE_ID_ONE_BUS_CP1,
+            self.fault_state)
 
     def _validate_version(self):
         # telnetlib ist ab Python 3.11 deprecated
@@ -72,10 +73,10 @@ class ChargepointModule(AbstractChargepoint):
 
     def get_values(self) -> None:
         if self.version is not None:
-            with SingleComponentUpdateContext(self.component_info):
+            with SingleComponentUpdateContext(self.fault_state):
                 with self.__client_error_context:
                     try:
-                        with HardwareCheckContext(self._client):
+                        with SeriesHardwareCheckContext(self._client):
                             if self.version is False:
                                 raise FaultState.error(
                                     "Firmware des openWB Satellit ist nicht mit openWB 2 kompatibel. "
@@ -103,10 +104,10 @@ class ChargepointModule(AbstractChargepoint):
 
     def set_current(self, current: float) -> None:
         if self.version is not None:
-            with SingleComponentUpdateContext(self.component_info, update_always=False):
+            with SingleComponentUpdateContext(self.fault_state, update_always=False):
                 with self.__client_error_context:
                     try:
-                        with HardwareCheckContext(self._client):
+                        with SeriesHardwareCheckContext(self._client):
                             self.delay_second_cp(self.CP0_DELAY)
                             with self._client.client:
                                 if self.version:

--- a/packages/modules/chargepoints/smartwb/chargepoint_module.py
+++ b/packages/modules/chargepoints/smartwb/chargepoint_module.py
@@ -5,7 +5,7 @@ from modules.chargepoints.smartwb.config import SmartWB
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_context import SingleComponentUpdateContext
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_chargepoint_value_store
 from modules.common.component_state import ChargepointState
 from modules.common import req
@@ -15,9 +15,9 @@ class ChargepointModule(AbstractChargepoint):
     def __init__(self, config: SmartWB) -> None:
         self.config = config
         self.store = get_chargepoint_value_store(self.config.id)
-        self.component_info = ComponentInfo(
+        self.fault_state = FaultState(ComponentInfo(
             self.config.id,
-            "Ladepunkt", "chargepoint")
+            "Ladepunkt", "chargepoint"))
         self.__client_error_context = ErrorCounterContext(
             "Anhaltender Fehler beim Auslesen des Ladepunkts. Soll-Stromstärke wird zurückgesetzt.")
         self.phases_in_use = 1
@@ -25,7 +25,7 @@ class ChargepointModule(AbstractChargepoint):
     def set_current(self, current: float) -> None:
         if self.__client_error_context.error_counter_exceeded():
             current = 0
-        with SingleComponentUpdateContext(self.component_info, False):
+        with SingleComponentUpdateContext(self.fault_state, False):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 timeout = self.config.configuration.timeout
@@ -34,7 +34,7 @@ class ChargepointModule(AbstractChargepoint):
                 req.get_http_session().get('http://'+ip_address+'/setCurrent', params=params, timeout=(timeout, None))
 
     def get_values(self) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 timeout = self.config.configuration.timeout
@@ -89,7 +89,7 @@ class ChargepointModule(AbstractChargepoint):
                 self.__client_error_context.reset_error_counter()
 
     def clear_rfid(self) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             with self.__client_error_context:
                 ip_address = self.config.configuration.ip_address
                 timeout = self.config.configuration.timeout

--- a/packages/modules/common/component_context.py
+++ b/packages/modules/common/component_context.py
@@ -1,8 +1,9 @@
 import logging
 import threading
 from typing import Optional, List, Union, Any, Dict
+from helpermodules.constants import NO_ERROR
 
-from modules.common.fault_state import ComponentInfo, FaultState
+from modules.common.fault_state import ComponentInfo, FaultState, FaultStateLevel
 
 log = logging.getLogger(__name__)
 
@@ -16,16 +17,19 @@ class SingleComponentUpdateContext:
                 component.update()
     """
 
-    def __init__(self, component_info: ComponentInfo, update_always: bool = True):
-        self.__component_info = component_info
+    def __init__(self, fault_state: FaultState, update_always: bool = True):
+        self.__fault_state = fault_state
         self.update_always = update_always
 
     def __enter__(self):
-        log.debug("Update Komponente ['"+self.__component_info.name+"']")
+        log.debug("Update Komponente ['"+self.__fault_state.component_info.name+"']")
+        if self.update_always:
+            self.__fault_state.fault_state = FaultStateLevel.NO_ERROR
+            self.__fault_state.fault_str = NO_ERROR
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
-        MultiComponentUpdateContext.override_subcomponent_state(self.__component_info, exception, self.update_always)
+        MultiComponentUpdateContext.override_subcomponent_state(self.__fault_state, exception)
         return True
 
 
@@ -49,15 +53,18 @@ class MultiComponentUpdateContext:
             raise Exception("Nesting MultiComponentUpdateContext is not supported")
         MultiComponentUpdateContext.__thread_local.active_context = self
         log.debug("Update Komponenten " +
-                  str([component.component_info.name for component in self.__device_components]))
+                  str([component.fault_state.component_info.name for component in self.__device_components]))
+        for component in self.__device_components:
+            component.fault_state.fault_state = FaultStateLevel.NO_ERROR
+            component.fault_state.fault_str = NO_ERROR
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
-        fault_state = FaultState.from_exception(exception)
         for component in self.__device_components:
-            component_info = component.component_info
-            if component_info not in self.__ignored_components:
-                fault_state.store_error(component_info)
+            fault_state = component.fault_state
+            if fault_state not in self.__ignored_components:
+                fault_state.from_exception(exception)
+                fault_state.store_error()
         delattr(MultiComponentUpdateContext.__thread_local, "active_context")
         return True
 
@@ -65,21 +72,15 @@ class MultiComponentUpdateContext:
         self.__ignored_components.append(component)
 
     @staticmethod
-    def override_subcomponent_state(component_info: ComponentInfo, exception, update_always: bool):
+    def override_subcomponent_state(fault_state: FaultState, exception):
         active_context = getattr(
             MultiComponentUpdateContext.__thread_local, "active_context", None
         )  # type: Optional[MultiComponentUpdateContext]
         if active_context:
             # If a MultiComponentUpdateContext is active, we need make sure that it will not override
             # the value for the individual component
-            active_context.ignore_subcomponent_state(component_info)
+            active_context.ignore_subcomponent_state(fault_state)
 
         if exception:
-            fault_state = FaultState.from_exception(exception)
-        else:
-            # Fehlerstatus nicht überschreiben
-            if update_always:
-                fault_state = FaultState.no_error()
-            else:
-                return
-        fault_state.store_error(component_info)
+            fault_state.from_exception(exception)
+        fault_state.store_error()

--- a/packages/modules/common/configurable_device.py
+++ b/packages/modules/common/configurable_device.py
@@ -20,7 +20,7 @@ class IndependentComponentUpdater(Generic[T_COMPONENT]):
 
     def __call__(self, components: Iterable[T_COMPONENT]) -> None:
         for component in components:
-            with SingleComponentUpdateContext(component.component_info):
+            with SingleComponentUpdateContext(component.fault_state):
                 self.__updater(component)
 
 

--- a/packages/modules/common/configurable_vehicle.py
+++ b/packages/modules/common/configurable_vehicle.py
@@ -9,7 +9,7 @@ from modules.common import store
 from modules.common.abstract_vehicle import CalculatedSocState, GeneralVehicleConfig, VehicleUpdateData
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import CarState
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.vehicles.common.calc_soc import calc_soc
 from modules.vehicles.manual.config import ManualSoc
 from modules.vehicles.mqtt.config import MqttSocSetup
@@ -50,14 +50,14 @@ class ConfigurableVehicle(Generic[T_VEHICLE_CONFIG]):
         self.calc_while_charging = calc_while_charging
         self.vehicle = vehicle
         self.store = store.get_car_value_store(self.vehicle)
-        self.component_info = ComponentInfo(self.vehicle, self.vehicle_config.name, "vehicle")
+        self.fault_state = FaultState(ComponentInfo(self.vehicle, self.vehicle_config.name, "vehicle"))
 
     def update(self, vehicle_update_data: VehicleUpdateData):
         log.debug(f"Vehicle Instance {type(self.vehicle_config)}")
         log.debug(f"Calculated SoC-State {self.calculated_soc_state}")
         log.debug(f"Vehicle Update Data {vehicle_update_data}")
         log.debug(f"General Config {self.general_config}")
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
 
             source = self._get_carstate_source(vehicle_update_data)
             if source == SocSource.NO_UPDATE:

--- a/packages/modules/common/fault_state.py
+++ b/packages/modules/common/fault_state.py
@@ -1,21 +1,14 @@
-import functools
 import logging
 import traceback
-from enum import IntEnum
 from typing import Optional, Callable, TypeVar
 
-from helpermodules import compatibility, exceptions, pub
+from helpermodules import exceptions, pub
 from helpermodules.constants import NO_ERROR
 from modules.common import component_type
 from modules.common.component_setup import ComponentSetup
+from modules.common.fault_state_level import FaultStateLevel
 
 log = logging.getLogger(__name__)
-
-
-class FaultStateLevel(IntEnum):
-    NO_ERROR = 0
-    WARNING = 1
-    ERROR = 2
 
 
 class ComponentInfo:
@@ -45,83 +38,53 @@ class ComponentInfo:
 
 
 class FaultState(Exception):
-    def __init__(self, fault_str: str, fault_state: FaultStateLevel) -> None:
-        self.fault_str = fault_str
-        self.fault_state = fault_state
+    def __init__(self, component_info: ComponentInfo) -> None:
+        self.component_info = component_info
+        self.fault_str = NO_ERROR
+        self.fault_state = FaultStateLevel.NO_ERROR
 
-    def store_error(self, component_info: ComponentInfo) -> None:
+    def store_error(self) -> None:
         try:
             if self.fault_state != FaultStateLevel.NO_ERROR:
-                log.error(component_info.name + ": FaultState " +
+                log.error(self.component_info.name + ": FaultState " +
                           str(self.fault_state) + ", FaultStr " +
                           self.fault_str + ", Traceback: \n" +
                           traceback.format_exc())
-            ramdisk = compatibility.is_ramdisk_in_use()
-            if ramdisk:
-                topic = component_type.type_topic_mapping_comp(component_info.type)
-                prefix = "openWB/set/" + topic + "/"
-                if component_info.type != "counter" and component_info.type != "bat":
-                    if component_type == "vehicle":
-                        prefix += str(component_info.id) + "/socFault"
-                    else:
-                        prefix += str(component_info.id) + "/fault"
-                else:
-                    prefix += "fault"
-                pub.pub_single(prefix + "Str", self.fault_str, hostname=component_info.hostname)
-                pub.pub_single(prefix + "State", self.fault_state.value, hostname=component_info.hostname)
-                if "chargepoint" in component_info.type:
-                    pub.pub_single("openWB/set/" + topic + "/" + str(component_info.id) +
-                                   "/get/fault_str", self.fault_str, hostname=component_info.hostname)
-                    pub.pub_single("openWB/set/" + topic + "/" + str(component_info.id) +
-                                   "/get/fault_state", self.fault_state.value, hostname=component_info.hostname)
-            else:
-                topic = component_type.type_to_topic_mapping(component_info.type)
-                pub.Pub().pub("openWB/set/" + topic + "/" + str(component_info.id) + "/get/fault_str", self.fault_str)
-                pub.Pub().pub(
-                    "openWB/set/" + topic + "/" + str(component_info.id) + "/get/fault_state", self.fault_state.value)
-                if component_info.parent_hostname and component_info.parent_hostname != component_info.hostname:
-                    pub.pub_single("openWB/set/" + topic + "/" + str(component_info.parent_id) +
-                                   "/get/fault_str", self.fault_str, hostname=component_info.parent_hostname)
-                    pub.pub_single(
-                        "openWB/set/" + topic + "/" + str(component_info.parent_id) + "/get/fault_state",
-                        self.fault_state.value, hostname=component_info.parent_hostname)
+            topic = component_type.type_to_topic_mapping(self.component_info.type)
+            topic_prefix = f"openWB/set/{topic}/{self.component_info.id}"
+            pub.Pub().pub(f"{topic_prefix}/get/fault_str", self.fault_str)
+            pub.Pub().pub(f"{topic_prefix}/get/fault_state", self.fault_state.value)
+            if (self.component_info.parent_hostname and
+                    self.component_info.parent_hostname != self.component_info.hostname):
+                pub.pub_single(f"{topic_prefix}/get/fault_str",
+                               self.fault_str, hostname=self.component_info.parent_hostname)
+                pub.pub_single(f"{topic_prefix}/get/fault_state",
+                               self.fault_state.value, hostname=self.component_info.parent_hostname)
         except Exception:
             log.exception("Fehler im Modul fault_state")
 
-    @staticmethod
-    def error(message: str) -> "FaultState":
-        return FaultState(message, FaultStateLevel.ERROR)
+    def error(self, message: str) -> None:
+        self.fault_str = message
+        self.fault_state = FaultStateLevel.ERROR
 
-    @staticmethod
-    def warning(message: str) -> "FaultState":
-        return FaultState(message, FaultStateLevel.WARNING)
+    def warning(self, message: str) -> None:
+        self.fault_str = message
+        self.fault_state = FaultStateLevel.WARNING
 
-    @staticmethod
-    def no_error() -> "FaultState":
-        return FaultState(NO_ERROR, FaultStateLevel.NO_ERROR)
+    def no_error(self) -> None:
+        self.fault_str = NO_ERROR
+        self.fault_state = FaultStateLevel.NO_ERROR
 
-    @staticmethod
-    def from_exception(exception: Optional[Exception] = None) -> "FaultState":
+    def from_exception(self, exception: Optional[Exception] = None) -> None:
         if exception is None:
-            return FaultState.no_error()
-        if isinstance(exception, FaultState):
-            return exception
-        return exceptions.get_default_exception_registry().translate_exception(exception)
+            self.fault_str = NO_ERROR
+            self.fault_state = FaultStateLevel.NO_ERROR
+        elif isinstance(exception, FaultState):
+            self.fault_str = exception.fault_str
+            self.fault_state = exception.fault_state
+        else:
+            self.fault_str, self.fault_state = exceptions.get_default_exception_registry().translate_exception(
+                exception)
 
 
 T_C = TypeVar("T_C", bound=Callable)
-
-
-def exceptions_to_fault_state(module_name: str) -> Callable[[T_C], T_C]:
-    def decorate(delegate: T_C) -> T_C:
-        @functools.wraps(delegate)
-        def wrapper(*args, **kwargs):
-            try:
-                return delegate(*args, **kwargs)
-            except Exception as e:
-                if isinstance(e, FaultState):
-                    raise
-                else:
-                    raise FaultState.error(module_name + " " + str(type(e)) + " " + str(e)) from e
-        return wrapper
-    return decorate

--- a/packages/modules/common/fault_state_level.py
+++ b/packages/modules/common/fault_state_level.py
@@ -1,0 +1,7 @@
+from enum import IntEnum
+
+
+class FaultStateLevel(IntEnum):
+    NO_ERROR = 0
+    WARNING = 1
+    ERROR = 2

--- a/packages/modules/common/hardware_check.py
+++ b/packages/modules/common/hardware_check.py
@@ -1,0 +1,71 @@
+from typing import Any, List, Optional, Protocol, Tuple, Union
+from modules.common.evse import Evse
+from modules.common.fault_state import FaultState
+from modules.common.modbus import ModbusSerialClient_, ModbusTcpClient_
+
+EVSE_MIN_FIRMWARE = 7
+
+OPEN_TICKET = " Bitte nehme über die Support-Funktion in den Einstellungen Kontakt mit uns auf."
+USB_ADAPTER_BROKEN = ("Auslesen von Zähler UND Evse nicht möglich. Vermutlich ist der USB-Adapter defekt oder zwei "
+                      f"Busteilnehmer haben die gleiche Modbus-ID. Bitte die Zähler-ID prüfen. {OPEN_TICKET}")
+METER_PROBLEM = ("Der Zähler konnte nicht ausgelesen werden. "
+                 f"Vermutlich ist der Zähler falsch konfiguriert oder defekt. {OPEN_TICKET}")
+METER_BROKEN = ("Die Spannungen des Zählers konnten nicht korrekt ausgelesen werden. "
+                f"Der Zähler ist defekt. {OPEN_TICKET}")
+EVSE_BROKEN = ("Auslesen der EVSE nicht möglich. "
+               f"Vermutlich ist die EVSE defekt oder hat eine unbekannte Modbus-ID. {OPEN_TICKET}")
+
+
+def check_meter_values(voltages: List[float]) -> Optional[str]:
+    def valid_voltage(voltage) -> bool:
+        return 200 < voltage < 250
+    if ((valid_voltage(voltages[0]) and voltages[1] == 0 and voltages[2] == 0) or
+            (valid_voltage(voltages[0]) and valid_voltage(voltages[1]) and voltages[2] == 0) or
+            (valid_voltage(voltages[0]) and valid_voltage(voltages[1]) and valid_voltage((voltages[2])))):
+        return None
+    else:
+        return METER_BROKEN
+
+
+class ClientHandlerProtocol(Protocol):
+    @property
+    def client(self) -> Union[ModbusSerialClient_, ModbusTcpClient_]: ...
+    @property
+    def local_charge_point_num(self) -> int: ...
+    @property
+    def fault_state(self) -> FaultState: ...
+    @property
+    def evse_client(self) -> Evse: ...
+    @property
+    def meter_client(self) -> Any: ...
+    @property
+    def read_error(self) -> int: ...
+
+
+class SeriesHardwareCheckMixin:
+    def __init__(self) -> None:
+        pass
+
+    def check_hardware(self: ClientHandlerProtocol):
+        try:
+            if self.evse_client.get_firmware_version() > EVSE_MIN_FIRMWARE:
+                evse_check_passed = True
+            else:
+                evse_check_passed = False
+        except Exception:
+            evse_check_passed = False
+        meter_check_passed, meter_error_msg = self.check_meter()
+        if meter_check_passed is False and evse_check_passed is False:
+            raise Exception(USB_ADAPTER_BROKEN)
+        if meter_check_passed is False:
+            raise Exception(meter_error_msg)
+        elif meter_check_passed and meter_error_msg == METER_BROKEN:
+            self.fault_state.warning(METER_BROKEN)
+        if evse_check_passed is False:
+            raise Exception(EVSE_BROKEN)
+
+    def check_meter(self: ClientHandlerProtocol) -> Tuple[bool, Optional[str]]:
+        try:
+            return True, check_meter_values(self.meter_client.get_voltages())
+        except Exception:
+            return False, METER_PROBLEM

--- a/packages/modules/common/hardware_check_context.py
+++ b/packages/modules/common/hardware_check_context.py
@@ -1,15 +1,13 @@
 from modules.internal_chargepoint_handler.clients import ClientHandler
 
 
-class HardwareCheckContext:
+class SeriesHardwareCheckContext:
     def __init__(self, client: ClientHandler):
         self.client = client
 
     def __enter__(self):
+        self.client.check_hardware()
         return None
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
-        if exception:
-            self.client.check_hardware()
-            raise exception
         return True

--- a/packages/modules/common/hardware_check_test.py
+++ b/packages/modules/common/hardware_check_test.py
@@ -3,14 +3,16 @@ from unittest.mock import Mock
 import pytest
 from modules.common import sdm
 from modules.common.evse import Evse
+from modules.common.hardware_check import (
+    EVSE_BROKEN, METER_BROKEN, METER_PROBLEM, USB_ADAPTER_BROKEN, check_meter_values)
 from modules.internal_chargepoint_handler.clients import ClientHandler
 
 
 @pytest.mark.parametrize(
     "evse_side_effect, evse_return_value, meter_side_effect, meter_return_value, expected_error_msg",
-    [pytest.param(Exception("Modbus"), None, None, [230]*3, ClientHandler.EVSE_BROKEN, id="EVSE defekt"),
-     pytest.param(None, 18, Exception("Modbus"), None, ClientHandler.METER_PROBLEM, id="Zähler verkonfiguriert"),
-     pytest.param(Exception("Modbus"), None, Exception("Modbus"), None, ClientHandler.USB_ADAPTER_BROKEN,
+    [pytest.param(Exception("Modbus"), None, None, [230]*3, EVSE_BROKEN, id="EVSE defekt"),
+     pytest.param(None, 18, Exception("Modbus"), None, METER_PROBLEM, id="Zähler verkonfiguriert"),
+     pytest.param(Exception("Modbus"), None, Exception("Modbus"), None, USB_ADAPTER_BROKEN,
                   id="USB-Adapter defekt")
      ]
 )
@@ -33,7 +35,7 @@ def test_hardware_check_fails(evse_side_effect,
 
     # execution and evaluation
     with pytest.raises(Exception, match=expected_error_msg):
-        ClientHandler(0, Mock(), [1])
+        ClientHandler(0, Mock(), [1], Mock())
 
 
 def test_hardware_check_succeeds(monkeypatch):
@@ -48,33 +50,23 @@ def test_hardware_check_succeeds(monkeypatch):
 
     # execution and evaluation
     # keine Exception
-    ClientHandler(0, Mock(), [1])
+    ClientHandler(0, Mock(), [1], Mock())
 
 
 @pytest.mark.parametrize(
     "voltages, expected_msg",
     [pytest.param([230, 0, 0], None, id="einphasig oder zweiphasig L2 defekt (nicht erkennbar)"),
-     pytest.param([0, 0, 0], ClientHandler.METER_BROKEN, id="einphasig, L1 defekt"),
-     pytest.param([230, 230, 0], None, id="zweiphasig"),
-     pytest.param([0, 230, 0], ClientHandler.METER_BROKEN, id="zweiphasig, L1 defekt"),
+     pytest.param([0, 0, 0], METER_BROKEN, id="einphasig, L1 defekt"),
+     pytest.param([230, 230, 0], None, id="zweiphasig oder dreiphasig, L3 defekt (nicht erkennbar)"),
+     pytest.param([0, 230, 0], METER_BROKEN, id="zweiphasig, L1 defekt"),
      pytest.param([230, 230, 230], None, id="dreiphasig"),
-     pytest.param([0, 230, 230], ClientHandler.METER_BROKEN, id="dreiphasig, L1 defekt"),
-     pytest.param([230, 0, 230], ClientHandler.METER_BROKEN, id="dreiphasig, L2 defekt"),
-     pytest.param([230, 230, 0], ClientHandler.METER_BROKEN, id="dreiphasig, L3 defekt"),
+     pytest.param([0, 230, 230], METER_BROKEN, id="dreiphasig, L1 defekt"),
+     pytest.param([230, 0, 230], METER_BROKEN, id="dreiphasig, L2 defekt"),
      ]
 )
-def check_meter(voltages, expected_msg, monkeypatch):
-    # setup
-    mock_evse_client = Mock(spec=Evse, get_firmware_version=Mock(return_value=18))
-    mock_evse_facotry = Mock(spec=Evse, return_value=mock_evse_client)
-    monkeypatch.setattr(ClientHandler, "_evse_factory", mock_evse_facotry)
-
-    mock_meter_client = Mock(spec=sdm.Sdm630, get_voltages=Mock(side_effect=[[230]*3, voltages]))
-    mock_find_meter_client = Mock(spec=sdm.Sdm630, return_value=mock_meter_client)
-    monkeypatch.setattr(ClientHandler, "find_meter_client", mock_find_meter_client)
-
-    # execution
-    msg = ClientHandler(0, Mock(), [1]).check_meter()
+def test_check_meter(voltages, expected_msg, monkeypatch):
+    # setup & execution
+    msg = check_meter_values(voltages)
 
     # assert
     assert msg == expected_msg

--- a/packages/modules/common/simcount/_calculate.py
+++ b/packages/modules/common/simcount/_calculate.py
@@ -1,14 +1,12 @@
 import logging
 from typing import Union, Tuple
 
-from modules.common.fault_state import exceptions_to_fault_state
 
 Number = Union[int, float]
 
 log = logging.getLogger(__name__)
 
 
-@exceptions_to_fault_state(__name__)
 def calculate_import_export(time_since_previous: Number, power1: Number, power2: Number) -> Tuple[float, float]:
     log.debug("time passed: %g, power1: %g, power2: %g", time_since_previous, power1, power2)
     power_low = min(power1, power2)

--- a/packages/modules/common/simcount/_simcount.py
+++ b/packages/modules/common/simcount/_simcount.py
@@ -4,7 +4,6 @@ Berechnet die importierte und exportierte Leistung, wenn der Zähler / PV-Modul 
 import logging
 import time
 
-from modules.common.fault_state import exceptions_to_fault_state
 from modules.common.simcount._calculate import calculate_import_export
 from modules.common.simcount.simcounter_state import SimCounterState
 from modules.common.simcount._simcounter_store import get_sim_counter_store
@@ -12,7 +11,6 @@ from modules.common.simcount._simcounter_store import get_sim_counter_store
 log = logging.getLogger(__name__)
 
 
-@exceptions_to_fault_state(__name__)
 def sim_count(power_present: float, topic: str = "", data: SimCounterState = None, prefix: str = "") -> SimCounterState:
     """ emulate import export
 
@@ -31,19 +29,20 @@ def sim_count(power_present: float, topic: str = "", data: SimCounterState = Non
     timestamp_present = time.time()
     previous_state = store.load(prefix, topic) if data is None else data
 
-    if previous_state is None:
-        log.debug("No previous state found. Starting new simulation.")
-        return store.initialize(prefix, topic, power_present, timestamp_present)
-    else:
-        log.debug("Previous state: %s", previous_state)
-        hours_since_previous = (timestamp_present - previous_state.timestamp) / 3600
-        imported, exported = calculate_import_export(hours_since_previous, previous_state.power, power_present)
-        current_state = SimCounterState(
-            timestamp_present,
-            power_present,
-            previous_state.imported + imported,
-            previous_state.exported + exported
-        )
-        log.debug("imported: %g Wh, exported: %g Wh, new state: %s", imported, exported, current_state)
-        store.save(prefix, topic, current_state)
-        return current_state
+    if isinstance(power_present, (int, float)):
+        if previous_state is None:
+            log.debug("No previous state found. Starting new simulation.")
+            return store.initialize(prefix, topic, power_present, timestamp_present)
+        else:
+            log.debug("Previous state: %s", previous_state)
+            hours_since_previous = (timestamp_present - previous_state.timestamp) / 3600
+            imported, exported = calculate_import_export(hours_since_previous, previous_state.power, power_present)
+            current_state = SimCounterState(
+                timestamp_present,
+                power_present,
+                previous_state.imported + imported,
+                previous_state.exported + exported
+            )
+            log.debug("imported: %g Wh, exported: %g Wh, new state: %s", imported, exported, current_state)
+            store.save(prefix, topic, current_state)
+            return current_state

--- a/packages/modules/common/store/_api.py
+++ b/packages/modules/common/store/_api.py
@@ -32,7 +32,7 @@ class LoggingValueStore(Generic[T], ValueStore[T]):
 
 
 def update_values(component):
-    with SingleComponentUpdateContext(component.component_info, update_always=False):
+    with SingleComponentUpdateContext(component.fault_state, update_always=False):
         if hasattr(component, "store"):
             try:
                 component.store.update()

--- a/packages/modules/devices/alpha_ess/bat.py
+++ b/packages/modules/devices/alpha_ess/bat.py
@@ -8,7 +8,7 @@ from modules.devices.alpha_ess.config import AlphaEssBatSetup, AlphaEssConfigura
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -26,7 +26,7 @@ class AlphaEssBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, unit_id: int) -> None:
         # keine Unterschiede zwischen den Versionen

--- a/packages/modules/devices/alpha_ess/counter.py
+++ b/packages/modules/devices/alpha_ess/counter.py
@@ -7,7 +7,7 @@ from modules.devices.alpha_ess.config import AlphaEssConfiguration, AlphaEssCoun
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
 
@@ -21,7 +21,7 @@ class AlphaEssCounter:
         self.component_config = dataclass_from_dict(AlphaEssCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.__device_config = device_config
 
     def update(self, unit_id: int):

--- a/packages/modules/devices/alpha_ess/device.py
+++ b/packages/modules/devices/alpha_ess/device.py
@@ -66,7 +66,7 @@ class Device(AbstractDevice):
             with self.client:
                 for component in self.components:
                     # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                    with SingleComponentUpdateContext(self.components[component].component_info):
+                    with SingleComponentUpdateContext(self.components[component].fault_state):
                         self.components[component].update(unit_id=default_unit_id)
         else:
             log.warning(

--- a/packages/modules/devices/alpha_ess/inverter.py
+++ b/packages/modules/devices/alpha_ess/inverter.py
@@ -6,7 +6,7 @@ from modules.devices.alpha_ess.config import AlphaEssConfiguration, AlphaEssInve
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, Number
 from modules.common.simcount._simcounter import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -22,7 +22,7 @@ class AlphaEssInverter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.__device_config = device_config
 
     def update(self, unit_id: int) -> None:

--- a/packages/modules/devices/batterx/bat.py
+++ b/packages/modules/devices/batterx/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.devices.batterx.config import BatterXBatSetup
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 
@@ -16,7 +16,7 @@ class BatterXBat:
         self.component_config = dataclass_from_dict(BatterXBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, resp: Dict) -> None:
         power = resp["1121"]["1"]

--- a/packages/modules/devices/batterx/counter.py
+++ b/packages/modules/devices/batterx/counter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.devices.batterx.config import BatterXCounterSetup
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 
@@ -19,7 +19,7 @@ class BatterXCounter:
         self.component_config = dataclass_from_dict(BatterXCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, resp: Dict) -> None:
         power = resp["2913"]["0"]

--- a/packages/modules/devices/batterx/external_inverter.py
+++ b/packages/modules/devices/batterx/external_inverter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.devices.batterx.config import BatterXExternalInverterSetup
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 
@@ -16,7 +16,7 @@ class BatterXExternalInverter:
         self.component_config = dataclass_from_dict(BatterXExternalInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def get_power(self, resp: Dict) -> float:
         return resp["2913"]["3"] * -1

--- a/packages/modules/devices/batterx/inverter.py
+++ b/packages/modules/devices/batterx/inverter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.devices.batterx.config import BatterXInverterSetup
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 
@@ -16,7 +16,7 @@ class BatterXInverter:
         self.component_config = dataclass_from_dict(BatterXInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def get_power(self, resp: Dict) -> float:
         return resp["1634"]["0"] * -1

--- a/packages/modules/devices/byd/bat.py
+++ b/packages/modules/devices/byd/bat.py
@@ -8,7 +8,7 @@ from modules.devices.byd.config import BYDBatSetup
 from modules.common import req
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 
@@ -23,7 +23,7 @@ class BYDBat:
         self.component_config = dataclass_from_dict(BYDBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_config.id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         power, soc = self.get_values()

--- a/packages/modules/devices/byd/device.py
+++ b/packages/modules/devices/byd/device.py
@@ -46,7 +46,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/carlo_gavazzi/counter.py
+++ b/packages/modules/devices/carlo_gavazzi/counter.py
@@ -8,7 +8,7 @@ from modules.devices.carlo_gavazzi.config import CarloGavazziCounterSetup
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -24,7 +24,7 @@ class CarloGavazziCounter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         unit = 1

--- a/packages/modules/devices/carlo_gavazzi/device.py
+++ b/packages/modules/devices/carlo_gavazzi/device.py
@@ -48,7 +48,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/discovergy/counter.py
+++ b/packages/modules/devices/discovergy/counter.py
@@ -1,7 +1,7 @@
 from requests import Session
 
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 from modules.devices.discovergy import api
 from modules.devices.discovergy.config import DiscovergyCounterSetup
@@ -11,7 +11,7 @@ class DiscovergyCounter:
     def __init__(self, component_config: DiscovergyCounterSetup) -> None:
         self.component_config = component_config
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session):
         self.store.set(api.get_last_reading(session, self.component_config.configuration.meter_id))

--- a/packages/modules/devices/discovergy/inverter.py
+++ b/packages/modules/devices/discovergy/inverter.py
@@ -2,7 +2,7 @@ from requests import Session
 
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.discovergy import api
 from modules.devices.discovergy.config import DiscovergyInverterSetup
@@ -12,7 +12,7 @@ class DiscovergyInverter:
     def __init__(self, component_config: DiscovergyInverterSetup) -> None:
         self.component_config = component_config
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session):
         reading = api.get_last_reading(session, self.component_config.configuration.meter_id)

--- a/packages/modules/devices/e3dc/bat.py
+++ b/packages/modules/devices/e3dc/bat.py
@@ -5,7 +5,7 @@ from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.modbus import ModbusDataType, Endian
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_bat_value_store
 from modules.common.simcount._simcounter import SimCounter
 from modules.devices.e3dc.config import E3dcBatSetup
@@ -30,7 +30,7 @@ class E3dcBat:
         # bat
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: modbus.ModbusTcpClient_) -> None:
 

--- a/packages/modules/devices/e3dc/counter.py
+++ b/packages/modules/devices/e3dc/counter.py
@@ -5,7 +5,7 @@ from typing import Tuple, List
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount._simcounter import SimCounter
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
@@ -46,7 +46,7 @@ class E3dcCounter:
         self.component_config = component_config
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: modbus.ModbusTcpClient_) -> None:
         power, powers = read_counter(client)

--- a/packages/modules/devices/e3dc/device.py
+++ b/packages/modules/devices/e3dc/device.py
@@ -45,7 +45,7 @@ def create_device(device_config: E3dc) -> ConfigurableDevice:
                                                      E3dcExternalInverter]]) -> None:
         with client as c:
             for component in components:
-                with SingleComponentUpdateContext(component.component_info):
+                with SingleComponentUpdateContext(component.fault_state):
                     component.update(c)
 
     try:

--- a/packages/modules/devices/e3dc/external_inverter.py
+++ b/packages/modules/devices/e3dc/external_inverter.py
@@ -5,7 +5,7 @@ from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.modbus import ModbusDataType, Endian
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.common.simcount._simcounter import SimCounter
 from modules.devices.e3dc.config import E3dcExternalInverterSetup
@@ -27,7 +27,7 @@ class E3dcExternalInverter:
         self.component_config = component_config
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: modbus.ModbusTcpClient_) -> None:
 

--- a/packages/modules/devices/e3dc/inverter.py
+++ b/packages/modules/devices/e3dc/inverter.py
@@ -5,7 +5,7 @@ from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.modbus import ModbusDataType, Endian
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.common.simcount._simcounter import SimCounter
 from modules.devices.e3dc.config import E3dcInverterSetup
@@ -27,7 +27,7 @@ class E3dcInverter:
         self.component_config = component_config
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: modbus.ModbusTcpClient_) -> None:
 

--- a/packages/modules/devices/enphase/counter.py
+++ b/packages/modules/devices/enphase/counter.py
@@ -16,7 +16,7 @@ class EnphaseCounter:
     def __init__(self, component_config: Union[Dict, EnphaseCounterSetup]) -> None:
         self.component_config = dataclass_from_dict(EnphaseCounterSetup, component_config)
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response):
         config = self.component_config.configuration

--- a/packages/modules/devices/enphase/inverter.py
+++ b/packages/modules/devices/enphase/inverter.py
@@ -16,7 +16,7 @@ class EnphaseInverter:
     def __init__(self, component_config: Union[Dict, EnphaseInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(EnphaseInverterSetup, component_config)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         config = self.component_config.configuration

--- a/packages/modules/devices/fems/bat.py
+++ b/packages/modules/devices/fems/bat.py
@@ -3,7 +3,7 @@ from helpermodules.scale_metric import scale_metric
 from modules.devices.fems.config import FemsBatSetup
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_bat_value_store
 
 
@@ -12,7 +12,7 @@ class FemsBat:
         self.ip_address = ip_address
         self.component_config = component_config
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session) -> None:
         if self.component_config.configuration.num == 1:

--- a/packages/modules/devices/fems/counter.py
+++ b/packages/modules/devices/fems/counter.py
@@ -3,7 +3,7 @@ from helpermodules.scale_metric import scale_metric
 from modules.devices.fems.config import FemsCounterSetup
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 
 
@@ -12,7 +12,7 @@ class FemsCounter:
         self.ip_address = ip_address
         self.component_config = component_config
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session) -> None:
         try:

--- a/packages/modules/devices/fems/inverter.py
+++ b/packages/modules/devices/fems/inverter.py
@@ -3,7 +3,7 @@ from helpermodules.scale_metric import scale_metric
 from modules.devices.fems.config import FemsInverterSetup
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 
 
@@ -12,7 +12,7 @@ class FemsInverter:
         self.ip_address = ip_address
         self.component_config = component_config
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session) -> None:
         response = session.get(

--- a/packages/modules/devices/fronius/bat.py
+++ b/packages/modules/devices/fronius/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.fronius.config import FroniusBatSetup
@@ -22,7 +22,7 @@ class FroniusBat:
         self.device_config = device_config
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         meter_id = str(self.component_config.configuration.meter_id)

--- a/packages/modules/devices/fronius/counter_s0.py
+++ b/packages/modules/devices/fronius/counter_s0.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.fronius.config import FroniusConfiguration, FroniusS0CounterSetup
@@ -21,7 +21,7 @@ class FroniusS0Counter:
         self.device_config = device_config
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         session = req.get_http_session()

--- a/packages/modules/devices/fronius/counter_sm.py
+++ b/packages/modules/devices/fronius/counter_sm.py
@@ -27,7 +27,7 @@ class FroniusSmCounter:
         self.device_config = device_config
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         session = req.get_http_session()

--- a/packages/modules/devices/fronius/inverter.py
+++ b/packages/modules/devices/fronius/inverter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.fronius.config import FroniusInverterSetup
@@ -18,7 +18,7 @@ class FroniusInverter:
         self.component_config = dataclass_from_dict(FroniusInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response: Dict) -> None:
         # Rückgabewert ist die aktuelle Wirkleistung in [W].

--- a/packages/modules/devices/fronius/inverter_secondary.py
+++ b/packages/modules/devices/fronius/inverter_secondary.py
@@ -18,7 +18,7 @@ class FroniusSecondaryInverter:
         self.component_config = dataclass_from_dict(FroniusSecondaryInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response: Dict) -> None:
         # Rückgabewert ist die aktuelle Wirkleistung in [W].

--- a/packages/modules/devices/good_we/bat.py
+++ b/packages/modules/devices/good_we/bat.py
@@ -6,7 +6,7 @@ from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.modbus import ModbusDataType
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_bat_value_store
 from modules.devices.good_we.config import GoodWeBatSetup
 
@@ -20,7 +20,7 @@ class GoodWeBat:
         self.component_config = dataclass_from_dict(GoodWeBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/devices/good_we/counter.py
+++ b/packages/modules/devices/good_we/counter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
 from modules.devices.good_we.config import GoodWeCounterSetup
@@ -20,7 +20,7 @@ class GoodWeCounter:
         self.component_config = dataclass_from_dict(GoodWeCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/devices/good_we/device.py
+++ b/packages/modules/devices/good_we/device.py
@@ -41,8 +41,8 @@ class Device(AbstractDevice):
         else:
             component_type = component_config.type
         component_config = dataclass_from_dict(COMPONENT_TYPE_TO_MODULE[
-                                                   component_type].component_descriptor.configuration_factory,
-                                               component_config)
+            component_type].component_descriptor.configuration_factory,
+            component_config)
         if component_type in self.COMPONENT_TYPE_TO_CLASS:
             self.components["component" + str(component_config.id)] = (self.COMPONENT_TYPE_TO_CLASS[component_type](
                 self.device_config.configuration.modbus_id, component_config, self.client))
@@ -57,7 +57,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/good_we/inverter.py
+++ b/packages/modules/devices/good_we/inverter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
 from modules.devices.good_we.config import GoodWeInverterSetup
@@ -20,7 +20,7 @@ class GoodWeInverter:
         self.component_config = dataclass_from_dict(GoodWeInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/devices/http/bat.py
+++ b/packages/modules/devices/http/bat.py
@@ -6,7 +6,7 @@ from requests import Session
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.http.api import create_request_function
@@ -19,7 +19,7 @@ class HttpBat:
         self.component_config = dataclass_from_dict(HttpBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
         self.__get_imported = create_request_function(url, self.component_config.configuration.imported_path)

--- a/packages/modules/devices/http/counter.py
+++ b/packages/modules/devices/http/counter.py
@@ -6,7 +6,7 @@ from requests import Session
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.http.api import create_request_function, create_request_function_array
@@ -19,7 +19,7 @@ class HttpCounter:
         self.component_config = dataclass_from_dict(HttpCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
         self.__get_imported = create_request_function(url, self.component_config.configuration.imported_path)

--- a/packages/modules/devices/http/inverter.py
+++ b/packages/modules/devices/http/inverter.py
@@ -7,7 +7,7 @@ from dataclass_utils import dataclass_from_dict
 from helpermodules import compatibility
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.http.api import create_request_function
@@ -20,7 +20,7 @@ class HttpInverter:
         self.component_config = dataclass_from_dict(HttpInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
         self.__get_power = create_request_function(url, self.component_config.configuration.power_path)
         self.__get_exported = create_request_function(url, self.component_config.configuration.exported_path)

--- a/packages/modules/devices/huawei/bat.py
+++ b/packages/modules/devices/huawei/bat.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.huawei.config import HuaweiBatSetup
@@ -18,7 +18,7 @@ class HuaweiBat:
         self.component_config = dataclass_from_dict(HuaweiBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, bat_power_reg, bat_soc_reg) -> None:
         soc = bat_soc_reg / 10

--- a/packages/modules/devices/huawei/counter.py
+++ b/packages/modules/devices/huawei/counter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.huawei.config import HuaweiCounterSetup
@@ -18,7 +18,7 @@ class HuaweiCounter:
         self.component_config = dataclass_from_dict(HuaweiCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, counter_currents_reg, counter_power_reg):
         power = counter_power_reg * -1

--- a/packages/modules/devices/huawei/device.py
+++ b/packages/modules/devices/huawei/device.py
@@ -39,7 +39,7 @@ def create_device(device_config: Huawei):
             bat_soc_reg = c.read_holding_registers(37760, ModbusDataType.INT_16, unit=modbus_id)  # Int 16 37760
 
             for component in components:
-                with SingleComponentUpdateContext(component.component_info):
+                with SingleComponentUpdateContext(component.fault_state):
                     if isinstance(component, HuaweiBat):
                         component.update(bat_power_reg, bat_soc_reg)
                     elif isinstance(component, HuaweiCounter):

--- a/packages/modules/devices/huawei/inverter.py
+++ b/packages/modules/devices/huawei/inverter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.huawei.config import HuaweiInverterSetup
@@ -18,7 +18,7 @@ class HuaweiInverter:
         self.component_config = dataclass_from_dict(HuaweiInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, inverter_power_reg) -> None:
         power = inverter_power_reg * -1

--- a/packages/modules/devices/huawei_smartlogger/bat.py
+++ b/packages/modules/devices/huawei_smartlogger/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -22,7 +22,7 @@ class Huawei_SmartloggerBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id

--- a/packages/modules/devices/huawei_smartlogger/counter.py
+++ b/packages/modules/devices/huawei_smartlogger/counter.py
@@ -3,7 +3,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -19,7 +19,7 @@ class Huawei_SmartloggerCounter:
         self.client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         modbus_id = self.component_config.configuration.modbus_id

--- a/packages/modules/devices/huawei_smartlogger/device.py
+++ b/packages/modules/devices/huawei_smartlogger/device.py
@@ -63,7 +63,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/huawei_smartlogger/inverter.py
+++ b/packages/modules/devices/huawei_smartlogger/inverter.py
@@ -4,7 +4,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -23,7 +23,7 @@ class Huawei_SmartloggerInverter:
         self.client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id

--- a/packages/modules/devices/janitza/counter.py
+++ b/packages/modules/devices/janitza/counter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -22,7 +22,7 @@ class JanitzaCounter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/devices/janitza/device.py
+++ b/packages/modules/devices/janitza/device.py
@@ -48,7 +48,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/json/bat.py
+++ b/packages/modules/devices/json/bat.py
@@ -6,7 +6,7 @@ import jq
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.json.config import JsonBatSetup
@@ -18,7 +18,7 @@ class JsonBat:
         self.component_config = dataclass_from_dict(JsonBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         config = self.component_config.configuration

--- a/packages/modules/devices/json/counter.py
+++ b/packages/modules/devices/json/counter.py
@@ -6,7 +6,7 @@ import jq
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount._simcounter import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.json.config import JsonCounterSetup
@@ -18,7 +18,7 @@ class JsonCounter:
         self.component_config = dataclass_from_dict(JsonCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response):
         config = self.component_config.configuration

--- a/packages/modules/devices/json/inverter.py
+++ b/packages/modules/devices/json/inverter.py
@@ -6,7 +6,7 @@ import jq
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.json.config import JsonInverterSetup
@@ -18,7 +18,7 @@ class JsonInverter:
         self.component_config = dataclass_from_dict(JsonInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         config = self.component_config.configuration

--- a/packages/modules/devices/kostal_piko/counter.py
+++ b/packages/modules/devices/kostal_piko/counter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.kostal_piko.config import KostalPikoCounterSetup
@@ -21,7 +21,7 @@ class KostalPikoCounter:
         self.ip_address = ip_address
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def get_values(self) -> Tuple[float, List[float]]:
         params = (('dxsEntries', ['83887106', '83887362', '83887618']),)

--- a/packages/modules/devices/kostal_piko/device.py
+++ b/packages/modules/devices/kostal_piko/device.py
@@ -58,7 +58,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/kostal_piko/inverter.py
+++ b/packages/modules/devices/kostal_piko/inverter.py
@@ -4,7 +4,7 @@ from typing import Dict, Tuple, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.common import req
 from modules.devices.kostal_piko.config import KostalPikoInverterSetup
@@ -18,7 +18,7 @@ class KostalPikoInverter:
         self.component_config = dataclass_from_dict(KostalPikoInverterSetup, component_config)
         self.ip_address = ip_address
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> Tuple[float, float]:
         # Die Differenz der Einträge entspricht nicht der Batterieleistung.

--- a/packages/modules/devices/kostal_piko_old/inverter.py
+++ b/packages/modules/devices/kostal_piko_old/inverter.py
@@ -4,7 +4,7 @@ import re
 
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.kostal_piko_old.config import KostalPikoOldInverterSetup
 
@@ -15,7 +15,7 @@ class KostalPikoOldInverter:
     def __init__(self, component_config: KostalPikoOldInverterSetup) -> None:
         self.component_config = component_config
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         # power may be a string "xxx" when the inverter is offline, so we cannot match as a number

--- a/packages/modules/devices/kostal_plenticore/bat.py
+++ b/packages/modules/devices/kostal_plenticore/bat.py
@@ -4,7 +4,7 @@ from typing import Any, Callable
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.modbus import ModbusDataType
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.kostal_plenticore.config import KostalPlenticoreBatSetup
@@ -19,7 +19,7 @@ class KostalPlenticoreBat:
         self.component_config = component_config
         self.store = get_bat_value_store(self.component_config.id)
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="speicher")
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def read_state(self, reader: Callable[[int, ModbusDataType], Any]) -> BatState:
         power = reader(582, ModbusDataType.INT_16) * -1

--- a/packages/modules/devices/kostal_plenticore/counter.py
+++ b/packages/modules/devices/kostal_plenticore/counter.py
@@ -2,7 +2,7 @@
 from typing import Any, Callable
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -16,7 +16,7 @@ class KostalPlenticoreCounter:
         self.component_config = component_config
         self.store = get_counter_value_store(self.component_config.id)
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="bezug")
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def get_values(self, reader: Callable[[int, ModbusDataType], Any]) -> CounterState:
         power_factor = reader(150, ModbusDataType.FLOAT_32)

--- a/packages/modules/devices/kostal_plenticore/inverter.py
+++ b/packages/modules/devices/kostal_plenticore/inverter.py
@@ -2,7 +2,7 @@
 from typing import Any, Callable
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
 from modules.devices.kostal_plenticore.config import KostalPlenticoreInverterSetup
@@ -13,7 +13,7 @@ class KostalPlenticoreInverter:
                  component_config: KostalPlenticoreInverterSetup) -> None:
         self.component_config = component_config
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def read_state(self, reader: Callable[[int, ModbusDataType], Any]) -> InverterState:
         # PV-Anlage kann nichts verbrauchen, also ggf. Register-/Rundungsfehler korrigieren.

--- a/packages/modules/devices/kostal_sem/counter.py
+++ b/packages/modules/devices/kostal_sem/counter.py
@@ -2,7 +2,7 @@
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
 from modules.devices.kostal_sem.config import KostalSemCounterSetup
@@ -15,7 +15,7 @@ class KostalSemCounter:
         self.component_config = component_config
         self.__tcp_client = tcp_client
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/devices/kostal_steca/inverter.py
+++ b/packages/modules/devices/kostal_steca/inverter.py
@@ -8,7 +8,7 @@ from math import isnan
 from modules.common import req
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.kostal_steca.config import KostalStecaInverterSetup
 
@@ -20,7 +20,7 @@ class KostalStecaInverter:
         self.ip_address = ip_address
         self.component_config = component_config
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         power, exported = self.get_values()

--- a/packages/modules/devices/lg/bat.py
+++ b/packages/modules/devices/lg/bat.py
@@ -4,8 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
-from modules.common.fault_state import FaultState
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.lg.config import LgBatSetup
@@ -17,7 +16,7 @@ class LgBat:
         self.component_config = dataclass_from_dict(LgBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         power = float(response["statistics"]["batconv_power"])
@@ -26,8 +25,7 @@ class LgBat:
         try:
             soc = float(response["statistics"]["bat_user_soc"])
         except ValueError:
-            FaultState.warning(
-                'Speicher-SOC ist nicht numerisch und wird auf 0 gesetzt.').store_error(self.component_info)
+            self.component_info.fault_state.warning('Speicher-SOC ist nicht numerisch und wird auf 0 gesetzt.')
             soc = 0
 
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/lg/counter.py
+++ b/packages/modules/devices/lg/counter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.lg.config import LgCounterSetup
@@ -16,7 +16,7 @@ class LgCounter:
         self.component_config = dataclass_from_dict(LgCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         power = float(response["statistics"]["grid_power"])

--- a/packages/modules/devices/lg/inverter.py
+++ b/packages/modules/devices/lg/inverter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.lg.config import LgInverterSetup
@@ -16,7 +16,7 @@ class LgInverter:
         self.component_config = dataclass_from_dict(LgInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response: Dict) -> None:
         power = float(response["statistics"]["pcs_pv_total_power"]) * -1

--- a/packages/modules/devices/mqtt/bat.py
+++ b/packages/modules/devices/mqtt/bat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import Dict, Union
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_type import ComponentDescriptor
@@ -10,7 +10,7 @@ from modules.devices.mqtt.config import MqttBatSetup
 class MqttBat:
     def __init__(self, component_config: Union[Dict, MqttBatSetup]) -> None:
         self.component_config = dataclass_from_dict(MqttBatSetup, component_config)
-        self.component_info = ComponentInfo.from_component_config(component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(component_config))
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=MqttBatSetup)

--- a/packages/modules/devices/mqtt/counter.py
+++ b/packages/modules/devices/mqtt/counter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import Dict, Union
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_type import ComponentDescriptor
@@ -10,7 +10,7 @@ from modules.devices.mqtt.config import MqttCounterSetup
 class MqttCounter:
     def __init__(self, component_config: Union[Dict, MqttCounterSetup]) -> None:
         self.component_config = dataclass_from_dict(MqttCounterSetup, component_config)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=MqttCounterSetup)

--- a/packages/modules/devices/mqtt/inverter.py
+++ b/packages/modules/devices/mqtt/inverter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import Dict, Union
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_type import ComponentDescriptor
@@ -10,7 +10,7 @@ from modules.devices.mqtt.config import MqttInverterSetup
 class MqttInverter:
     def __init__(self, component_config: Union[Dict, MqttInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(MqttInverterSetup, component_config)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=MqttInverterSetup)

--- a/packages/modules/devices/openwb_bat_kit/device.py
+++ b/packages/modules/devices/openwb_bat_kit/device.py
@@ -37,7 +37,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/openwb_evu_kit/device.py
+++ b/packages/modules/devices/openwb_evu_kit/device.py
@@ -51,7 +51,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
                     time.sleep(0.2)
         else:

--- a/packages/modules/devices/openwb_flex/bat.py
+++ b/packages/modules/devices/openwb_flex/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.lovato import Lovato
 from modules.common.sdm import Sdm630
 from modules.common.simcount import SimCounter
@@ -28,7 +28,7 @@ class BatKitFlex:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         # TCP-Verbindung schließen möglichst bevor etwas anderes gemacht wird, um im Fehlerfall zu verhindern,

--- a/packages/modules/devices/openwb_flex/counter.py
+++ b/packages/modules/devices/openwb_flex/counter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.lovato import Lovato
 from modules.common.mpm3pm import Mpm3pm
 from modules.common.simcount import SimCounter
@@ -28,7 +28,7 @@ class EvuKitFlex:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         # TCP-Verbindung schließen möglichst bevor etwas anderes gemacht wird, um im Fehlerfall zu verhindern,

--- a/packages/modules/devices/openwb_flex/device.py
+++ b/packages/modules/devices/openwb_flex/device.py
@@ -51,7 +51,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/openwb_flex/inverter.py
+++ b/packages/modules/devices/openwb_flex/inverter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.lovato import Lovato
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -27,7 +27,7 @@ class PvKitFlex:
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.simulation = {}
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         """ liest die Werte des Moduls aus.

--- a/packages/modules/devices/openwb_pv_kit/device.py
+++ b/packages/modules/devices/openwb_pv_kit/device.py
@@ -36,7 +36,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/powerdog/counter.py
+++ b/packages/modules/devices/powerdog/counter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -25,7 +25,7 @@ class PowerdogCounter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, inverter_power: float):
         with self.__tcp_client:

--- a/packages/modules/devices/powerdog/device.py
+++ b/packages/modules/devices/powerdog/device.py
@@ -51,7 +51,7 @@ class Device(AbstractDevice):
             if len(self.components) == 1:
                 for component in self.components:
                     if isinstance(self.components[component], inverter.PowerdogInverter):
-                        with SingleComponentUpdateContext(self.components[component].component_info):
+                        with SingleComponentUpdateContext(self.components[component].fault_state):
                             self.components[component].update()
                     else:
                         raise Exception(

--- a/packages/modules/devices/powerdog/inverter.py
+++ b/packages/modules/devices/powerdog/inverter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -25,7 +25,7 @@ class PowerdogInverter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> float:
         with self.__tcp_client:

--- a/packages/modules/devices/powerfox/counter.py
+++ b/packages/modules/devices/powerfox/counter.py
@@ -7,7 +7,7 @@ from requests import Session
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 from modules.devices.powerfox.config import PowerfoxCounterSetup
 
@@ -19,7 +19,7 @@ class PowerfoxCounter:
                  component_config: Union[Dict, PowerfoxCounterSetup]) -> None:
         self.component_config = dataclass_from_dict(PowerfoxCounterSetup, component_config)
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session) -> None:
         response = session.get('https://backend.powerfox.energy/api/2.0/my/'+self.component_config.configuration.id +

--- a/packages/modules/devices/powerfox/inverter.py
+++ b/packages/modules/devices/powerfox/inverter.py
@@ -7,7 +7,7 @@ from requests import Session
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.powerfox.config import PowerfoxInverterSetup
 
@@ -19,7 +19,7 @@ class PowerfoxInverter:
                  component_config: Union[Dict, PowerfoxInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(PowerfoxInverterSetup, component_config)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session) -> None:
         response = session.get('https://backend.powerfox.energy/api/2.0/my/'+self.component_config.configuration.id +

--- a/packages/modules/devices/qcells/bat.py
+++ b/packages/modules/devices/qcells/bat.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.store import get_bat_value_store
 from modules.devices.qcells.config import QCellsBatSetup
@@ -17,7 +17,7 @@ class QCellsBat:
         self.__modbus_id = modbus_id
         self.component_config = dataclass_from_dict(QCellsBatSetup, component_config)
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_) -> None:
         power = client.read_input_registers(0x0016, ModbusDataType.INT_16, unit=self.__modbus_id)

--- a/packages/modules/devices/qcells/counter.py
+++ b/packages/modules/devices/qcells/counter.py
@@ -5,7 +5,7 @@ from pymodbus.constants import Endian
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.store import get_counter_value_store
 from modules.devices.qcells.config import QCellsCounterSetup
@@ -18,7 +18,7 @@ class QCellsCounter:
         self.component_config = dataclass_from_dict(QCellsCounterSetup, component_config)
         self.__modbus_id = modbus_id
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_):
         power = client.read_input_registers(0x0046, ModbusDataType.INT_32, wordorder=Endian.Little,

--- a/packages/modules/devices/qcells/device.py
+++ b/packages/modules/devices/qcells/device.py
@@ -30,7 +30,7 @@ def create_device(device_config: QCells):
     def update_components(components: Iterable[Union[QCellsBat, QCellsCounter, QCellsInverter]]):
         with client as c:
             for component in components:
-                with SingleComponentUpdateContext(component.component_info):
+                with SingleComponentUpdateContext(component.fault_state):
                     component.update(c)
 
     try:

--- a/packages/modules/devices/qcells/inverter.py
+++ b/packages/modules/devices/qcells/inverter.py
@@ -5,7 +5,7 @@ from pymodbus.constants import Endian
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.store import get_inverter_value_store
 from modules.devices.qcells.config import QCellsInverterSetup
@@ -18,7 +18,7 @@ class QCellsInverter:
         self.component_config = dataclass_from_dict(QCellsInverterSetup, component_config)
         self.__modbus_id = modbus_id
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_) -> None:
         power_string1 = (client.read_input_registers(

--- a/packages/modules/devices/rct/bat.py
+++ b/packages/modules/devices/rct/bat.py
@@ -15,7 +15,7 @@ class RctBat:
     def __init__(self, component_config: RctBatSetup) -> None:
         self.component_config = dataclass_from_dict(RctBatSetup, component_config)
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, rct_client: RCT) -> None:
         my_tab = []
@@ -39,9 +39,9 @@ class RctBat:
         self.store.set(bat_state)
         if (stat1.value + stat2.value + stat3.value) > 0:
             # Werte werden trotz Fehlercode übermittelt.
-            raise FaultState.warning(
+            self.component_info.fault_state.warning(
                 f"Alarm Status Speicher ist ungleich 0. Status 1: {stat1.value}, Status 2: {stat2.value}, "
-                f"Status 3: {stat3.value},")
+                f"Status 3: {stat3.value}")
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=RctBatSetup)

--- a/packages/modules/devices/rct/counter.py
+++ b/packages/modules/devices/rct/counter.py
@@ -15,7 +15,7 @@ class RctCounter:
     def __init__(self, component_config: RctCounterSetup) -> None:
         self.component_config = dataclass_from_dict(RctCounterSetup, component_config)
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, rct_client: RCT):
         # generate id list for fast bulk read
@@ -49,7 +49,7 @@ class RctCounter:
         self.store.set(counter_state)
         if (stat1.value + stat2.value + stat3.value + stat4.value) > 0:
             # Werte werden trotz Fehlercode übermittelt.
-            raise FaultState.warning(
+            self.component_info.fault_state.warning(
                 f"Alarm Status Speicher ist ungleich 0. Status 1: {stat1.value}, Status 2: {stat2.value}, "
                 f"Status 3: {stat3.value}, Status 4: {stat4.value},")
 

--- a/packages/modules/devices/rct/inverter.py
+++ b/packages/modules/devices/rct/inverter.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.rct.config import RctInverterSetup
 from modules.devices.rct.rct_lib import RCT
@@ -12,7 +12,7 @@ class RctInverter:
     def __init__(self, component_config: RctInverterSetup) -> None:
         self.component_config = dataclass_from_dict(RctInverterSetup, component_config)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, rct_client: RCT) -> None:
         my_tab = []

--- a/packages/modules/devices/saxpower/bat.py
+++ b/packages/modules/devices/saxpower/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -22,7 +22,7 @@ class SaxpowerBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/devices/saxpower/device.py
+++ b/packages/modules/devices/saxpower/device.py
@@ -48,7 +48,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/shelly/inverter.py
+++ b/packages/modules/devices/shelly/inverter.py
@@ -4,7 +4,7 @@ from typing import Optional
 from modules.common import req
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.common.simcount._simcounter import SimCounter
 from modules.devices.shelly.config import ShellyInverterSetup
@@ -22,7 +22,7 @@ class ShellyInverter:
         self.component_config = component_config
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.address = address
         self.generation = generation
 

--- a/packages/modules/devices/siemens/bat.py
+++ b/packages/modules/devices/siemens/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -22,7 +22,7 @@ class SiemensBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/devices/siemens/counter.py
+++ b/packages/modules/devices/siemens/counter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -22,7 +22,7 @@ class SiemensCounter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
 

--- a/packages/modules/devices/siemens/device.py
+++ b/packages/modules/devices/siemens/device.py
@@ -55,7 +55,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/siemens/inverter.py
+++ b/packages/modules/devices/siemens/inverter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -22,7 +22,7 @@ class SiemensInverter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/devices/siemens_sentron/counter.py
+++ b/packages/modules/devices/siemens_sentron/counter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
 from modules.devices.siemens_sentron.config import SiemensSentronCounterSetup
@@ -18,7 +18,7 @@ class SiemensSentronCounter:
         self.component_config = dataclass_from_dict(SiemensSentronCounterSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/devices/siemens_sentron/device.py
+++ b/packages/modules/devices/siemens_sentron/device.py
@@ -48,7 +48,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/sma_sunny_boy/bat.py
+++ b/packages/modules/devices/sma_sunny_boy/bat.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.store import get_bat_value_store
 from modules.devices.sma_sunny_boy.config import SmaSunnyBoyBatSetup
@@ -18,7 +18,7 @@ class SunnyBoyBat:
         self.component_config = dataclass_from_dict(SmaSunnyBoyBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def read(self) -> BatState:
         unit = 3

--- a/packages/modules/devices/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma_sunny_boy/bat_smart_energy.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -23,7 +23,7 @@ class SunnyBoySmartEnergyBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         self.store.set(self.read())

--- a/packages/modules/devices/sma_sunny_boy/counter.py
+++ b/packages/modules/devices/sma_sunny_boy/counter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -22,7 +22,7 @@ class SmaSunnyBoyCounter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         imp = self.__tcp_client.read_holding_registers(30865, ModbusDataType.UINT_32, unit=3)

--- a/packages/modules/devices/sma_sunny_boy/device.py
+++ b/packages/modules/devices/sma_sunny_boy/device.py
@@ -74,7 +74,7 @@ class Device(AbstractDevice):
             with self.client:
                 for component in self.components.values():
                     # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                    with SingleComponentUpdateContext(component.component_info):
+                    with SingleComponentUpdateContext(component.fault_state):
                         component.update()
         else:
             log.warning(
@@ -150,7 +150,7 @@ def read_inverter(ip1: str,
     # Since openWB 2 does not have a limitation on the number of inverters we do not implement this there. However
     # we still need to implement this for the read_legacy-bridge.
     # Here we act like we only update the first inverter, while we actually query all inverters and sum them up:
-    with SingleComponentUpdateContext(inverter1.component_info):
+    with SingleComponentUpdateContext(inverter1.fault_state):
         if isinstance(inverter1, SmaWebboxInverter):
             state = inverter1.read()
             total_power = state.power

--- a/packages/modules/devices/sma_sunny_boy/inverter.py
+++ b/packages/modules/devices/sma_sunny_boy/inverter.py
@@ -26,7 +26,7 @@ class SmaSunnyBoyInverter:
         self.component_config = dataclass_from_dict(SmaSunnyBoyInverterSetup, component_config)
         self.tcp_client = tcp_client
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         self.store.set(self.read())

--- a/packages/modules/devices/sma_sunny_island/bat.py
+++ b/packages/modules/devices/sma_sunny_island/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_bat_value_store
 from modules.devices.sma_sunny_island.config import SmaSunnyIslandBatSetup
@@ -18,7 +18,7 @@ class SunnyIslandBat:
         self.component_config = dataclass_from_dict(SmaSunnyIslandBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def read(self) -> BatState:
         unit = 3

--- a/packages/modules/devices/sma_sunny_island/device.py
+++ b/packages/modules/devices/sma_sunny_island/device.py
@@ -48,7 +48,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components.values():
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(component.component_info):
+                with SingleComponentUpdateContext(component.fault_state):
                     component.update()
         else:
             log.warning(

--- a/packages/modules/devices/sma_webbox/device.py
+++ b/packages/modules/devices/sma_webbox/device.py
@@ -45,7 +45,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components.values():
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(component.component_info):
+                with SingleComponentUpdateContext(component.fault_state):
                     component.update()
         else:
             log.warning(

--- a/packages/modules/devices/sma_webbox/inverter.py
+++ b/packages/modules/devices/sma_webbox/inverter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.sma_webbox.config import SmaWebboxInverterSetup
 
@@ -15,7 +15,7 @@ class SmaWebboxInverter:
         self.__device_address = device_address
         self.component_config = dataclass_from_dict(SmaWebboxInverterSetup, component_config)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         self.store.set(self.read())

--- a/packages/modules/devices/smart_me/counter.py
+++ b/packages/modules/devices/smart_me/counter.py
@@ -7,7 +7,7 @@ from requests import Session
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 from modules.devices.smart_me.config import SmartMeCounterSetup
 
@@ -19,7 +19,7 @@ class SmartMeCounter:
                  component_config: Union[Dict, SmartMeCounterSetup]) -> None:
         self.component_config = dataclass_from_dict(SmartMeCounterSetup, component_config)
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session) -> None:
         def parse_phase_values(key: str) -> List[float]:

--- a/packages/modules/devices/smart_me/inverter.py
+++ b/packages/modules/devices/smart_me/inverter.py
@@ -7,7 +7,7 @@ from requests import Session
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.smart_me.config import SmartMeInverterSetup
 
@@ -19,7 +19,7 @@ class SmartMeInverter:
                  component_config: Union[Dict, SmartMeInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(SmartMeInverterSetup, component_config)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, session: Session) -> None:
         response = session.get('https://smart-me.com:443/api/Devices/' +

--- a/packages/modules/devices/smartfox/counter.py
+++ b/packages/modules/devices/smartfox/counter.py
@@ -7,7 +7,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 from modules.devices.smartfox.config import SmartfoxCounterSetup
 
@@ -21,7 +21,7 @@ class SmartfoxCounter:
         self.__device_address = device_address
         self.component_config = dataclass_from_dict(SmartfoxCounterSetup, component_config)
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         def get_xml_text(attribute_value: str) -> str:

--- a/packages/modules/devices/solar_log/counter.py
+++ b/packages/modules/devices/solar_log/counter.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.solar_log.config import SolarLogCounterSetup
@@ -21,7 +21,7 @@ class SolarLogCounter:
         self.component_config = dataclass_from_dict(SolarLogCounterSetup, component_config)
         self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response: Dict) -> None:
         self.store_values(self.get_power(response))

--- a/packages/modules/devices/solar_log/inverter.py
+++ b/packages/modules/devices/solar_log/inverter.py
@@ -5,7 +5,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.solar_log.config import SolarLogInverterSetup
 
@@ -18,7 +18,7 @@ class SolarLogInverter:
                  component_config: Union[Dict, SolarLogInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(SolarLogInverterSetup, component_config)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response: Dict) -> None:
         self.store.set(self.get_values(response))

--- a/packages/modules/devices/solar_view/counter.py
+++ b/packages/modules/devices/solar_view/counter.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 from modules.devices.solar_view.api import request
 from modules.devices.solar_view.config import SolarViewCounterSetup
@@ -18,7 +18,7 @@ class SolarViewCounter:
     def __init__(self, component_config: Union[Dict, SolarViewCounterSetup]) -> None:
         self.component_config = dataclass_from_dict(SolarViewCounterSetup, component_config)
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, ip_address: str, port: int, timeout: int) -> None:
         exported_values = request(ip_address, port, timeout, '21*')

--- a/packages/modules/devices/solar_view/inverter.py
+++ b/packages/modules/devices/solar_view/inverter.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.solar_view.api import request
 from modules.devices.solar_view.config import SolarViewInverterSetup
@@ -18,7 +18,7 @@ class SolarViewInverter:
     def __init__(self, component_config: Union[Dict, SolarViewInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(SolarViewInverterSetup, component_config)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, ip_address: str, port: int, timeout: int) -> None:
         values = request(ip_address, port, timeout, self.component_config.configuration.command)

--- a/packages/modules/devices/solar_watt/bat.py
+++ b/packages/modules/devices/solar_watt/bat.py
@@ -5,7 +5,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.solar_watt.api import parse_value
@@ -22,7 +22,7 @@ class SolarWattBat:
         self.component_config = dataclass_from_dict(SolarWattBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response: Dict, energy_manager: bool) -> None:
         if energy_manager:

--- a/packages/modules/devices/solar_watt/counter.py
+++ b/packages/modules/devices/solar_watt/counter.py
@@ -5,7 +5,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.solar_watt.api import parse_value
@@ -22,7 +22,7 @@ class SolarWattCounter:
         self.component_config = dataclass_from_dict(SolarWattCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response: Dict, energy_manager: bool) -> None:
         if energy_manager:

--- a/packages/modules/devices/solar_watt/inverter.py
+++ b/packages/modules/devices/solar_watt/inverter.py
@@ -5,7 +5,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.solar_watt.api import parse_value
@@ -22,7 +22,7 @@ class SolarWattInverter:
         self.component_config = dataclass_from_dict(SolarWattInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response: Dict) -> None:
         power = parse_value(response, "PowerProduced") * -1

--- a/packages/modules/devices/solar_world/counter.py
+++ b/packages/modules/devices/solar_world/counter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.solar_world.config import SolarWorldCounterSetup
@@ -16,7 +16,7 @@ class SolarWorldCounter:
         self.component_config = dataclass_from_dict(SolarWorldCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response):
         power = response["PowerIn"] - response["PowerOut"]

--- a/packages/modules/devices/solar_world/inverter.py
+++ b/packages/modules/devices/solar_world/inverter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.solar_world.config import SolarWorldInverterSetup
@@ -16,7 +16,7 @@ class SolarWorldInverter:
         self.component_config = dataclass_from_dict(SolarWorldInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         try:

--- a/packages/modules/devices/solaredge/bat.py
+++ b/packages/modules/devices/solaredge/bat.py
@@ -8,7 +8,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -29,7 +29,7 @@ class SolaredgeBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         self.store.set(self.read_state())

--- a/packages/modules/devices/solaredge/counter.py
+++ b/packages/modules/devices/solaredge/counter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
 from modules.devices.solaredge.config import SolaredgeCounterSetup
@@ -25,7 +25,7 @@ class SolaredgeCounter:
         self.__tcp_client = tcp_client
         self.registers = SolaredgeMeterRegisters()
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self._read_scaled_int16 = create_scaled_reader(
             self.__tcp_client, self.component_config.configuration.modbus_id, ModbusDataType.INT_16
         )

--- a/packages/modules/devices/solaredge/device.py
+++ b/packages/modules/devices/solaredge/device.py
@@ -102,7 +102,7 @@ class Device(AbstractDevice):
             with self.client:
                 for component in self.components:
                     # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                    with SingleComponentUpdateContext(self.components[component].component_info):
+                    with SingleComponentUpdateContext(self.components[component].fault_state):
                         self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/solaredge/external_inverter.py
+++ b/packages/modules/devices/solaredge/external_inverter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
 from modules.devices.solaredge.config import SolaredgeExternalInverterSetup
@@ -25,7 +25,7 @@ class SolaredgeExternalInverter:
         self.__tcp_client = tcp_client
         self.registers = SolaredgeMeterRegisters(self.component_config.configuration.meter_id)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self._read_scaled_int16 = create_scaled_reader(
             self.__tcp_client, self.component_config.configuration.modbus_id, ModbusDataType.INT_16
         )

--- a/packages/modules/devices/solaredge/inverter.py
+++ b/packages/modules/devices/solaredge/inverter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
 from modules.devices.solaredge.config import SolaredgeInverterSetup
@@ -20,7 +20,7 @@ class SolaredgeInverter:
         self.component_config = dataclass_from_dict(SolaredgeInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self._read_scaled_int16 = create_scaled_reader(
             self.__tcp_client, self.component_config.configuration.modbus_id, ModbusDataType.INT_16
         )

--- a/packages/modules/devices/solarmax/bat.py
+++ b/packages/modules/devices/solarmax/bat.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -15,7 +15,7 @@ class SolarmaxBat:
         self.component_config = dataclass_from_dict(SolarmaxBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_) -> None:
         unit = self.component_config.configuration.modbus_id

--- a/packages/modules/devices/solarmax/device.py
+++ b/packages/modules/devices/solarmax/device.py
@@ -24,7 +24,7 @@ def create_device(device_config: Solarmax):
     def update_components(components: Iterable[Union[SolarmaxBat, inverter.SolarmaxInverter]]):
         with client as c:
             for component in components:
-                with SingleComponentUpdateContext(component.component_info):
+                with SingleComponentUpdateContext(component.fault_state):
                     component.update(c)
 
     try:

--- a/packages/modules/devices/solarmax/inverter.py
+++ b/packages/modules/devices/solarmax/inverter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -19,7 +19,7 @@ class SolarmaxInverter:
         self.component_config = dataclass_from_dict(SolarmaxInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_) -> None:
         power = client.read_holding_registers(4151, ModbusDataType.UINT_32,

--- a/packages/modules/devices/solax/bat.py
+++ b/packages/modules/devices/solax/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -24,7 +24,7 @@ class SolaxBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/devices/solax/counter.py
+++ b/packages/modules/devices/solax/counter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_counter_value_store
 from modules.devices.solax.config import SolaxCounterSetup
@@ -23,7 +23,7 @@ class SolaxCounter:
         self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         with self.__tcp_client:

--- a/packages/modules/devices/solax/device.py
+++ b/packages/modules/devices/solax/device.py
@@ -56,7 +56,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/solax/inverter.py
+++ b/packages/modules/devices/solax/inverter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
 from modules.devices.solax.config import SolaxInverterSetup
@@ -22,7 +22,7 @@ class SolaxInverter:
         self.__modbus_id = modbus_id
         self.__tcp_client = tcp_client
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         with self.__tcp_client:

--- a/packages/modules/devices/sonnenbatterie/bat.py
+++ b/packages/modules/devices/sonnenbatterie/bat.py
@@ -6,8 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
-from modules.common.fault_state import FaultState
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sonnenbatterie.config import SonnenbatterieBatSetup
@@ -27,7 +26,7 @@ class SonnenbatterieBat:
         self.component_config = dataclass_from_dict(SonnenbatterieBatSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def __read_variant_0(self):
         return req.get_http_session().get('http://' + self.__device_address + ':7979/rest/devices/battery',

--- a/packages/modules/devices/sonnenbatterie/counter.py
+++ b/packages/modules/devices/sonnenbatterie/counter.py
@@ -6,8 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
-from modules.common.fault_state import FaultState
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.sonnenbatterie.config import SonnenbatterieCounterSetup
@@ -27,7 +26,7 @@ class SonnenbatterieCounter:
         self.component_config = dataclass_from_dict(SonnenbatterieCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def __read_variant_1(self, api: str = "v1"):
         return req.get_http_session().get(

--- a/packages/modules/devices/sonnenbatterie/device.py
+++ b/packages/modules/devices/sonnenbatterie/device.py
@@ -62,7 +62,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/sonnenbatterie/inverter.py
+++ b/packages/modules/devices/sonnenbatterie/inverter.py
@@ -6,8 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
-from modules.common.fault_state import FaultState
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.sonnenbatterie.config import SonnenbatterieInverterSetup
@@ -27,7 +26,7 @@ class SonnenbatterieInverter:
         self.component_config = dataclass_from_dict(SonnenbatterieInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def __read_variant_1(self, api: str = "v1"):
         return req.get_http_session().get(

--- a/packages/modules/devices/studer/bat.py
+++ b/packages/modules/devices/studer/bat.py
@@ -6,7 +6,7 @@ from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.modbus import ModbusDataType
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_bat_value_store
 from modules.devices.studer.config import StuderBatSetup
 
@@ -18,7 +18,7 @@ class StuderBat:
         self.component_config = dataclass_from_dict(StuderBatSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         unit = 60

--- a/packages/modules/devices/studer/device.py
+++ b/packages/modules/devices/studer/device.py
@@ -52,7 +52,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/studer/inverter.py
+++ b/packages/modules/devices/studer/inverter.py
@@ -18,7 +18,7 @@ class StuderInverter:
         self.component_config = dataclass_from_dict(StuderInverterSetup, component_config)
         self.__tcp_client = tcp_client
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         vc_count = self.component_config.configuration.vc_count

--- a/packages/modules/devices/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -24,7 +24,7 @@ class SungrowBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         unit = self.__device_modbus_id

--- a/packages/modules/devices/sungrow/counter.py
+++ b/packages/modules/devices/sungrow/counter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, Endian
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -25,7 +25,7 @@ class SungrowCounter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, pv_power: float):
         unit = self.__device_modbus_id

--- a/packages/modules/devices/sungrow/inverter.py
+++ b/packages/modules/devices/sungrow/inverter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, Endian
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -24,7 +24,7 @@ class SungrowInverter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> float:
         unit = self.__device_modbus_id

--- a/packages/modules/devices/sunways/device.py
+++ b/packages/modules/devices/sunways/device.py
@@ -47,7 +47,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/sunways/inverter.py
+++ b/packages/modules/devices/sunways/inverter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.sunways.config import SunwaysInverterSetup
 
@@ -27,7 +27,7 @@ class SunwaysInverter:
         self.ip_address = ip_address
         self.password = password
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         params = (

--- a/packages/modules/devices/tesla/bat.py
+++ b/packages/modules/devices/tesla/bat.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_bat_value_store
 from modules.devices.tesla.http_client import PowerwallHttpClient
 from modules.devices.tesla.config import TeslaBatSetup
@@ -14,7 +14,7 @@ class TeslaBat:
     def __init__(self, component_config: Union[Dict, TeslaBatSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaBatSetup, component_config)
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: PowerwallHttpClient, aggregate) -> None:
         self.store.set(BatState(

--- a/packages/modules/devices/tesla/counter.py
+++ b/packages/modules/devices/tesla/counter.py
@@ -6,7 +6,7 @@ from requests import HTTPError
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_counter_value_store
 from modules.devices.tesla.config import TeslaCounterSetup
 from modules.devices.tesla.http_client import PowerwallHttpClient
@@ -18,7 +18,7 @@ class TeslaCounter:
     def __init__(self, component_config: Union[Dict, TeslaCounterSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaCounterSetup, component_config)
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: PowerwallHttpClient, aggregate):
         # read firmware version

--- a/packages/modules/devices/tesla/inverter.py
+++ b/packages/modules/devices/tesla/inverter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.tesla.http_client import PowerwallHttpClient
 from modules.devices.tesla.config import TeslaInverterSetup
@@ -14,7 +14,7 @@ class TeslaInverter:
     def __init__(self, component_config: Union[Dict, TeslaInverterSetup]) -> None:
         self.component_config = dataclass_from_dict(TeslaInverterSetup, component_config)
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: PowerwallHttpClient, aggregate) -> None:
         pv_watt = aggregate["solar"]["instant_power"]

--- a/packages/modules/devices/varta/bat_api.py
+++ b/packages/modules/devices/varta/bat_api.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import req
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.varta.config import VartaBatApiSetup
@@ -18,7 +18,7 @@ class VartaBatApi:
         self.__device_address = device_address
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         def get_xml_text(attribute_value: str) -> float:

--- a/packages/modules/devices/varta/bat_modbus.py
+++ b/packages/modules/devices/varta/bat_modbus.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -15,7 +15,7 @@ class VartaBatModbus:
         self.component_config = dataclass_from_dict(VartaBatModbusSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_) -> None:
         self.set_state(self.get_state(client))

--- a/packages/modules/devices/varta/counter.py
+++ b/packages/modules/devices/varta/counter.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -15,7 +15,7 @@ class VartaCounter:
         self.component_config = dataclass_from_dict(VartaCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, client: ModbusTcpClient_):
         power = client.read_holding_registers(1078, ModbusDataType.INT_16, unit=1) * -1

--- a/packages/modules/devices/varta/device.py
+++ b/packages/modules/devices/varta/device.py
@@ -33,11 +33,11 @@ def create_device(device_config: Varta):
         with client as c:
             for component in components:
                 if isinstance(component, (VartaBatModbus, VartaCounter)):
-                    with SingleComponentUpdateContext(component.component_info):
+                    with SingleComponentUpdateContext(component.fault_state):
                         component.update(c)
         for component in components:
             if isinstance(component, (VartaBatApi)):
-                with SingleComponentUpdateContext(component.component_info):
+                with SingleComponentUpdateContext(component.fault_state):
                     component.update()
 
     try:

--- a/packages/modules/devices/victron/bat.py
+++ b/packages/modules/devices/victron/bat.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
@@ -22,7 +22,7 @@ class VictronBat:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id

--- a/packages/modules/devices/victron/counter.py
+++ b/packages/modules/devices/victron/counter.py
@@ -5,7 +5,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
@@ -22,7 +22,7 @@ class VictronCounter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         unit = self.component_config.configuration.modbus_id

--- a/packages/modules/devices/victron/device.py
+++ b/packages/modules/devices/victron/device.py
@@ -55,7 +55,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/victron/inverter.py
+++ b/packages/modules/devices/victron/inverter.py
@@ -6,7 +6,7 @@ from dataclass_utils import dataclass_from_dict
 from modules.common import modbus
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
@@ -25,7 +25,7 @@ class VictronInverter:
         self.__tcp_client = tcp_client
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id

--- a/packages/modules/devices/virtual/counter.py
+++ b/packages/modules/devices/virtual/counter.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.virtual.config import VirtualCounterSetup
@@ -17,7 +17,7 @@ class VirtualCounter:
         self.component_config = dataclass_from_dict(VirtualCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id, add_child_values=True)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         imported, exported = self.sim_counter.sim_count(self.component_config.configuration.external_consumption)

--- a/packages/modules/devices/virtual/device.py
+++ b/packages/modules/devices/virtual/device.py
@@ -41,7 +41,7 @@ class Device(AbstractDevice):
         if self.components:
             for component in self.components:
                 # Auch wenn bei einer Komponente ein Fehler auftritt, sollen alle anderen noch ausgelesen werden.
-                with SingleComponentUpdateContext(self.components[component].component_info):
+                with SingleComponentUpdateContext(self.components[component].fault_state):
                     self.components[component].update()
         else:
             log.warning(

--- a/packages/modules/devices/vzlogger/counter.py
+++ b/packages/modules/devices/vzlogger/counter.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.vzlogger.config import VZLoggerCounterSetup
@@ -15,7 +15,7 @@ class VZLoggerCounter:
         self.component_config = dataclass_from_dict(VZLoggerCounterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response):
         config = self.component_config.configuration

--- a/packages/modules/devices/vzlogger/inverter.py
+++ b/packages/modules/devices/vzlogger/inverter.py
@@ -2,7 +2,7 @@
 from dataclass_utils import dataclass_from_dict
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.vzlogger.config import VZLoggerInverterSetup
@@ -15,7 +15,7 @@ class VZLoggerInverter:
         self.component_config = dataclass_from_dict(VZLoggerInverterSetup, component_config)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         config = self.component_config.configuration

--- a/packages/modules/devices/youless/inverter.py
+++ b/packages/modules/devices/youless/inverter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store import get_inverter_value_store
 from modules.devices.youless.config import YoulessInverterSetup
 
@@ -10,7 +10,7 @@ class YoulessInverter:
     def __init__(self, component_config: YoulessInverterSetup) -> None:
         self.component_config = component_config
         self.store = get_inverter_value_store(self.component_config.id)
-        self.component_info = ComponentInfo.from_component_config(self.component_config)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self, response) -> None:
         if self.component_config.configuration.source_s0:

--- a/packages/modules/internal_chargepoint_handler/chargepoint_module.py
+++ b/packages/modules/internal_chargepoint_handler/chargepoint_module.py
@@ -7,6 +7,7 @@ from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import ChargepointState
 from modules.common.fault_state import ComponentInfo, FaultState
+from modules.common.hardware_check_context import SeriesHardwareCheckContext
 from modules.common.store import get_internal_chargepoint_value_store, get_chargepoint_value_store
 from modules.internal_chargepoint_handler.clients import ClientHandler
 
@@ -27,12 +28,12 @@ class ChargepointModule(AbstractChargepoint):
                  parent_cp: int,
                  hierarchy_id: int) -> None:
         self.local_charge_point_num = local_charge_point_num
-        self.component_info = ComponentInfo(
+        self.fault_state = FaultState(ComponentInfo(
             hierarchy_id,
             "Ladepunkt "+str(local_charge_point_num),
             "chargepoint",
             parent_id=parent_cp,
-            parent_hostname=parent_hostname)
+            parent_hostname=parent_hostname))
         self.store_internal = get_internal_chargepoint_value_store(local_charge_point_num)
         self.store = get_chargepoint_value_store(hierarchy_id)
         self.old_plug_state = False
@@ -47,7 +48,7 @@ class ChargepointModule(AbstractChargepoint):
             self._precise_current = self.__client.evse_client.is_precise_current_active()
 
     def set_current(self, current: float) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             formatted_current = int(current*100) if self._precise_current else int(current)
             if self.set_current_evse != formatted_current:
                 self.__client.evse_client.set_current(formatted_current)
@@ -59,25 +60,23 @@ class ChargepointModule(AbstractChargepoint):
             self.store_internal.set(chargepoint_state)
             self.store_internal.update()
         try:
-            powers, power = self.__client.meter_client.get_power()
-            if power < self.PLUG_STANDBY_POWER_THRESHOLD:
-                power = 0
-            voltages = self.__client.meter_client.get_voltages()
-            meter_check_passed, meter_error_msg = self.__client.check_meter()
-            if meter_check_passed is False:
-                raise ValueError(meter_error_msg)
-            currents = self.__client.meter_client.get_currents()
-            imported = self.__client.meter_client.get_imported()
-            power_factors = self.__client.meter_client.get_power_factors()
-            frequency = self.__client.meter_client.get_frequency()
-            phases_in_use = sum(1 for current in currents if current > 3)
-            if phases_in_use == 0:
-                phases_in_use = self.old_phases_in_use
-            else:
-                self.old_phases_in_use = phases_in_use
+            with SeriesHardwareCheckContext(self.__client):
+                powers, power = self.__client.meter_client.get_power()
+                if power < self.PLUG_STANDBY_POWER_THRESHOLD:
+                    power = 0
+                voltages = self.__client.meter_client.get_voltages()
+                currents = self.__client.meter_client.get_currents()
+                imported = self.__client.meter_client.get_imported()
+                power_factors = self.__client.meter_client.get_power_factors()
+                frequency = self.__client.meter_client.get_frequency()
+                phases_in_use = sum(1 for current in currents if current > 3)
+                if phases_in_use == 0:
+                    phases_in_use = self.old_phases_in_use
+                else:
+                    self.old_phases_in_use = phases_in_use
 
-            time.sleep(0.1)
-            plug_state, charge_state, self.set_current_evse = self.__client.evse_client.get_plug_charge_state()
+                time.sleep(0.1)
+                plug_state, charge_state, self.set_current_evse = self.__client.evse_client.get_plug_charge_state()
             self.__client.read_error = 0
 
             if phase_switch_cp_active:
@@ -121,7 +120,6 @@ class ChargepointModule(AbstractChargepoint):
                 store_state(chargepoint_state)
                 raise FaultState.error(msg)
             else:
-                self.__client.check_hardware()
                 raise FaultState.error(__name__ + " " + str(type(e)) + " " + str(e)) from e
 
         store_state(chargepoint_state)
@@ -129,7 +127,7 @@ class ChargepointModule(AbstractChargepoint):
 
     def perform_phase_switch(self, phases_to_use: int, duration: int) -> None:
         gpio_cp, gpio_relay = self.__client.get_pins_phase_switch(phases_to_use)
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             self.__client.evse_client.set_current(0)
         time.sleep(1)
         GPIO.output(gpio_cp, GPIO.HIGH)  # CP off
@@ -142,7 +140,7 @@ class ChargepointModule(AbstractChargepoint):
 
     def perform_cp_interruption(self, duration: int) -> None:
         gpio_cp = self.__client.get_pins_cp_interruption()
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             self.__client.evse_client.set_current(0)
         GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BOARD)

--- a/packages/modules/internal_chargepoint_handler/internal_chargepoint_handler.py
+++ b/packages/modules/internal_chargepoint_handler/internal_chargepoint_handler.py
@@ -11,7 +11,7 @@ from helpermodules.pub import Pub, pub_single
 from helpermodules.subdata import SubData
 from modules.chargepoints.internal_openwb.config import InternalChargepointMode
 from modules.common.component_context import SingleComponentUpdateContext
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.store._util import get_rounding_function_by_digits
 from modules.common.component_state import ChargepointState
 from modules.internal_chargepoint_handler import chargepoint_module
@@ -146,15 +146,20 @@ class InternalChargepointHandler:
         self.event_start = event_start
         self.event_stop = event_stop
         self.heartbeat = False
-        with SingleComponentUpdateContext(
+        fault_state_info_cp0 = FaultState(
             ComponentInfo(hierarchy_id_cp0, "Interner Ladepunkt 0", "chargepoint", parent_id=parent_cp0,
-                          parent_hostname=global_data.parent_ip)):
+                          parent_hostname=global_data.parent_ip))
+        fault_state_info_cp1 = FaultState(
+            ComponentInfo(hierarchy_id_cp1, "Interner Ladepunkt 1", "chargepoint", parent_id=parent_cp1,
+                          parent_hostname=global_data.parent_ip))
+        with SingleComponentUpdateContext(fault_state_info_cp0):
             # Allgemeine Fehlermeldungen an LP 1:
-            self.cp0_client_handler = client_factory(0)
+            self.cp0_client_handler = client_factory(0, fault_state_info_cp0)
             self.cp0 = HandlerChargepoint(self.cp0_client_handler, 0, mode, global_data, parent_cp0, hierarchy_id_cp0)
+        with SingleComponentUpdateContext(fault_state_info_cp1):
             if mode == InternalChargepointMode.DUO.value:
                 log.debug("Zweiter Ladepunkt für Duo konfiguriert.")
-                self.cp1_client_handler = client_factory(1, self.cp0_client_handler)
+                self.cp1_client_handler = client_factory(1, fault_state_info_cp1, self.cp0_client_handler)
                 self.cp1 = HandlerChargepoint(self.cp1_client_handler, 1, mode,
                                               global_data, parent_cp1, hierarchy_id_cp1)
             else:
@@ -223,7 +228,7 @@ class HandlerChargepoint:
         else:
             self.module = chargepoint_module.ChargepointModule(
                 local_charge_point_num, client_handler, global_data.parent_ip, parent_cp, hierarchy_id)
-        with SingleComponentUpdateContext(self.module.component_info):
+        with SingleComponentUpdateContext(self.module.fault_state):
             self.update_values = UpdateValues(local_charge_point_num, global_data.parent_ip, parent_cp, hierarchy_id)
             self.update_state = UpdateState(self.module, hierarchy_id)
             self.old_plug_state = False
@@ -234,7 +239,7 @@ class HandlerChargepoint:
                 return thread.is_alive()
             else:
                 return False
-        with SingleComponentUpdateContext(self.module.component_info):
+        with SingleComponentUpdateContext(self.module.fault_state):
             if self.local_charge_point_num == 1:
                 time.sleep(0.1)
             phase_switch_cp_active = __thread_active(self.update_state.cp_interruption_thread) or __thread_active(

--- a/packages/modules/internal_chargepoint_handler/socket.py
+++ b/packages/modules/internal_chargepoint_handler/socket.py
@@ -56,7 +56,7 @@ class Socket(ChargepointModule):
         super().__init__(local_charge_point_num, client_handler, parent_hostname, parent_cp, hierarchy_id)
 
     def set_current(self, current: float) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             try:
                 actor = ActorState(GPIO.input(19))
             except Exception:

--- a/packages/modules/vehicles/skodaconnect/soc-disabled.py
+++ b/packages/modules/vehicles/skodaconnect/soc-disabled.py
@@ -9,7 +9,7 @@ from modules.common.abstract_device import DeviceDescriptor
 from modules.common.abstract_vehicle import AbstractSoc
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_state import CarState
-from modules.common.fault_state import ComponentInfo
+from modules.common.fault_state import ComponentInfo, FaultState
 from modules.vehicles.skodaconnect.api import SkodaConnectApi
 from modules.vehicles.skodaconnect.config import SkodaConnect, SkodaConnectConfiguration
 
@@ -22,10 +22,10 @@ class Soc(AbstractSoc):
         self.config = dataclass_from_dict(SkodaConnect, device_config)
         self.vehicle = vehicle
         self.store = store.get_car_value_store(self.vehicle)
-        self.component_info = ComponentInfo(self.vehicle, self.config.name, "vehicle")
+        self.fault_state = FaultState(ComponentInfo(self.vehicle, self.config.name, "vehicle"))
 
     def update(self, charge_state: bool = False) -> None:
-        with SingleComponentUpdateContext(self.component_info):
+        with SingleComponentUpdateContext(self.fault_state):
             soc, range = SkodaConnectApi(self.config, self.vehicle).fetch_soc()
             self.store.set(CarState(soc, range))
 


### PR DESCRIPTION
Bisher wurden Fehlermeldungen im UI nur korrekt angezeigt, wenn sie über `raise` abgesetzt wurden. Nun kann auch per Setzen von `self.fault_state.warning(msg)` eine Warnung erzeugt werden.
Erkennung eines defekten Zählers in der openWB Pro.