### PR TITLE
fix chargelog no pv charging

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -639,7 +639,7 @@ class Chargepoint(ChargepointRfidMixin):
                     message = message_ev if message_ev else message
                     # Ein Eintrag muss nur erstellt werden, wenn vorher schon geladen wurde und auch danach noch
                     # geladen werden soll.
-                    if charging_ev.chargemode_changed and self.data.get.charge_state and state:
+                    if charging_ev.chargemode_changed and self.data.set.log.imported_since_mode_switch != 0 and state:
                         chargelog.save_interim_data(self, charging_ev)
 
                     # Wenn die Nachrichten gesendet wurden, EV wieder löschen, wenn das EV im Algorithmus nicht


### PR DESCRIPTION
 Log-Daten werden nur zurückgesetzt, wenn während einer laufenden Ladung umgeschaltet wird.