### PR TITLE
fix: Exception when plan_data is None

### DIFF
--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -261,8 +261,7 @@ class Ev:
                     max_phases_hw,
                     phase_switch_supported)
                 if plan_data:
-                    plans = self.charge_template.data.chargemode.scheduled_charging.plans
-                    control_parameter.current_plan = plans[plan_data.num].name
+                    name = self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].name
                     # Wenn mit einem neuen Plan geladen wird, muss auch die Energiemenge von neuem gezählt werden.
                     if (self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].limit.
                             selected == "amount" and
@@ -270,11 +269,13 @@ class Ev:
                         control_parameter.imported_at_plan_start = imported
                     # Wenn der SoC ein paar Minuten alt ist, kann der Termin trotzdem gehalten werden.
                     # Zielladen kannn nicht genauer arbeiten, als das Abfrageintervall vom SoC.
-                    if (self.soc_module and self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].
-                           limit.selected == "soc"):
+                    if (self.soc_module and 
+                            self.charge_template.data.chargemode.
+                            scheduled_charging.plans[plan_data.num].limit.selected == "soc"):
                         soc_request_intervall_offset = self.soc_module.general_config.request_interval_charging
                     else:
                         soc_request_intervall_offset = 0
+                    control_parameter.current_plan = name
                 else:
                     control_parameter.current_plan = None
                 required_current, submode, message, phases = self.charge_template.scheduled_charging_calc_current(

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -260,6 +260,7 @@ class Ev:
                     used_amount,
                     max_phases_hw,
                     phase_switch_supported)
+                soc_request_intervall_offset = 0
                 if plan_data:
                     name = self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].name
                     # Wenn mit einem neuen Plan geladen wird, muss auch die Energiemenge von neuem gezählt werden.
@@ -273,8 +274,6 @@ class Ev:
                             self.charge_template.data.chargemode.
                             scheduled_charging.plans[plan_data.num].limit.selected == "soc"):
                         soc_request_intervall_offset = self.soc_module.general_config.request_interval_charging
-                    else:
-                        soc_request_intervall_offset = 0
                     control_parameter.current_plan = name
                 else:
                     control_parameter.current_plan = None

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -261,21 +261,21 @@ class Ev:
                     max_phases_hw,
                     phase_switch_supported)
                 if plan_data:
-                    name = self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].name
+                    control_parameter.current_plan = self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].name
                     # Wenn mit einem neuen Plan geladen wird, muss auch die Energiemenge von neuem gezählt werden.
                     if (self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].limit.
                             selected == "amount" and
                             name != control_parameter.current_plan):
                         control_parameter.imported_at_plan_start = imported
+                    # Wenn der SoC ein paar Minuten alt ist, kann der Termin trotzdem gehalten werden.
+                    # Zielladen kannn nicht genauer arbeiten, als das Abfrageintervall vom SoC.
+                    if (self.soc_module and self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].
+                           limit.selected == "soc"):
+                        soc_request_intervall_offset = self.soc_module.general_config.request_interval_charging
+                    else:
+                        soc_request_intervall_offset = 0
                 else:
-                    name = None
-                # Wenn der SoC ein paar Minuten alt ist, kann der Termin trotzdem gehalten werden.
-                # Zielladen kannn nicht genauer arbeiten, als das Abfrageintervall vom SoC.
-                if (self.soc_module and self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].
-                        limit.selected == "soc"):
-                    soc_request_intervall_offset = self.soc_module.general_config.request_interval_charging
-                else:
-                    soc_request_intervall_offset = 0
+                    control_parameter.current_plan = None
                 required_current, submode, message, phases = self.charge_template.scheduled_charging_calc_current(
                     plan_data,
                     self.data.get.soc,
@@ -283,7 +283,6 @@ class Ev:
                     control_parameter.phases,
                     self.ev_template.data.min_current,
                     soc_request_intervall_offset)
-                control_parameter.current_plan = name
 
             # Wenn Zielladen auf Überschuss wartet, prüfen, ob Zeitladen aktiv ist.
             if (submode != "instant_charging" and

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -261,7 +261,8 @@ class Ev:
                     max_phases_hw,
                     phase_switch_supported)
                 if plan_data:
-                    control_parameter.current_plan = self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].name
+                    plans = self.charge_template.data.chargemode.scheduled_charging.plans
+                    control_parameter.current_plan = plans[plan_data.num].name
                     # Wenn mit einem neuen Plan geladen wird, muss auch die Energiemenge von neuem gezählt werden.
                     if (self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].limit.
                             selected == "amount" and

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -269,7 +269,7 @@ class Ev:
                         control_parameter.imported_at_plan_start = imported
                     # Wenn der SoC ein paar Minuten alt ist, kann der Termin trotzdem gehalten werden.
                     # Zielladen kannn nicht genauer arbeiten, als das Abfrageintervall vom SoC.
-                    if (self.soc_module and 
+                    if (self.soc_module and
                             self.charge_template.data.chargemode.
                             scheduled_charging.plans[plan_data.num].limit.selected == "soc"):
                         soc_request_intervall_offset = self.soc_module.general_config.request_interval_charging


### PR DESCRIPTION
2024-02-29 09:32:21,737 - {control.ev:338} - {ERROR:MainThread} - Fehler im ev-Modul 1
Traceback (most recent call last):
  File "/var/www/html/openWB/packages/control/ev.py", line 274, in get_required_current
    if (self.soc_module and self.charge_template.data.chargemode.scheduled_charging.plans[plan_data.num].
AttributeError: 'NoneType' object has no attribute 'num'

PR #1444 versehentlich geschlossen