### PR TITLE
enphase: added automatic token generation and more

### DIFF
--- a/packages/modules/devices/enphase/config.py
+++ b/packages/modules/devices/enphase/config.py
@@ -13,11 +13,13 @@ class EnphaseConfiguration:
                  version: EnphaseVersion = EnphaseVersion.V1,
                  user: Optional[str] = None,
                  password: Optional[str] = None,
+                 serial: Optional[str] = None,
                  token: Optional[str] = None):
         self.hostname = hostname
         self.version = version
         self.user = user
         self.password = password
+        self.serial = serial
         self.token = token
 
 

--- a/packages/modules/devices/enphase/device.py
+++ b/packages/modules/devices/enphase/device.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
+import jwt
 import logging
+import re
+import time
 from typing import Dict, List, Union
-
-from dataclass_utils import dataclass_from_dict
+from dataclass_utils import asdict, dataclass_from_dict
 from helpermodules.cli import run_using_positional_cli_args
+from helpermodules.pub import Pub
 from modules.common import req
 from modules.common.abstract_device import AbstractDevice, DeviceDescriptor
 from modules.common.component_context import MultiComponentUpdateContext
@@ -33,6 +36,8 @@ class Device(AbstractDevice):
     def __init__(self, device_config: Union[Dict, Enphase]) -> None:
         self.components = {}  # type: Dict[str, enphase_component_classes]
         self.read_live_data = False
+        self.token_tries = 0
+        self.token_fails = 0
         try:
             self.device_config = dataclass_from_dict(Enphase, device_config)
         except Exception:
@@ -59,37 +64,176 @@ class Device(AbstractDevice):
                 ','.join(self.COMPONENT_TYPE_TO_CLASS.keys())
             )
 
+    def auto_set_version(self) -> None:
+        response = req.get_http_session().get(
+            'http://'+self.device_config.configuration.hostname+'/',
+            timeout=5, allow_redirects=False)
+        if response.status_code == 200:
+            self.device_config.configuration.version = EnphaseVersion.V1.value
+        elif response.status_code == 301:
+            if response.headers.get('Location', '').startswith('https'):
+                self.device_config.configuration.version = EnphaseVersion.V2.value
+            else:
+                self.device_config.configuration.version = EnphaseVersion.V1.value
+        else:
+            log.error("Could not identify Envoy firmware version")
+            return
+        try:
+            log.debug("saving envoy version")
+            Pub().pub("openWB/system/device/" + str(self.device_config.id) + "/config", asdict(self.device_config))
+        except Exception as e:
+            log.exception('Token mqtt write exception ' + str(e))
+
+    def auto_set_serial(self) -> None:
+        if self.device_config.configuration.version == EnphaseVersion.V1.value:
+            response = req.get_http_session().get(
+                'http://'+self.device_config.configuration.hostname+'/',
+                timeout=5)
+        elif self.device_config.configuration.version == EnphaseVersion.V2.value:
+            response = req.get_http_session().get(
+                'https://'+self.device_config.configuration.hostname+'/',
+                timeout=5, verify=False)
+        else:
+            log.error(f"unknown version: {self.device_config.configuration.version}")
+            return
+        pattern = re.compile('<title.*>.* ([0-9]+)</title>')
+        match = re.search(pattern, response.text)
+        if match is None:
+            log.error("could not find Envoy serial")
+            return
+        self.device_config.configuration.serial = match.group(1)
+        try:
+            log.debug("saving envoy serial")
+            Pub().pub("openWB/system/device/" + str(self.device_config.id) + "/config", asdict(self.device_config))
+        except Exception as e:
+            log.exception('Token mqtt write exception ' + str(e))
+
+    def find_counter_eid(self, measurement_type: str) -> str:
+        if self.device_config.configuration.version == EnphaseVersion.V1.value:
+            json_response = req.get_http_session().get(
+                'http://'+self.device_config.configuration.hostname+'/ivp/meters', timeout=5).json()
+        elif self.device_config.configuration.version == EnphaseVersion.V2.value:
+            # v2 requires token authentication
+            if self.check_token() is False:
+                log.error("no valid token to connect to envoy")
+                return
+            response = req.get_http_session().get(
+                'https://'+self.device_config.configuration.hostname+'/ivp/meters',
+                timeout=5, verify=False,
+                headers={"Authorization": f"Bearer {self.device_config.configuration.token}"})
+            if response.ok is False:
+                log.info("token invalid, will be renewed if credentials are set")
+                self.device_config.configuration.token = None
+                self.token_fails += 1
+                return
+            self.token_fails = 0
+            json_response = response.json()
+        for cnt in json_response:
+            if cnt.get('measurementType') == measurement_type:
+                return str(cnt.get('eid'))
+
+    def check_token(self) -> bool:
+        if (self.device_config.configuration.token is None or
+                self.device_config.configuration.token == ""):
+            log.info("no valid token found, trying to receive token")
+            if self.receive_token() is False:
+                return False
+        try:
+            token_exp = jwt.decode(
+                self.device_config.configuration.token, options={"verify_signature": False})["exp"]
+        except Exception as e:
+            log.error("invalid token stored, trying to receive new token" + str(e))
+            if self.receive_token() is False:
+                return False
+            try:
+                token_exp = jwt.decode(
+                    self.device_config.configuration.token, options={"verify_signature": False})["exp"]
+            except Exception as e:
+                log.error("received token invalid" + str(e))
+                return False
+        if token_exp < (time.time() + 3600*24):
+            log.info("token will expire in less than one day, trying to receive new token")
+            self.receive_token()
+        return True
+
+    def receive_token(self) -> bool:
+        if self.token_tries > 5:
+            log.error("unsuccessfully tried 5 times to receive valid token, giving up. check log")
+            return False
+        if self.token_fails > 5:
+            log.error("received 5 times a non-working token, giving up. check Envoy / gateway serial number")
+            return False
+        self.token_tries += 1
+        if (self.device_config.configuration.user is None or
+                self.device_config.configuration.password is None or
+                self.device_config.configuration.serial is None):
+            log.error("no credentials to authenticate to get token!")
+            return False
+        response = req.get_http_session().post(
+            'https://enlighten.enphaseenergy.com/login/login.json?',
+            data={'user[email]': self.device_config.configuration.user,
+                  'user[password]': self.device_config.configuration.password},
+            timeout=5)
+        if response.ok is False:
+            log.error(f"could not authenticate at enphase, check credentials. "
+                      f"HTTP status code returned: {response.status_code}")
+            return False
+        response_json = response.json()
+        response = req.get_http_session().post(
+            'https://entrez.enphaseenergy.com/tokens',
+            json={'session_id': response_json['session_id'],
+                  'serial_num': self.device_config.configuration.serial,
+                  'username': self.device_config.configuration.user},
+            timeout=5)
+        if response.ok is False:
+            log.error(f"could not receive token from enphase, check Envoy serial number. "
+                      f"HTTP status code returned: {response.status_code}")
+            return False
+        self.token_tries = 0
+        token = response.text.strip()
+        log.info(f"received new token: {token}")
+        self.device_config.configuration.token = token
+        try:
+            log.debug("saving new access token")
+            Pub().pub("openWB/system/device/" + str(self.device_config.id) + "/config", asdict(self.device_config))
+        except Exception as e:
+            log.exception('Token mqtt write exception ' + str(e))
+            return False
+        return True
+
     def update(self) -> None:
         if self.device_config.configuration.version == EnphaseVersion.V2.value:
             # v2 requires token authentication
