### PR TITLE
Partially revert PR #1262

### DIFF
--- a/packages/modules/devices/fems/bat.py
+++ b/packages/modules/devices/fems/bat.py
@@ -20,8 +20,7 @@ class FemsBat:
         else:
             data = "ess2"
         response = session.get(
-            "http://" + self.ip_address + ":8084/rest/channel/(" + data + "|_sum)/" +
-            "(Soc|DcChargeEnergy|DcDischargeEnergy|GridActivePower|ProductionActivePower|ConsumptionActivePower)",
+            "http://" + self.ip_address + ":8084/rest/channel/"+data+"/(Soc|DcChargeEnergy|DcDischargeEnergy)",
             timeout=2).json()
         for singleValue in response:
             address = singleValue["address"]
@@ -32,6 +31,15 @@ class FemsBat:
             elif address == data+"/DcDischargeEnergy":
                 exported = scale_metric(singleValue['value'], singleValue.get('unit'), 'Wh')
             elif address == "_sum/GridActivePower":
+                grid = scale_metric(singleValue['value'], singleValue.get('unit'), 'W')
+
+        response = session.get(
+            "http://" + self.ip_address +
+            ":8084/rest/channel/_sum/(GridActivePower|ProductionActivePower|ConsumptionActivePower)",
+            timeout=2).json()
+        for singleValue in response:
+            address = singleValue["address"]
+            if (address == "_sum/GridActivePower"):
                 grid = scale_metric(singleValue['value'], singleValue.get('unit'), 'W')
             elif address == "_sum/ProductionActivePower":
                 pv = scale_metric(singleValue['value'], singleValue.get('unit'), 'W')

--- a/packages/modules/devices/fems/counter.py
+++ b/packages/modules/devices/fems/counter.py
@@ -16,11 +16,10 @@ class FemsCounter:
 
     def update(self, session: Session) -> None:
         try:
-            # Grid meter values and grid total energy sums
+            # Grid meter values
             response = session.get('http://' + self.ip_address +
-                                   ':8084/rest/channel/(meter0|_sum)/' +
-                                   '(ActivePower.*|VoltageL.|Frequency|Grid.+ActiveEnergy)',
-                                   timeout=6).json()
+                                   ':8084/rest/channel/meter0/(ActivePower.*|VoltageL.|Frequency)',
+                                   timeout=1).json()
 
             # ATTENTION: Recent FEMS versions started using the "unit" field (see example response below) and
             #            kind-of arbitrarily return either Volts, Kilowatthours or Hz or Millivolts, Watthours or
@@ -45,7 +44,15 @@ class FemsCounter:
                     voltages[1] = scale_metric(singleValue['value'], singleValue.get('unit'), 'V')
                 elif (address == 'meter0/VoltageL3'):
                     voltages[2] = scale_metric(singleValue['value'], singleValue.get('unit'), 'V')
-                elif (address == '_sum/GridBuyActiveEnergy'):
+
+            # Grid total energy sums
+            response = session.get(
+                'http://'+self.ip_address+':8084/rest/channel/_sum/Grid.+ActiveEnergy',
+                timeout=1).json()
+
+            for singleValue in response:
+                address = singleValue['address']
+                if (address == '_sum/GridBuyActiveEnergy'):
                     imported = scale_metric(singleValue['value'], singleValue.get('unit'), 'Wh')
                 elif (address == '_sum/GridSellActiveEnergy'):
                     exported = scale_metric(singleValue['value'], singleValue.get('unit'), 'Wh')

--- a/packages/modules/devices/fems/inverter.py
+++ b/packages/modules/devices/fems/inverter.py
@@ -16,15 +16,14 @@ class FemsInverter:
 
     def update(self, session: Session) -> None:
         response = session.get(
-            'http://'+self.ip_address+':8084/rest/channel/_sum/(ProductionActivePower|ProductionActiveEnergy)',
+            'http://'+self.ip_address+':8084/rest/channel/_sum/ProductionActivePower',
             timeout=2).json()
-        for singleValue in response:
-            address = singleValue["address"]
-            if address == "_sum/ProductionActivePower":
-                power = scale_metric(singleValue['value'], singleValue.get('unit'), 'W') * -1
-            elif address == "_sum/ProductionActiveEnergy":
-                exported = scale_metric(singleValue['value'], singleValue.get('unit'), 'Wh')
+        power = scale_metric(response["value"], response.get("unit"), 'W') * -1
 
+        response = session.get(
+            'http://'+self.ip_address+':8084/rest/channel/_sum/ProductionActiveEnergy',
+            timeout=2).json()
+        exported = scale_metric(response["value"], response.get("unit"), 'Wh')
         inverter_state = InverterState(
             power=power,
             exported=exported


### PR DESCRIPTION
Fixing issue #1347

At least older FEMS seem not to support Regex in any path fragment other than the very last one. FEMS just returns:

`requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://<IP>:8084/rest/channel/(meter0%7C_sum)/(ActivePower.*%7CVoltageL.%7CFrequency%7CGrid.+ActiveEnergy)`

We could try to detect the OpenEMS / FEMS version and behave accordingly. But who has multiple OpenEMS-versions available for testing in which versions which behaviour is supported? At least I don't and I don't even have control if and when Fenecon updates my FEMS.

So for now, I have no idea how to get a solution for both, the timeouts mentioned in PR #1262 and still support older FEMS. But to me the timeouts seem to be the less critical problem than not getting any more data out of FEMS.