### PR TITLE
handle errors during configurable initialization - RSE

### DIFF
--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -30,6 +30,7 @@ from helpermodules import system
 from control import pv
 from dataclass_utils import dataclass_from_dict
 from modules.common.abstract_vehicle import CalculatedSocState, GeneralVehicleConfig
+from modules.common.configurable_ripple_control_receiver import ConfigurableRcr
 from modules.common.simcount.simcounter_state import SimCounterState
 from modules.internal_chargepoint_handler.internal_chargepoint_handler_config import (
     GlobalHandlerData, InternalChargepoint, RfidData)
@@ -575,7 +576,8 @@ class SubData:
                         mod = importlib.import_module(".ripple_control_receivers." +
                                                       config_dict["type"]+".ripple_control_receiver", "modules")
                         config = dataclass_from_dict(mod.device_descriptor.configuration_factory, config_dict)
-                        var.data.ripple_control_receiver.module = mod.create_ripple_control_receiver(config)
+                        var.data.ripple_control_receiver.module = ConfigurableRcr(
+                            config=config, component_initialiser=mod.create_ripple_control_receiver)
                 elif re.search("/general/ripple_control_receiver/get/", msg.topic) is not None:
                     self.set_json_payload_class(var.data.ripple_control_receiver.get, msg)
                 elif re.search("/general/ripple_control_receiver/", msg.topic) is not None:

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -192,6 +192,7 @@ class TariffState:
         self.prices = prices
 
 
+@auto_str
 class RcrState:
     def __init__(self, override_value: float) -> None:
         self.override_value = override_value

--- a/packages/modules/common/configurable_ripple_control_receiver.py
+++ b/packages/modules/common/configurable_ripple_control_receiver.py
@@ -12,13 +12,16 @@ T_RCR_CONFIG = TypeVar("T_RCR_CONFIG")
 class ConfigurableRcr(Generic[T_RCR_CONFIG]):
     def __init__(self,
                  config: T_RCR_CONFIG,
-                 component_updater: Callable[[], float]) -> None:
-        self.__component_updater = component_updater
+                 component_initialiser: Callable[[], float]) -> None:
         self.config = config
         self.fault_state = FaultState(ComponentInfo(None, self.config.name,
                                       ComponentType.RIPPLE_CONTROL_RECEIVER.value))
+        with SingleComponentUpdateContext(self.fault_state):
+            self.__component_updater = component_initialiser(config)
         self.store = store.get_ripple_control_receiver_value_store()
 
     def update(self):
-        with SingleComponentUpdateContext(self.fault_state):
-            self.store.set(self.__component_updater())
+        if hasattr(self, "__component_updater"):
+            # Wenn beim Initialisieren etwas schief gelaufen ist, ursprüngliche Fehlermeldung beibehalten
+            with SingleComponentUpdateContext(self.fault_state):
+                self.store.set(self.__component_updater())

--- a/packages/modules/common/configurable_ripple_control_receiver.py
+++ b/packages/modules/common/configurable_ripple_control_receiver.py
@@ -17,11 +17,11 @@ class ConfigurableRcr(Generic[T_RCR_CONFIG]):
         self.fault_state = FaultState(ComponentInfo(None, self.config.name,
                                       ComponentType.RIPPLE_CONTROL_RECEIVER.value))
         with SingleComponentUpdateContext(self.fault_state):
-            self.__component_updater = component_initialiser(config)
+            self._component_updater = component_initialiser(config)
         self.store = store.get_ripple_control_receiver_value_store()
 
     def update(self):
-        if hasattr(self, "__component_updater"):
+        if hasattr(self, "_component_updater"):
             # Wenn beim Initialisieren etwas schief gelaufen ist, ursprüngliche Fehlermeldung beibehalten
             with SingleComponentUpdateContext(self.fault_state):
-                self.store.set(self.__component_updater())
+                self.store.set(self._component_updater())

--- a/packages/modules/ripple_control_receivers/dimm_kit/ripple_control_receiver.py
+++ b/packages/modules/ripple_control_receivers/dimm_kit/ripple_control_receiver.py
@@ -5,7 +5,6 @@ import socket
 
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_state import RcrState
-from modules.common.configurable_ripple_control_receiver import ConfigurableRcr
 from modules.common.modbus import ModbusTcpClient_
 from modules.common.version_by_telnet import get_version_by_telnet
 from modules.ripple_control_receivers.dimm_kit.config import IoLanRcr
@@ -23,38 +22,33 @@ VALID_VERSIONS = ["openWB DimmModul"]
 
 def create_ripple_control_receiver(config: IoLanRcr):
     def updater():