-            if self.device_config.configuration.token is None:
-                if self.device_config.configuration.user is None or self.device_config.configuration.password is None:
-                    log.error("no valid token found and no credentials to authenticate!")
-                    # ToDo: throw error and set fault state
-                else:
-                    log.info("no valid token found, trying to receive token with user/pass")
-                    # ToDo: fetch token with user/pass
+            if self.check_token() is False:
+                log.error("no valid token to connect to envoy")
+                return
         log.debug("Start device reading " + str(self.components))
         if self.components:
             with MultiComponentUpdateContext(self.components):
-                json_live_data = None  # ToDo: available in V1?
+                json_live_data = None
                 if self.device_config.configuration.version == EnphaseVersion.V1.value:
-                    # ToDo: live_data available in V1?
-                    # json_live_data = ...
                     json_response = req.get_http_session().get(
                         'http://'+self.device_config.configuration.hostname+'/ivp/meters/readings', timeout=5).json()
+                    # json_live_data does not exist on older firmware
                 elif self.device_config.configuration.version == EnphaseVersion.V2.value:
+                    response = req.get_http_session().get(
+                        'https://'+self.device_config.configuration.hostname+'/ivp/meters/readings',
+                        timeout=5, verify=False,
+                        headers={"Authorization": f"Bearer {self.device_config.configuration.token}"})
+                    if response.ok is False:
+                        log.info("token invalid, will be renewed if credentials are set")
+                        self.device_config.configuration.token = None
+                        self.token_fails += 1
+                        return
+                    self.token_fails = 0
+                    json_response = response.json()
+                    log.debug(f"meters/readings json response: {json_response}")
                     if self.read_live_data:
                         json_live_data = req.get_http_session().get(
                             'https://'+self.device_config.configuration.hostname+'/ivp/livedata/status',
                             timeout=5, verify=False,
                             headers={"Authorization": f"Bearer {self.device_config.configuration.token}"}).json()
-                    log.debug(f"livedata/status json response: {json_live_data}")
-                    json_response = req.get_http_session().get(
-                        'https://'+self.device_config.configuration.hostname+'/ivp/meters/readings',
-                        timeout=5, verify=False,
-                        headers={"Authorization": f"Bearer {self.device_config.configuration.token}"}).json()
-                    log.debug(f"meters/readings json response: {json_response}")
+                        log.debug(f"livedata/status json response: {json_live_data}")
                 else:
                     log.error(f"unknown version: {self.device_config.configuration.version}")
                     return


### PR DESCRIPTION
This contains automatic token generation with checks if the token is valid and limits to how often a token generation is tried if its not successful.
Also contains functions to retrieve firmware version, envoy serial number and meter eids: Not used at the moment, should be made available in the config dialog for easier setup in the future

Potential issue: Unsure if the method/path to store the token is correct/the best method