### PR TITLE
Speicher-Beachtung

### DIFF
--- a/packages/control/bat_all.py
+++ b/packages/control/bat_all.py
@@ -65,8 +65,6 @@ def get_factory() -> Get:
 class Set:
     charging_power_left: float = 0
     regulate_up: bool = False
-    switch_on_soc_reached: bool = False
-    switch_on_soc_state = SwitchOnBatState = SwitchOnBatState.SWITCH_ON_SOC_NOT_REACHED
 
 
 def set_factory() -> Set:
@@ -183,7 +181,6 @@ class BatAll:
                 self.data.set.charging_power_left = 0
                 self.data.get.power = 0
             Pub().pub("openWB/set/bat/set/charging_power_left", self.data.set.charging_power_left)
-            Pub().pub("openWB/set/bat/set/switch_on_soc_reached", self.data.set.switch_on_soc_reached)
             Pub().pub("openWB/set/bat/set/regulate_up", self.data.set.regulate_up)
         except Exception:
             log.exception("Fehler im Bat-Modul")

--- a/packages/control/bat_all.py
+++ b/packages/control/bat_all.py
@@ -210,7 +210,7 @@ class BatAll:
                     # Wenn der Speicher entladen wird, darf diese Leistung nicht zum Laden der Fahrzeuge genutzt werden.
                     # Wenn der Speicher schneller regelt als die LP, würde sonst der Speicher reduziert werden.
                     self.data.set.charging_power_left = self.data.get.power
-                    self.data.set.regulate_up = True
+                self.data.set.regulate_up = True
             elif config.bat_mode == BatConsiderationMode.EV_MODE.value:
                 # Speicher sollte weder ge- noch entladen werden.
                 self.data.set.charging_power_left = self.data.get.power
@@ -228,13 +228,14 @@ class BatAll:
                             if self.data.get.power > config.bat_power_reserve:
                                 self.data.set.charging_power_left = self.data.get.power - config.bat_power_reserve
                             else:
-                                self.data.set.charging_power_left = config.bat_power_reserve + self.data.get.power
+                                self.data.set.charging_power_left = config.bat_power_reserve - self.data.get.power
                         else:
                             # Speicher wird geladen
                             self.data.set.charging_power_left = 0
+                            self.data.set.regulate_up = True
                 else:
                     if config.bat_power_discharge > 0:
-                        if self.data.get.power * -1 > config.bat_power_discharge:
+                        if self.data.get.power * -1 >= config.bat_power_discharge:
                             # Wenn der Speicher mit mehr als der erlaubten Entladeleistung entladen wird, muss das vom
                             # Überschuss subtrahiert werden.
                             self.data.set.charging_power_left = config.bat_power_discharge + self.data.get.power

