### PR TITLE
Update info Zielladen

### DIFF
--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -758,7 +758,7 @@ class ChargeTemplate:
     SCHEDULED_CHARGING_LIMITED_BY_AMOUNT = '{}kWh geladene Energie'
     SCHEDULED_CHARGING_IN_TIME = 'Zielladen mit {}A, um {}  um {} zu erreichen.'
     SCHEDULED_CHARGING_CHEAP_HOUR = "Zielladen, da ein günstiger Zeitpunkt zum preisbasierten Laden ist."
-    SCHEDULED_CHARGING_EXPENSIVE_HOUR = ("Kein Zielladen, da kein günstiger Zeitpunkt zum preisbasierten Laden "
+    SCHEDULED_CHARGING_EXPENSIVE_HOUR = ("Zielladen ausstehen, da noch kein günstiger Zeitpunkt zum preisbasierten Laden "
                                          "ist. Falls vorhanden, wird mit Überschuss geladen.")
 
     def scheduled_charging_calc_current(self,

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -295,7 +295,8 @@ class Ev:
                     self.data.get.soc,
                     used_amount
                 )
-                message = tmp_message
+                # Info vom Zielladen erhalten
+                message += tmp_message
                 if tmp_current > 0:
                     control_parameter.current_plan = name
                     # Wenn mit einem neuen Plan geladen wird, muss auch die Energiemenge von neuem gezählt werden.


### PR DESCRIPTION
Wenn Zeit-Laden-Pläne angelegt, aber noch nicht aktiv sind wurde die Info des Zielladenmodus unterdrückt.