### PR TITLE
Voltego: catch regenerated token

### DIFF
--- a/packages/modules/electricity_tariffs/voltego/tariff.py
+++ b/packages/modules/electricity_tariffs/voltego/tariff.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 from typing import Dict
 import pytz
+import requests
 
 from dataclass_utils import asdict
 from helpermodules import timecheck
@@ -39,6 +40,14 @@ def _refresh_token(config: VoltegoTariff):
 
 
 def fetch(config: VoltegoTariff) -> None:
+    def get_raw_prices():
+        return req.get_http_session().get(
+            "https://api.voltego.de/market_data/day_ahead/DE_LU/60",
+            headers={"Content-Type": "application/json;charset=UTF-8",
+                     "Authorization": f'Bearer {config.configuration.token.access_token}'},
+            params={"from": start_date, "tz": timezone}
+        ).json()["elements"]
+
     validate_token(config)
     # start_date von voller Stunde sonst liefert die API die nächste Stunde
     start_date = datetime.datetime.fromtimestamp(
@@ -49,12 +58,12 @@ def fetch(config: VoltegoTariff) -> None:
         timezone = "UTC+2:00"
     else:
         timezone = "UTC+1:00"
-    raw_prices = req.get_http_session().get(
-        "https://api.voltego.de/market_data/day_ahead/DE_LU/60",
-        headers={"Content-Type": "application/json;charset=UTF-8",
-                 "Authorization": f'Bearer {config.configuration.token.access_token}'},
-        params={"from": start_date, "tz": timezone}
-    ).json()["elements"]
+    # Bei Voltego wird anscheinend nicht ein Token pro Client, sondern das letzte erzeugte gespeichert.
+    try:
+        raw_prices = get_raw_prices()
+    except requests.exceptions.HTTPError:
+        _refresh_token(config)
+        raw_prices = get_raw_prices()
     prices: Dict[int, float] = {}
     for data in raw_prices:
         formatted_price = data["price"]/1000000  # €/MWh -> €/Wh


### PR DESCRIPTION
Bei Voltego wird anscheinend nicht ein Token pro Client, sondern das letzte erzeugte gespeichert. Ein Kunde hatte mir seine Zugangsdaten zur Verfügung gestellt, dabei ist das Problem aufgetreten.Ist aber auch ein Problem, wenn jemand noch mit einer anderen Steuerung die Daten aus seinem Account abfragt, dann bekommt die openWB keine Daten mehr. Deshalb muss dann ein neuer Token generiert werden.