--- a/packages/control/bat_all.py
+++ b/packages/control/bat_all.py
@@ -203,7 +203,7 @@ class BatAll:
         """
         try:
             config = data.data.general_data.data.chargemode_config.pv_charging
-            self.data.set.charging_power_left = self.data.get.power
+
             self.data.set.regulate_up = False
             if config.bat_mode == BatConsiderationMode.BAT_MODE.value:
                 if self.data.get.power < 0:
@@ -216,12 +216,32 @@ class BatAll:
                 self.data.set.charging_power_left = self.data.get.power
             else:
                 if self.data.get.soc <= config.min_bat_soc:
-                    if config.ev_power_reserve != 0 and self.data.get.power > 0:
-                        # es darf maximal die Ladeleistung des Speichers zum Laden des EV verwendet werden.
-                        self.data.set.charging_power_left = max(config.ev_power_reserve, self.data.get.power)
+                    if self.data.get.power < 0:
+                        # Wenn der Speicher entladen wird, darf diese Leistung nicht zum Laden der Fahrzeuge
+                        # genutzt werden. Wenn der Speicher schneller regelt als die LP, würde sonst der Speicher
+                        # reduziert werden.
+                        self.data.set.charging_power_left = self.data.get.power
+                        self.data.set.regulate_up = True
+                    else:
+                        # Speicher-Vorrang bis zum Min-Soc
+                        if config.bat_power_reserve != 0:
+                            if self.data.get.power > config.bat_power_reserve:
+                                self.data.set.charging_power_left = self.data.get.power - config.bat_power_reserve
+                            else:
+                                self.data.set.charging_power_left = config.bat_power_reserve + self.data.get.power
+                        else:
+                            # Speicher wird geladen
+                            self.data.set.charging_power_left = 0
                 else:
                     if config.bat_power_discharge > 0:
-                        self.data.set.charging_power_left = config.bat_power_discharge
+                        if self.data.get.power * -1 > config.bat_power_discharge:
+                            # Wenn der Speicher mit mehr als der erlaubten Entladeleistung entladen wird, muss das vom
+                            # Überschuss subtrahiert werden.
+                            self.data.set.charging_power_left = config.bat_power_discharge + self.data.get.power
+                        else:
+                            self.data.set.charging_power_left = self._limit_rundown_power(
+                                config.bat_power_discharge)
+                        log.debug(f"Erlaubte Entlade-Leistung nutzen {self.data.set.charging_power_left}W")
                     else:
                         # Speicher sollte weder ge- noch entladen werden.
                         self.data.set.charging_power_left = self.data.get.power

--- a/packages/control/bat_all_test.py
+++ b/packages/control/bat_all_test.py
@@ -123,19 +123,27 @@ class Params:
 
 
 cases = [
-    Params("lädt, EV-Vorrang ohne Ladeleistungsreserve", PvCharging(bat_prio=False, charging_power_reserve=0), 500,
-           100, 500, False),
-    Params("lädt, EV-Vorrang mit Ladeleistungsreserve, Speicher voll",
-           PvCharging(bat_prio=False, charging_power_reserve=200), 500,
-           100, 500, False),
-    Params("lädt, EV-Vorrang mit Ladeleistungsreserve", PvCharging(bat_prio=False, charging_power_reserve=200), 500,
-           99, 300, False),
-    Params("lädt, Speicher-Vorrang mit erlaubter Entladeleistung", PvCharging(bat_prio=True), 500, 51, 500, False),
-    Params("lädt, Speicher-Vorrang ohne erlaubte Entladeleistung, Minimal-SoC unterschritten",
-           PvCharging(bat_prio=True), 500, 50, 0, True),
-    Params("entlädt mit mehr als Entladeleistung, Speicher-Vorrang mit erlaubter Entladeleistung",
-           PvCharging(bat_prio=True), -2500, 51, -1500, False),
-    Params("entlädt, Speicher-Vorrang mit erlaubter Entladeleistung", PvCharging(bat_prio=True), -600, 51, 500, False),
+    Params("Speicher, Speicher lädt", PvCharging(bat_mode="bat_mode"), 500, 90, 0, True),
+    Params("Speicher, Speicher entlädt", PvCharging(bat_mode="bat_mode"), -500, 90, -500, True),
+    Params("EV, Speicher lädt", PvCharging(bat_mode="ev_mode"), 500, 90, 500, False),
+    Params("EV, Speicher entlädt", PvCharging(bat_mode="ev_mode"), -500, 90, -500, False),
+    Params("Mindest-SoC, SoC nicht erreicht, Speicher entlädt",
+           PvCharging(bat_mode="min_soc_bat_mode"), -500, 40, -500, True),
+    Params("Mindest-SoC, SoC nicht erreicht, Speicher lädt", PvCharging(bat_mode="min_soc_bat_mode"), 500, 40, 0, True),
+    Params("Mindest-SoC, SoC nicht erreicht, Speicher-Reserve, Speicher entlädt",
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), -500, 40, 500, True),
+    Params("Mindest-SoC, SoC nicht erreicht, Speicher-Reserve nicht ausgenutzt, Speicher lädt",
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), 1600, 40, -400, True),
+    Params("Mindest-SoC, SoC nicht erreicht, Speicher-Reserve ausgenutzt, Speicher lädt",
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=200), 2200, 40, 200, True),
+    Params("Mindest-SoC, SoC erreicht, Speicher entlädt", PvCharging(bat_mode="min_soc_bat_mode"), -500, 90, -500,
+           False),
+    Params("Mindest-SoC, SoC erreicht, Speicher lädt", PvCharging(bat_mode="min_soc_bat_mode"), 500, 90, 500, False),
+    Params("Mindest-SoC, SoC erreicht, Entladung in Auto, Speicher entlädt",
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_discharge=500), -500, 90, 0, False),
+    Params("Mindest-SoC, SoC erreicht, Entladung in Auto, Speicher lädt",
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_discharge=500), 500, 90, 100, False),
+
 ]
 
 

--- a/packages/control/bat_all_test.py
+++ b/packages/control/bat_all_test.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 from control.bat import Bat
 
-from control.bat_all import BatAll, SwitchOnBatState
+from control.bat_all import BatAll
 from control import data
 from control.chargepoint.chargepoint_all import AllChargepointData, AllChargepoints, AllGet
 from control.general import General, PvCharging

--- a/packages/control/bat_all_test.py
+++ b/packages/control/bat_all_test.py
@@ -131,18 +131,18 @@ cases = [
            PvCharging(bat_mode="min_soc_bat_mode"), -500, 40, -500, True),
     Params("Mindest-SoC, SoC nicht erreicht, Speicher lädt", PvCharging(bat_mode="min_soc_bat_mode"), 500, 40, 0, True),
     Params("Mindest-SoC, SoC nicht erreicht, Speicher-Reserve, Speicher entlädt",
-           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), -500, 40, 500, True),
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), -500, 40, -500, True),
     Params("Mindest-SoC, SoC nicht erreicht, Speicher-Reserve nicht ausgenutzt, Speicher lädt",
            PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), 1600, 40, -400, True),
     Params("Mindest-SoC, SoC nicht erreicht, Speicher-Reserve ausgenutzt, Speicher lädt",
-           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=200), 2200, 40, 200, True),
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), 2200, 40, 200, True),
     Params("Mindest-SoC, SoC erreicht, Speicher entlädt", PvCharging(bat_mode="min_soc_bat_mode"), -500, 90, -500,
            False),
     Params("Mindest-SoC, SoC erreicht, Speicher lädt", PvCharging(bat_mode="min_soc_bat_mode"), 500, 90, 500, False),
     Params("Mindest-SoC, SoC erreicht, Entladung in Auto, Speicher entlädt",
            PvCharging(bat_mode="min_soc_bat_mode", bat_power_discharge=500), -500, 90, 0, False),
     Params("Mindest-SoC, SoC erreicht, Entladung in Auto, Speicher lädt",
-           PvCharging(bat_mode="min_soc_bat_mode", bat_power_discharge=500), 500, 90, 100, False),
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_discharge=500), 500, 90, 1000, False),
 
 ]
 

--- a/packages/control/bat_all_test.py
+++ b/packages/control/bat_all_test.py
@@ -20,48 +20,6 @@ def data_fixture() -> None:
                                                        config=Mock(spec=Config, max_ac_out=7200)))
 
 
-@pytest.mark.parametrize(
-    "soc, switch_on_soc_reached, switch_on_soc, switch_off_soc," +
-    "expected_switch_on_soc_state, expected_switch_on_soc_reached",
-    [pytest.param(41, True, 60, 40, SwitchOnBatState.CHARGE_FROM_BAT, True,
-                  id="Laderegelung freigegeben, Ausschalt-SoC nicht erreicht"),
-     pytest.param(60, True, 60, 0, SwitchOnBatState.REACH_ONLY_SWITCH_ON_SOC, True,
-                  id="Laderegelung freigegeben, Ausschalt-SoC nicht konfiguriert"),
-     pytest.param(40, True, 60, 40, SwitchOnBatState.SWITCH_OFF_SOC_REACHED, False,
-                  id="Laderegelung freigegeben, Ausschalt-SoC erreicht"),
-     pytest.param(40, False, 0, 40, SwitchOnBatState.SWITCH_OFF_SOC_REACHED, False,
-                  id="Laderegelung nicht freigegeben, Einschalt-SoC nicht konfiguriert, Ausschalt-SoC erreicht"),
-     pytest.param(41, False, 0, 40, SwitchOnBatState.CHARGE_FROM_BAT, True,
-                  id="Laderegelung nicht freigegeben, Einschalt-SoC nicht konfiguriert, Ausschalt-SoC nicht erreicht"),
-     pytest.param(60, False, 60, 40, SwitchOnBatState.CHARGE_FROM_BAT, True,
-                  id="Laderegelung nicht freigegeben, Einschalt-SoC erreicht"),
-     pytest.param(59, False, 60, 40, SwitchOnBatState.SWITCH_ON_SOC_NOT_REACHED, False,
-                  id="Laderegelung nicht freigegeben, Einschalt-SoC nicht erreicht"),
-     pytest.param(59, False, 0, 0, SwitchOnBatState.CHARGE_FROM_BAT, True,
-                  id="Ein/Ausschalt-SoC nicht konfiguriert")]
-
-)
-def test_get_switch_on_state(soc: float,
-                             switch_on_soc_reached: bool,
-                             switch_on_soc: int,
-                             switch_off_soc: int,
-                             expected_switch_on_soc_state: SwitchOnBatState,
-                             expected_switch_on_soc_reached: bool):
-    # setup
-    b = BatAll()
-    b.data.get.soc = soc
-    b.data.set.switch_on_soc_reached = switch_on_soc_reached
-    data.data.general_data.data.chargemode_config.pv_charging.switch_on_soc = switch_on_soc
-    data.data.general_data.data.chargemode_config.pv_charging.switch_off_soc = switch_off_soc
-
-    # execution
-    b._get_switch_on_state()
-
-    # evaluation
-    assert b.data.set.switch_on_soc_reached == expected_switch_on_soc_reached
-    assert b.data.set.switch_on_soc_state == expected_switch_on_soc_state
-
-
 @pytest.mark.parametrize("parent, bat_power, expected_power",
                          [
                              pytest.param({"id": 6, "type": "counter", "children": [
@@ -135,14 +93,14 @@ cases = [
     Params("Mindest-SoC, SoC nicht erreicht, Speicher-Reserve nicht ausgenutzt, Speicher lädt",
            PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), 1600, 40, -400, True),
     Params("Mindest-SoC, SoC nicht erreicht, Speicher-Reserve ausgenutzt, Speicher lädt",
-           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), 2200, 40, 200, True),
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_reserve=2000), 2200, 40, 200, False),
     Params("Mindest-SoC, SoC erreicht, Speicher entlädt", PvCharging(bat_mode="min_soc_bat_mode"), -500, 90, -500,
            False),
     Params("Mindest-SoC, SoC erreicht, Speicher lädt", PvCharging(bat_mode="min_soc_bat_mode"), 500, 90, 500, False),
     Params("Mindest-SoC, SoC erreicht, Entladung in Auto, Speicher entlädt",
            PvCharging(bat_mode="min_soc_bat_mode", bat_power_discharge=500), -500, 90, 0, False),
     Params("Mindest-SoC, SoC erreicht, Entladung in Auto, Speicher lädt",
-           PvCharging(bat_mode="min_soc_bat_mode", bat_power_discharge=500), 500, 90, 1000, False),
+           PvCharging(bat_mode="min_soc_bat_mode", bat_power_discharge=500), 400, 90, 500, False),
 
 ]
 

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -12,7 +12,6 @@ import traceback
 from typing import List, Dict, Optional, Tuple
 
 from control import data
-from control.bat_all import SwitchOnBatState
 from control.chargepoint.chargepoint_state import ChargepointState, PHASE_SWITCH_STATES
 from control.chargepoint.control_parameter import ControlParameter
 from control.limiting_value import LimitingValue

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -662,13 +662,7 @@ class ChargeTemplate:
                     return min_current, "pv_charging", message
                 else:
                     # Min PV
-                    if data.data.bat_all_data.data.config.configured is True:
-                        if data.data.bat_all_data.data.set.switch_on_soc_state == SwitchOnBatState.CHARGE_FROM_BAT:
-                            return pv_charging.min_current, "instant_charging", message
-                        else:
-                            return 0, "stop", data.data.bat_all_data.data.set.switch_on_soc_state.value
-                    else:
-                        return pv_charging.min_current, "instant_charging", message
+                    return pv_charging.min_current, "instant_charging", message
             else:
                 return 0, "stop", self.PV_CHARGING_SOC_REACHED
         except Exception:

--- a/packages/control/ev_charge_template_test.py
+++ b/packages/control/ev_charge_template_test.py
@@ -5,7 +5,6 @@ import pytest
 
 from control import data
 from control import optional
-from control.bat_all import SwitchOnBatState
 from control.ev import ChargeTemplate, EvTemplate, EvTemplateData, SelectedPlan
 from control.general import General
 from helpermodules import timecheck
@@ -94,26 +93,20 @@ def test_instant_charging(selected: str, current_soc: float, used_amount: float,
 
 
 @pytest.mark.parametrize(
-    "min_soc, min_current, current_soc, switch_on_soc_state, expected",
+    "min_soc, min_current, current_soc, expected",
     [
-        pytest.param(0, 0, 100, SwitchOnBatState.CHARGE_FROM_BAT, (0, "stop",
-                     ChargeTemplate.PV_CHARGING_SOC_REACHED), id="max soc reached"),
-        pytest.param(15, 0, 14, SwitchOnBatState.CHARGE_FROM_BAT,
-                     (10, "instant_charging", None), id="min soc not reached"),
-        pytest.param(15, 0, None, SwitchOnBatState.CHARGE_FROM_BAT, (6, "pv_charging", None), id="soc not defined"),
-        pytest.param(15, 8, 15, SwitchOnBatState.CHARGE_FROM_BAT,
-                     (8, "instant_charging", None), id="min current configured"),
-        pytest.param(15, 8, 15, SwitchOnBatState.SWITCH_OFF_SOC_REACHED, (0, "stop",
-                     SwitchOnBatState.SWITCH_OFF_SOC_REACHED.value), id="min current, bat reached switch off soc"),
-        pytest.param(15, 0, 15, SwitchOnBatState.CHARGE_FROM_BAT, (6, "pv_charging", None), id="bare pv charging"),
+        pytest.param(0, 0, 100, (0, "stop", ChargeTemplate.PV_CHARGING_SOC_REACHED), id="max soc reached"),
+        pytest.param(15, 0, 14, (10, "instant_charging", None), id="min soc not reached"),
+        pytest.param(15, 0, None, (6, "pv_charging", None), id="soc not defined"),
+        pytest.param(15, 8, 15, (8, "instant_charging", None), id="min current configured"),
+        pytest.param(15, 0, 15, (6, "pv_charging", None), id="bare pv charging"),
     ])
-def test_pv_charging(min_soc: int, min_current: int, current_soc: float, switch_on_soc_state: SwitchOnBatState,
+def test_pv_charging(min_soc: int, min_current: int, current_soc: float,
                      expected: Tuple[int, str, Optional[str]]):
     # setup
     ct = ChargeTemplate(0)
     ct.data.chargemode.pv_charging.min_soc = min_soc
     ct.data.chargemode.pv_charging.min_current = min_current
-    data.data.bat_all_data.data.set.switch_on_soc_state = switch_on_soc_state
     data.data.bat_all_data.data.config.configured = True
 
     # execution

--- a/packages/control/general.py
+++ b/packages/control/general.py
@@ -33,12 +33,12 @@ def control_range_factory() -> List:
 
 @dataclass
 class PvCharging:
-    ev_power_reserve: int = 200
+    bat_power_reserve: int = 0
     control_range: List = field(default_factory=control_range_factory)
     feed_in_yield: int = 15000
     phase_switch_delay: int = 7
     phases_to_use: int = 1
-    bat_power_discharge: int = 1000
+    bat_power_discharge: int = 0
     min_bat_soc: int = 50
     bat_mode: BatConsiderationMode = BatConsiderationMode.EV_MODE.value
     switch_off_delay: int = 60

--- a/packages/control/general.py
+++ b/packages/control/general.py
@@ -7,6 +7,7 @@ import random
 from typing import List, Optional
 
 from control import data
+from control.bat_all import BatConsiderationMode
 from helpermodules.constants import NO_ERROR
 from helpermodules.pub import Pub
 from helpermodules import timecheck
@@ -32,19 +33,17 @@ def control_range_factory() -> List:
 
 @dataclass
 class PvCharging:
-    bat_prio: bool = True
-    charging_power_reserve: int = 200
+    ev_power_reserve: int = 200
     control_range: List = field(default_factory=control_range_factory)
     feed_in_yield: int = 15000
     phase_switch_delay: int = 7
     phases_to_use: int = 1
-    rundown_power: int = 1000
-    rundown_soc: int = 50
+    bat_power_discharge: int = 1000
+    min_bat_soc: int = 50
+    bat_mode: BatConsiderationMode = BatConsiderationMode.EV_MODE.value
     switch_off_delay: int = 60
-    switch_off_soc: int = 40
     switch_off_threshold: int = 5
     switch_on_delay: int = 30
-    switch_on_soc: int = 60
     switch_on_threshold: int = 1500
 
 

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -677,7 +677,6 @@ class SetData:
         """
         try:
             if ("openWB/set/bat/config/configured" in msg.topic or
-                    "openWB/set/bat/set/switch_on_soc_reached" in msg.topic or
                     "openWB/set/bat/set/regulate_up" in msg.topic):
                 self._validate_value(msg, bool)
             elif "openWB/set/bat/set/charging_power_left" in msg.topic:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -758,13 +758,13 @@ class SetData:
                 self._validate_value(msg, int, [(0, 0), (1, 1), (3, 3)])
             elif "openWB/set/general/chargemode_config/pv_charging/bat_prio" in msg.topic:
                 self._validate_value(msg, bool)
