### PR TITLE
fix phases for cps without phase switch

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -550,19 +550,17 @@ class Chargepoint(ChargepointRfidMixin):
             # Wenn noch kein Eintrag im Protokoll erstellt wurde, wurde noch nicht geladen und die Phase kann noch
             # umgeschaltet werden.
             if self.data.set.log.imported_since_plugged != 0:
-                no_switch = False
                 if charging_ev.ev_template.data.prevent_phase_switch:
                     log.info(f"Phasenumschaltung an Ladepunkt {self.num} nicht möglich, da bei EV"
                              f"{charging_ev.num} nach Ladestart nicht mehr umgeschaltet werden darf.")
-                    no_switch = True
-                elif self.cp_ev_support_phase_switch() is False:
-                    log.info(f"Phasenumschaltung an Ladepunkt {self.num} wird durch die Hardware nicht unterstützt.")
-                    no_switch = True
-                if no_switch:
                     if self.data.get.phases_in_use != 0:
                         phases = self.data.get.phases_in_use
                     else:
                         phases = self.data.control_parameter.phases
+                elif self.cp_ev_support_phase_switch() is False:
+                    # sonst passt die Phasenzahl nicht bei Autos, die eine Phase weg schalten.
+                    log.info(f"Phasenumschaltung an Ladepunkt {self.num} wird durch die Hardware nicht unterstützt.")
+                    phases = phases
         if phases != self.data.control_parameter.phases:
             self.data.control_parameter.phases = phases
         return phases

--- a/packages/control/chargepoint/get_phases_test.py
+++ b/packages/control/chargepoint/get_phases_test.py
@@ -152,7 +152,7 @@ cases_set_phases = [
     SetPhasesParams(name="Switch phases", phases=1, phases_in_use=3, prevent_phase_switch=False,
                     imported_since_plugged=1, phase_switch_suppported=True, expected_phases=1),
     SetPhasesParams(name="Phase switch not supported by cp", phases=1, phases_in_use=3, prevent_phase_switch=False,
-                    imported_since_plugged=1, phase_switch_suppported=False, expected_phases=3)
+                    imported_since_plugged=1, phase_switch_suppported=False, expected_phases=1)
 ]
 
 


### PR DESCRIPTION
Bei Ladepunkten ohne Phasenumschaltung wurde bisher als Phasenzahl phases_in_use genommen. Dadurch wurde eine Fehlkonfiguration der Phasenzahl durch den Benutzer ausgeschlossen. Allerdings führt dies zu Problemen bei Fahrzeugen, die beim Ladeende Phasen wegschalten. Deshalb wird nun doch die Phasenzahl aus den Einstellungen ermittelt.
[https://openwb.de/forum/viewtopic.php?p=100923#p100923](https://openwb.de/forum/viewtopic.php?p=100923#p100923)