### PR TITLE
fix logging evse version

### DIFF
--- a/packages/modules/common/evse.py
+++ b/packages/modules/common/evse.py
@@ -53,8 +53,6 @@ class Evse:
     def get_firmware_version(self) -> int:
         time.sleep(0.1)
         version = self.client.read_holding_registers(1005, ModbusDataType.UINT_16, unit=self.id)
-        with ModifyLoglevelContext(log, logging.DEBUG):
-            log.debug("FW-Version: "+str(version))
         return version
 
     def is_precise_current_active(self) -> bool:

--- a/packages/modules/internal_chargepoint_handler/chargepoint_module.py
+++ b/packages/modules/internal_chargepoint_handler/chargepoint_module.py
@@ -2,6 +2,7 @@ import logging
 
 import time
 from typing import Tuple
+from helpermodules.logger import ModifyLoglevelContext
 
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.component_context import SingleComponentUpdateContext
@@ -40,6 +41,8 @@ class ChargepointModule(AbstractChargepoint):
         self.old_phases_in_use = 0
         self.__client = client_handler
         version = self.__client.evse_client.get_firmware_version()
+        with ModifyLoglevelContext(log, logging.DEBUG):
+            log.debug(f"Firmware-Version der EVSE: {version}")
         if version < 17:
             self._precise_current = False
         else:


### PR DESCRIPTION
Durch den Hardware-Check wurde jeden Durchlauf die EVSE-Version im Level Debug ausgegeben.