### PR TITLE
fix totals percentage for diagram sum

### DIFF
--- a/packages/helpermodules/measurement_logging/process_log.py
+++ b/packages/helpermodules/measurement_logging/process_log.py
@@ -289,7 +289,7 @@ def _analyse_energy_source(data) -> Dict:
     if data:
         for i in range(0, len(data["entries"])):
             data["entries"][i] = analyse_percentage(data["entries"][i])
-        data["totals"] = analyse_percentage(data["totals"])
+        data["totals"] = analyse_percentage_totals(data["entries"], data["totals"])
     return data
 
 
@@ -334,6 +334,18 @@ def analyse_percentage(entry):
         log.exception(f"Fehler beim Berechnen des Strom-Mix von {entry['timestamp']}")
     finally:
         return entry
+
+
+def analyse_percentage_totals(entries, totals):
+    for source in ("grid", "pv", "bat", "cp"):
+        totals["hc"]["all"].update({f"energy_imported_{source}": 0})
+        totals["cp"]["all"].update({f"energy_imported_{source}": 0})
+        for entry in entries:
+            if "all" in entry["hc"].keys():
+                totals["hc"]["all"][f"energy_imported_{source}"] += entry["hc"]["all"][f"energy_imported_{source}"]*1000
+            if "all" in entry["cp"].keys():
+                totals["cp"]["all"][f"energy_imported_{source}"] += entry["cp"]["all"][f"energy_imported_{source}"]*1000
+    return totals
 
 
 def _process_entries(entries: List, calculation: CalculationType):


### PR DESCRIPTION
[https://openwb.de/forum/viewtopic.php?p=100537&sid=79f56b7229482f1924cf1e6a4c67bfbd#p100537](https://openwb.de/forum/viewtopic.php?p=100537&sid=79f56b7229482f1924cf1e6a4c67bfbd#p100537)
#12107284
Die Anteile für die Summen wurden über die Tagessummen berechnet. Dadurch wurde bei PV-Laden am Tag ohne Netzbezug trotzdem ein Anteil Netzbezug angezeigt, der im Tagesverlauf stattgefunden hat und auf alle Verbräuche umgelegt wurde. Jetzt werden die Anteile aus den einzelnen 5Min-Einträgen aufaddiert.

- [ ] @benderl Umrechnung in kWh ins Frontend verlagern?