-            elif ("openWB/set/general/chargemode_config/pv_charging/switch_on_soc" in msg.topic or
-                    "openWB/set/general/chargemode_config/pv_charging/switch_off_soc" in msg.topic or
-                    "openWB/set/general/chargemode_config/pv_charging/rundown_soc" in msg.topic):
+            elif "openWB/set/general/chargemode_config/pv_charging/min_bat_soc" in msg.topic:
                 self._validate_value(msg, int, [(0, 100)])
-            elif ("openWB/set/general/chargemode_config/pv_charging/rundown_power" in msg.topic or
-                    "openWB/set/general/chargemode_config/pv_charging/charging_power_reserve" in msg.topic):
+            elif ("openWB/set/general/chargemode_config/pv_charging/bat_power_discharge" in msg.topic or
+                    "openWB/set/general/chargemode_config/pv_charging/ev_power_reserve" in msg.topic):
                 self._validate_value(msg, float, [(0, float("inf"))])
+            elif "openWB/set/general/chargemode_config/pv_charging/bat_mode" in msg.topic:
+                self._validate_value(msg, str)
             elif "openWB/set/general/chargemode_config/" in msg.topic and "/phases_to_use" in msg.topic:
                 self._validate_value(msg, int, [(1, 1), (3, 3)])
             elif ("openWB/set/general/grid_protection_configured" in msg.topic or

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -761,7 +761,7 @@ class SetData:
             elif "openWB/set/general/chargemode_config/pv_charging/min_bat_soc" in msg.topic:
                 self._validate_value(msg, int, [(0, 100)])
             elif ("openWB/set/general/chargemode_config/pv_charging/bat_power_discharge" in msg.topic or
-                    "openWB/set/general/chargemode_config/pv_charging/ev_power_reserve" in msg.topic):
+                    "openWB/set/general/chargemode_config/pv_charging/bat_power_reserve" in msg.topic):
                 self._validate_value(msg, float, [(0, float("inf"))])
             elif "openWB/set/general/chargemode_config/pv_charging/bat_mode" in msg.topic:
                 self._validate_value(msg, str)

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -1414,9 +1414,8 @@ class UpdateConfig:
                     elif ("openWB/general/chargemode_config/pv_charging/rundown_power" == mode_topic and
                             decode_payload(mode_payload) == 0 and old_bat_prio):
                         return {"openWB/general/chargemode_config/pv_charging/bat_mode": "bat_mode"}
