### PR TITLE
B23 meter: fix list split

### DIFF
--- a/packages/modules/common/b23.py
+++ b/packages/modules/common/b23.py
@@ -30,7 +30,7 @@ class B23(AbstractCounter):
         # reading of total power and power per phase in one call
         powers = [val / 100 for val in self.client.read_holding_registers(
             0x5B14, [ModbusDataType.INT_32]*4, unit=self.id)]
-        return powers[1:3], powers[0]
+        return powers[1:4], powers[0]
 
     def get_power_factors(self) -> List[float]:
         time.sleep(0.1)


### PR DESCRIPTION
Sorry, in meinem Bugfix habe ich einen eigenen kleinen Bug eingebaut. Der Selektor zum Splitten der Liste war falsch.
Da merkt man, dass ich eher Java als Python Entwickler bin. :)

Sorry nochmal, ich hoffe ihr merged den Pull Request nochmal so schnell. ;-)