### PR TITLE
B23 meter: fix data types and adding powers per phase

### DIFF
--- a/packages/modules/common/b23.py
+++ b/packages/modules/common/b23.py
@@ -27,11 +27,10 @@ class B23(AbstractCounter):
 
     def get_power(self) -> Tuple[List[float], float]:
         time.sleep(0.1)
-        power = self.client.read_holding_registers(0x5B14, ModbusDataType.INT_32, unit=self.id) / 100
-        time.sleep(0.1)
+        # reading of total power and power per phase in one call
         powers = [val / 100 for val in self.client.read_holding_registers(
-            0x5B16, [ModbusDataType.INT_32]*3, unit=self.id)]
-        return powers, power
+            0x5B14, [ModbusDataType.INT_32]*4, unit=self.id)]
+        return powers[1:3], powers[0]
 
     def get_power_factors(self) -> List[float]:
         time.sleep(0.1)

--- a/packages/modules/common/b23.py
+++ b/packages/modules/common/b23.py
@@ -19,7 +19,7 @@ class B23(AbstractCounter):
 
     def get_frequency(self) -> float:
         time.sleep(0.1)
-        return self.client.read_holding_registers(0x5B2C, ModbusDataType.INT_16, unit=self.id) / 100
+        return self.client.read_holding_registers(0x5B2C, ModbusDataType.UINT_16, unit=self.id) / 100
 
     def get_imported(self) -> float:
         time.sleep(0.1)
@@ -28,12 +28,15 @@ class B23(AbstractCounter):
     def get_power(self) -> Tuple[List[float], float]:
         time.sleep(0.1)
         power = self.client.read_holding_registers(0x5B14, ModbusDataType.INT_32, unit=self.id) / 100
-        return [0]*3, power
+        time.sleep(0.1)
+        powers = [val / 100 for val in self.client.read_holding_registers(
+            0x5B16, [ModbusDataType.INT_32]*3, unit=self.id)]
+        return powers, power
 
     def get_power_factors(self) -> List[float]:
         time.sleep(0.1)
         return [val / 1000 for val in self.client.read_holding_registers(
-            0x5B3B, [ModbusDataType.UINT_32]*3, unit=self.id)]
+            0x5B3B, [ModbusDataType.INT_16]*3, unit=self.id)]
 
     def get_voltages(self) -> List[float]:
         time.sleep(0.1)


### PR DESCRIPTION
Hallo,

ich habe bei meiner Series 2 Standard+ mit ABB B23 festgestellt, dass die Werte für die Leistungsfaktoren nicht stimmen (da kommt nur Blödsinn raus). Außerdem fehlten die Leistungswerte je Phase.

Datentyp für die Frequenz war auch falsch, war aber wohl trotzdem kein Problem, weil die Werte quasi immer um die 50 rum liegen.

Meine Änderungen basieren auf der offiziellen Doku des Zählers:
https://search.abb.com/library/Download.aspx?DocumentID=2CMC485003M0201&LanguageCode=en&DocumentPartId=&Action=Launch