-                    else:
-                        return {"openWB/general/chargemode_config/pv_charging/bat_mode": "min_soc_mode"}
-                return {"openWB/general/chargemode_config/pv_charging/bat_mode": "min_soc_mode"}
+                else:
+                    return {"openWB/general/chargemode_config/pv_charging/bat_mode": "min_soc_mode"}
             elif "openWB/general/chargemode_config/pv_charging/rundown_soc" == topic:
                 return {"openWB/general/chargemode_config/pv_charging/min_bat_soc": decode_payload(payload)}
             elif "openWB/general/chargemode_config/pv_charging/rundown_power" == topic:

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -1406,6 +1406,15 @@ class UpdateConfig:
     def upgrade_datastore_41(self) -> None:
         def upgrade(topic: str, payload) -> Optional[dict]:
             if "openWB/general/chargemode_config/pv_charging/bat_prio" == topic:
+                for mode_topic, mode_payload in self.all_received_topics.items():
+                    if ("openWB/general/chargemode_config/pv_charging/charging_power_reserve" == mode_topic and
+                            decode_payload(mode_payload) == 0):
+                        return {"openWB/general/chargemode_config/pv_charging/bat_mode": "ev_mode"}
+                    elif ("openWB/general/chargemode_config/pv_charging/rundown_power" == mode_topic and
+                            decode_payload(mode_payload) == 0):
+                        return {"openWB/general/chargemode_config/pv_charging/bat_mode": "bat_mode"}
+                    else:
+                        return {"openWB/general/chargemode_config/pv_charging/bat_mode": "min_soc_mode"}
                 return {"openWB/general/chargemode_config/pv_charging/bat_mode": "min_soc_mode"}
             elif "openWB/general/chargemode_config/pv_charging/rundown_soc" == topic:
                 return {"openWB/general/chargemode_config/pv_charging/min_bat_soc": decode_payload(payload)}

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -43,7 +43,6 @@ class UpdateConfig:
         "^openWB/bat/config/configured$",
         "^openWB/bat/set/charging_power_left$",
         "^openWB/bat/set/regulate_up$",
