### PR TITLE
Fix missing house consumption log entries after data migration

### DIFF
--- a/packages/helpermodules/measurement_logging/process_log.py
+++ b/packages/helpermodules/measurement_logging/process_log.py
@@ -355,7 +355,7 @@ def analyse_percentage_totals(entries, totals):
         totals["cp"]["all"].update({f"energy_imported_{source}": 0})
         for entry in entries:
             if "hc" in entry.keys() and "all" in entry["hc"].keys():
-                totals["hc"]["all"][f"energy_imported_{source}"] += entry["hc"]["all"][f"energy_imported_{source}"]*1000
+                totals["hc"]["all"][f"energy_imported_{source}"] += entry["hc"]["all"].get(f"energy_imported_{source}", 0)*1000
             if "all" in entry["cp"].keys() and f"energy_imported_{source}" in entry["cp"]["all"].keys():
                 totals["cp"]["all"][f"energy_imported_{source}"] += entry["cp"]["all"][f"energy_imported_{source}"]*1000
     return totals

--- a/packages/helpermodules/measurement_logging/process_log.py
+++ b/packages/helpermodules/measurement_logging/process_log.py
@@ -355,7 +355,8 @@ def analyse_percentage_totals(entries, totals):
         totals["cp"]["all"].update({f"energy_imported_{source}": 0})
         for entry in entries:
             if "hc" in entry.keys() and "all" in entry["hc"].keys():
-                totals["hc"]["all"][f"energy_imported_{source}"] += entry["hc"]["all"].get(f"energy_imported_{source}", 0)*1000
+                totals["hc"]["all"][f"energy_imported_{source}"] += entry["hc"]["all"].get(
+                    f"energy_imported_{source}", 0)*1000
             if "all" in entry["cp"].keys() and f"energy_imported_{source}" in entry["cp"]["all"].keys():
                 totals["cp"]["all"][f"energy_imported_{source}"] += entry["cp"]["all"][f"energy_imported_{source}"]*1000
     return totals


### PR DESCRIPTION
After data migration, the migrated data contained entries with the `hc` key pointing to an empty dict being empty. On days or months where migrated entries get merged with entries written by software2 (e.g. the day/the month where the switch from 1.9 to 2.x took place), an error message occured and no data was shown at all.

![image](https://github.com/openWB/core/assets/1886500/40f4ab02-990d-4760-9c4b-fd0f6f25bf9a)

This PR opts avoid that error message by sacrificing some accuracy in the resulting totals.