-        if version:
-            r1 = State(client.read_coils(0x0000, 1, unit=config.configuration.modbus_id))
-            r2 = State(client.read_coils(0x0001, 1, unit=config.configuration.modbus_id))
-            log.debug(f"RSE-Kontakt 1: {r1}, RSE-Kontakt 2: {r2}")
-            if r1 == State.OPENED or r2 == State.OPENED:
-                override_value = 0
-            else:
-                override_value = 100
-            return RcrState(override_value=override_value)
-
+        r1 = State(client.read_coils(0x0000, 1, unit=config.configuration.modbus_id))
+        r2 = State(client.read_coils(0x0001, 1, unit=config.configuration.modbus_id))
+        log.debug(f"RSE-Kontakt 1: {r1}, RSE-Kontakt 2: {r2}")
+        if r1 == State.OPENED or r2 == State.OPENED:
+            override_value = 0
+        else:
+            override_value = 100
+        return RcrState(override_value=override_value)
+    version = False
+    client = ModbusTcpClient_(config.configuration.ip_address, config.configuration.port)
     try:
-        version = False
-        client = ModbusTcpClient_(config.configuration.ip_address, config.configuration.port)
-        try:
-            parsed_answer = get_version_by_telnet(VALID_VERSIONS[0], config.configuration.ip_address)
-            for version in VALID_VERSIONS:
-                if version in parsed_answer:
-                    version = True
-                    log.debug("Firmware des openWB Dimm-& Control-Kit ist mit openWB software2 kompatibel.")
-                else:
-                    version = False
-                    raise ValueError
-        except (ConnectionRefusedError, ValueError) as e:
-            e.args += (("Firmware des openWB Dimm-& Control-Kit ist nicht mit openWB software2 kompatibel. "
-                        "Bitte den Support kontaktieren."),)
-            raise e
-        except socket.timeout as e:
-            e.args += (("Die IP-Adresse ist nicht erreichbar. Bitte den Support kontaktieren."),)
-            raise e
-    except Exception:
-        log.exception("Fehler in create_device")
-    return ConfigurableRcr(config=config, component_updater=updater)
+        parsed_answer = get_version_by_telnet(VALID_VERSIONS[0], config.configuration.ip_address)
+        for version in VALID_VERSIONS:
+            if version in parsed_answer:
+                version = True
+                log.debug("Firmware des openWB Dimm-& Control-Kit ist mit openWB software2 kompatibel.")
+            else:
+                version = False
+                raise ValueError
+    except (ConnectionRefusedError, ValueError) as e:
+        e.args += (("Firmware des openWB Dimm-& Control-Kit ist nicht mit openWB software2 kompatibel. "
+                    "Bitte den Support kontaktieren."),)
+        raise e
+    except socket.timeout as e:
+        e.args += (("Die IP-Adresse ist nicht erreichbar. Bitte den Support kontaktieren."),)
+        raise e
+    return updater
 
 
 device_descriptor = DeviceDescriptor(configuration_factory=IoLanRcr)

--- a/packages/modules/ripple_control_receivers/dimm_kit/ripple_control_receiver.py
+++ b/packages/modules/ripple_control_receivers/dimm_kit/ripple_control_receiver.py
@@ -41,13 +41,13 @@ def create_ripple_control_receiver(config: IoLanRcr):
             else:
                 version = False
                 raise ValueError
-    except (ConnectionRefusedError, ValueError) as e:
-        e.args += (("Firmware des openWB Dimm-& Control-Kit ist nicht mit openWB software2 kompatibel. "
-                    "Bitte den Support kontaktieren."),)
-        raise e
-    except socket.timeout as e:
-        e.args += (("Die IP-Adresse ist nicht erreichbar. Bitte den Support kontaktieren."),)
-        raise e
+    except (ConnectionRefusedError, ValueError):
+        log.exception("Dimm-Kit")
+        raise Exception("Firmware des openWB Dimm-& Control-Kit ist nicht mit openWB software2 kompatibel. "
+                        "Bitte den Support kontaktieren.")
+    except socket.timeout:
+        log.exception("Dimm-Kit")
+        raise Exception("Die IP-Adresse ist nicht erreichbar. Bitte den Support kontaktieren.")
     return updater
 
 

--- a/packages/modules/ripple_control_receivers/gpio/ripple_control_receiver.py
+++ b/packages/modules/ripple_control_receivers/gpio/ripple_control_receiver.py
@@ -4,7 +4,6 @@ from typing import Tuple
 
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_state import RcrState
-from modules.common.configurable_ripple_control_receiver import ConfigurableRcr
 from modules.ripple_control_receivers.gpio.config import GpioRcr
 
 log = logging.getLogger(__name__)
@@ -44,7 +43,7 @@ def read() -> Tuple[bool, bool]:
 def create_ripple_control_receiver(config: GpioRcr):
     def updater():
         return read()
-    return ConfigurableRcr(config=config, component_updater=updater)
+    return updater
 
 
 device_descriptor = DeviceDescriptor(configuration_factory=GpioRcr)


### PR DESCRIPTION
Wenn beim Aufruf von create_ripple_control_receiver eine Exception auftritt, wurde diese nicht über den Kontexthandler in den fault_state/fault_str der jeweiligen Komponente übergeben, sodass die Exception zB nicht im Status angezeigt wird.

Nun wird in create_ripple_control_receiver die updater-Funktion zurückgegeben, sodass der Aufruf von create_ripple_control_receiver in der Confiugrable-Klasse erfolgen kann und der Kontexthandler genutzt werden kann.