-        "^openWB/bat/set/switch_on_soc_reached$",
         "^openWB/bat/get/fault_state$",
         "^openWB/bat/get/fault_str$",
         "^openWB/bat/get/soc$",
@@ -1405,8 +1404,8 @@ class UpdateConfig:
 
     def upgrade_datastore_41(self) -> None:
         def upgrade(topic: str, payload) -> Optional[dict]:
-            if "openWB/general/chargemode_config/pv_charging/bat_mode" == topic:
-                return {"openWB/general/chargemode_config/pv_charging/bat_mode": decode_payload(payload)}
+            if "openWB/general/chargemode_config/pv_charging/bat_prio" == topic:
+                return {"openWB/general/chargemode_config/pv_charging/bat_mode": "min_soc_mode"}
             elif "openWB/general/chargemode_config/pv_charging/rundown_soc" == topic:
                 return {"openWB/general/chargemode_config/pv_charging/min_bat_soc": decode_payload(payload)}
             elif "openWB/general/chargemode_config/pv_charging/rundown_power" == topic:

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -499,11 +499,12 @@ class UpdateConfig:
         log.debug("Broker-Konfiguration aktualisieren")
         InternalBrokerClient("update-config", self.on_connect, self.on_message).start_finite_loop()
         try:
+            # erst breaking changes auflösen, sonst sind alte Topics schon gelöscht
+            self.__solve_breaking_changes()
             self.__remove_outdated_topics()
             self._remove_invalid_topics()
             self.__pub_missing_defaults()
             self.__update_version()
