### PR TITLE
fix simcount in case of error, fix zero values if there is no previous value

### DIFF
--- a/packages/helpermodules/measurement_logging/write_log.py
+++ b/packages/helpermodules/measurement_logging/write_log.py
@@ -257,7 +257,10 @@ def fix_values(new_entry: Dict, previous_entry: Dict) -> Dict:
     def find_and_fix_value(value_name):
         if value.get(value_name) is not None:
             if value[value_name] == 0:
-                value[value_name] = previous_entry[group][component][value_name]
+                try:
+                    value[value_name] = previous_entry[group][component][value_name]
+                except KeyError:
+                    log.exception("Es konnte kein vorheriger Wert gefunden werden.")
     for group, value in new_entry.items():
         if group not in ("bat", "counter", "cp", "pv", "hc"):
             continue

--- a/packages/helpermodules/measurement_logging/write_log_test.py
+++ b/packages/helpermodules/measurement_logging/write_log_test.py
@@ -70,3 +70,53 @@ def test_fix_values():
                             'pv': {'all': {'exported': 3269}, 'pv1': {'exported': 3269}},
                             'sh': {},
                             'timestamp': 1709109001}
+
+
+def test_fix_values_missing_components():
+    # setup
+    previous_entry = {'bat': {'all': {'exported': 0, 'imported': 2281.851, 'soc': 96},
+                              'bat2': {'exported': 0, 'imported': 2281.851, 'soc': 96}},
+                      'counter': {'counter0': {'exported': 21.382,
+                                               'grid': True,
+                                               'imported': 17.913}},
+                      'cp': {'all': {'exported': 0, 'imported': 0},
+                             'cp3': {'exported': 0, 'imported': 0},
+                             'cp4': {'exported': 0, 'imported': 0},
+                             'cp5': {'exported': 0, 'imported': 0}},
+                      'date': '09:25',
+                      'ev': {'ev0': {'soc': 0}},
+                      'hc': {'all': {'imported': 108647.2791628165}},
+                      'pv': {'all': {'exported': 3269}},
+                      'sh': {},
+                      'timestamp': 1709108702}
+    new_entry = {'bat': {'all': {'exported': 0, 'imported': 2369.658, 'soc': 97},
+                         'bat2': {'exported': 0, 'imported': 2369.658, 'soc': 97}},
+                 'counter': {'counter0': {'exported': 22.167, 'grid': True, 'imported': 18.54}},
+                 'cp': {'all': {'exported': 0, 'imported': 0},
+                        'cp3': {'exported': 0, 'imported': 0},
+                        'cp4': {'exported': 0, 'imported': 0},
+                        'cp5': {'exported': 0, 'imported': 0}},
+                 'date': '09:30',
+                 'ev': {'ev0': {'soc': 0}},
+                 'hc': {'all': {'imported': 108683.21291147666}},
+                 'pv': {'all': {'exported': 0}, 'pv1': {'exported': 0}},
+                 'sh': {},
+                 'timestamp': 1709109001}
+
+    # execution
+    fixed_values = write_log.fix_values(new_entry, previous_entry)
+
+    # evaluation
+    assert fixed_values == {'bat': {'all': {'exported': 0, 'imported': 2369.658, 'soc': 97},
+                                    'bat2': {'exported': 0, 'imported': 2369.658, 'soc': 97}},
+                            'counter': {'counter0': {'exported': 22.167, 'grid': True, 'imported': 18.54}},
+                            'cp': {'all': {'exported': 0, 'imported': 0},
+                                   'cp3': {'exported': 0, 'imported': 0},
+                                   'cp4': {'exported': 0, 'imported': 0},
+                                   'cp5': {'exported': 0, 'imported': 0}},
+                            'date': '09:30',
+                            'ev': {'ev0': {'soc': 0}},
+                            'hc': {'all': {'imported': 108683.21291147666}},
+                            'pv': {'all': {'exported': 3269}, 'pv1': {'exported': 0}},
+                            'sh': {},
+                            'timestamp': 1709109001}


### PR DESCRIPTION
Im Fehlerfall wurde im simcount der Timestamp von der letzten erfolgreichen Abfrage genommen und wenn es wieder funktioniert, von diesem Zeitpunkt bis jetzt mit der akutellen Leistung integriert. Das führte zu einem Peak. Nun wird bei einem Zeitstempel, der doppelt so alt ist, wie das Regelintervall, als Zeitspanne für das Integral das Regelintervall verwendet.

https://forum.openwb.de/viewtopic.php?p=104268#p104268