### PR TITLE
MQTT-Topic "set/current" wird falsch mit "phases_to_use" beschrieben

### DIFF
--- a/packages/modules/internal_chargepoint_handler/internal_chargepoint_handler.py
+++ b/packages/modules/internal_chargepoint_handler/internal_chargepoint_handler.py
@@ -110,7 +110,6 @@ class UpdateState:
             pub.pub_single(
                 f"openWB/set/internal_chargepoint/{self.cp_module.local_charge_point_num}/data/trigger_phase_switch",
                 False)
-            pub_single(f"openWB/set/chargepoint/{self.hierarchy_id}/set/current", payload=data.phases_to_use)
 
         if data.cp_interruption_duration > 0:
             self.__thread_cp_interruption(data.cp_interruption_duration)


### PR DESCRIPTION
Die besagte Zeile ist in sich falsch und zudem unnötig, da in den Zeilen 105 und 106 set_current bereits verarbeitet und auf das MQTT-Topic gepusht wird.

Die Zeile führt dazu, dass bei "trigger_phase_switch" Log-Einträge in der nachfolgenden Art im main.log erzeugt werden:

```
2024-03-16 08:23:57,828 - {helpermodules.setdata:338} - {ERROR:Setdata} - Payload ungültig: Topic openWB/set/chargepoint/0/set/current, Payload 3 liegt in keinem der angegebenen Wertebereiche.
2024-03-16 08:25:17,937 - {helpermodules.setdata:338} - {ERROR:Setdata} - Payload ungültig: Topic openWB/set/chargepoint/0/set/current, Payload 1 liegt in keinem der angegebenen Wertebereiche.
2024-03-16 10:24:57,003 - {helpermodules.setdata:338} - {ERROR:Setdata} - Payload ungültig: Topic openWB/set/chargepoint/0/set/current, Payload 3 liegt in keinem der angegebenen Wertebereiche.
2024-03-16 10:26:58,111 - {helpermodules.setdata:338} - {ERROR:Setdata} - Payload ungültig: Topic openWB/set/chargepoint/0/set/current, Payload 1 liegt in keinem der angegebenen Wertebereiche.
2024-03-16 14:59:57,518 - {helpermodules.setdata:338} - {ERROR:Setdata} - Payload ungültig: Topic openWB/set/chargepoint/0/set/current, Payload 3 liegt in keinem der angegebenen Wertebereiche.
2024-03-16 15:01:17,414 - {helpermodules.setdata:338} - {ERROR:Setdata} - Payload ungültig: Topic openWB/set/chargepoint/0/set/current, Payload 1 liegt in keinem der angegebenen Wertebereiche.
```