-            self.__solve_breaking_changes()
         except Exception:
             log.exception("Fehler bei der Aktualisierung des Brokers.")
             pub_system_message({}, "Fehler bei der Aktualisierung der Konfiguration im Brokers.", MessageType.ERROR)

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -1406,12 +1406,13 @@ class UpdateConfig:
     def upgrade_datastore_41(self) -> None:
         def upgrade(topic: str, payload) -> Optional[dict]:
             if "openWB/general/chargemode_config/pv_charging/bat_prio" == topic:
+                old_bat_prio = decode_payload(payload)
                 for mode_topic, mode_payload in self.all_received_topics.items():
                     if ("openWB/general/chargemode_config/pv_charging/charging_power_reserve" == mode_topic and
-                            decode_payload(mode_payload) == 0):
+                            decode_payload(mode_payload) == 0 and old_bat_prio is False):
                         return {"openWB/general/chargemode_config/pv_charging/bat_mode": "ev_mode"}
                     elif ("openWB/general/chargemode_config/pv_charging/rundown_power" == mode_topic and
-                            decode_payload(mode_payload) == 0):
+                            decode_payload(mode_payload) == 0 and old_bat_prio):
                         return {"openWB/general/chargemode_config/pv_charging/bat_mode": "bat_mode"}
                     else:
                         return {"openWB/general/chargemode_config/pv_charging/bat_mode": "min_soc_mode"}

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -192,7 +192,7 @@ class UpdateConfig:
         "^openWB/general/chargemode_config/pv_charging/phases_to_use$",
         "^openWB/general/chargemode_config/pv_charging/min_bat_soc$",
         "^openWB/general/chargemode_config/pv_charging/bat_power_discharge$",
-        "^openWB/general/chargemode_config/pv_charging/ev_power_reserve$",
+        "^openWB/general/chargemode_config/pv_charging/bat_power_reserve$",
         "^openWB/general/chargemode_config/retry_failed_phase_switches$",
         "^openWB/general/chargemode_config/scheduled_charging/phases_to_use$",
         "^openWB/general/chargemode_config/instant_charging/phases_to_use$",
@@ -419,7 +419,7 @@ class UpdateConfig:
         ("openWB/general/chargemode_config/pv_charging/bat_mode", BatConsiderationMode.EV_MODE.value),
         ("openWB/general/chargemode_config/pv_charging/bat_power_discharge", 1000),
         ("openWB/general/chargemode_config/pv_charging/min_bat_soc", 50),
-        ("openWB/general/chargemode_config/pv_charging/ev_power_reserve", 200),
+        ("openWB/general/chargemode_config/pv_charging/bat_power_reserve", 200),
         ("openWB/general/chargemode_config/pv_charging/control_range", [0, 230]),
         ("openWB/general/chargemode_config/pv_charging/switch_off_threshold", 50),
         ("openWB/general/chargemode_config/pv_charging/switch_off_delay", 60),
@@ -1412,6 +1412,6 @@ class UpdateConfig:
             elif "openWB/general/chargemode_config/pv_charging/rundown_power" == topic:
                 return {"openWB/general/chargemode_config/pv_charging/bat_power_discharge": decode_payload(payload)}
             elif "openWB/general/chargemode_config/pv_charging/charging_power_reserve" == topic:
-                return {"openWB/general/chargemode_config/pv_charging/ev_power_reserve": decode_payload(payload)}
+                return {"openWB/general/chargemode_config/pv_charging/bat_power_reserve": decode_payload(payload)}
         self._loop_all_received_topics(upgrade)
         self.__update_topic("openWB/system/datastore_version", 42)

--- a/packages/modules/web_themes/standard_legacy/web/index.html
+++ b/packages/modules/web_themes/standard_legacy/web/index.html
@@ -159,14 +159,20 @@
 							</div>
 							<div class="row vaRow">
 								<div class="col pr-0">
-									Vorrang PV
+									Laden mit Überschuss
 								</div>
-								<div class="col text-right">
-									<input class="house-battery-priority" type="checkbox" data-toggle="toggle"
-										data-topic="openWB/set/general/chargemode_config/pv_charging/bat_prio"
-										data-on='<i class="fas fa-car-battery"></i>'
-										data-off='<i class="fas fa-car-side"></i>' data-onstyle="warning"
-										data-offstyle="primary" data-size="sm" data-style="w-100">
+								<div class="col-md-8 btn-group btn-group-toggle bat-consideration-mode"
+									data-toggle="buttons" data-name="bat_consideration_mode"
+									data-topic="openWB/set/general/chargemode_config/pv_charging/bat_mode">
+									<label class="btn btn-outline-warning btn-toggle">
+										<input type="radio" name="bat_mode_name" data-option="bat_mode">Speicher
+									</label>
+									<label class="btn btn-outline-primary btn-toggle">
+										<input type="radio" name="bat_mode_name" data-option="ev_mode">Fahrzeuge
+									</label>
+									<label class="btn btn-outline-success btn-toggle">
+										<input type="radio" name="bat_mode_name" data-option="min_soc_mode">Mindest-SoC
+									</label>
 								</div>
 							</div>
 						</div>

--- a/packages/modules/web_themes/standard_legacy/web/processAllMqttMsg.js
+++ b/packages/modules/web_themes/standard_legacy/web/processAllMqttMsg.js
@@ -650,14 +650,15 @@ function processPvMessages(mqttTopic, mqttPayload) {
 }
 
 function processPvConfigMessages(mqttTopic, mqttPayload) {
-	if (mqttTopic == 'openWB/general/chargemode_config/pv_charging/bat_prio') {
-		var element = $('.house-battery-priority');
+	if (mqttTopic == 'openWB/general/chargemode_config/pv_charging/bat_mode') {
 		data = JSON.parse(mqttPayload);
-		if (data == true) {
-			element.bootstrapToggle('on', true); // do not fire a changed-event to prevent a loop!
-		} else {
-			element.bootstrapToggle('off', true); // do not fire a changed-event to prevent a loop!
-		}
+		var element = $('.bat-consideration-mode input[type=radio][data-option="' + data + '"]');
+		element.prop('checked', true); // check selected batmode radio button
+		element.parent().addClass('active'); // activate selected batmode button
+		$('.bat-consideration-mode input[type=radio]').not('[data-option="' + data + '"]').each(function () {
+			$(this).prop('checked', false); // uncheck all other radio buttons
+			$(this).parent().removeClass('active'); // deselect all other batmode buttons
+		});
 	}
 }
 

--- a/packages/modules/web_themes/standard_legacy/web/setupMqttServices.js
+++ b/packages/modules/web_themes/standard_legacy/web/setupMqttServices.js
@@ -71,7 +71,7 @@ var topicsToSubscribe = [
 	["openWB/vehicle/template/charge_template/+/time_charging/plans/+", 1], // populate a list of time charge plans
 
 	// charge mode config
-	["openWB/general/chargemode_config/pv_charging/bat_prio", 0],
+	["openWB/general/chargemode_config/pv_charging/bat_mode", 0],
 
 	// electricity tariff
 	["openWB/optional/et/active", 1], // et provider is configured


### PR DESCRIPTION
Die Speicher-Beachtung wurde grundlegend überarbeitet. Es gibt nun drei Modi: Speicher - Fahrzeuge - Mindest-SoC des Speichers

Bei Auswahl "Fahrzeuge" wird der gesamte Überschussin das EV geladen. Ist die maximale Ladeleistung derFahrzeuge erreicht und es wird eingespeist, wirddieser Überschuss in den Speicher geladen.
Bei Auswahl "Speicher" wird der gesamte Überschussin den Speicher geladen. Ist die maximaleLadeleistung des Speichers erreicht und es wirdeingespeist, wird dieser Überschuss unter Beachtungder Einschaltschwelle in die Fahrzeuge geladen.
Bei Auswahl "Mindest-SoC des Speichers" wird derÜberschuss bis zum Mindest-SoC in den Speichergeladen. Ist die maximale Ladeleistung des Speicherserreicht und es wird eingespeist, wird dieserÜberschuss in die Fahrzeuge geladen. Wird derMindest-SoC überschritten, wird der Überschuss insFahrzeug geladen.