### PR TITLE
mqtt smarthome openWB 2.0

### DIFF
--- a/packages/modules/smarthome/mqtt/off.py
+++ b/packages/modules/smarthome/mqtt/off.py
@@ -1,19 +1,15 @@
 #!/usr/bin/python3
 import sys
-import os
 import time
 import paho.mqtt.client as mqtt
-import logging
-
-log = logging.getLogger(__name__)
 numberOfSupportedDevices = 9  # limit number of smart home devices
 
 
-def on_connect(client, userdata, flags, rc):
-    client.subscribe("openWB/LegacySmartHome/set/Devices/#", 2)
+def on_connect(client, userdata, flags, rc) -> None:
+    client.subscribe("openWB/set/LegacySmartHome/Devices/#", 2)
 
 
-def on_message(client, userdata, msg):
+def on_message(client, userdata, msg) -> None:
     global numberOfSupportedDevices
 
 
@@ -31,23 +27,13 @@ while True:
     elapsedTime = time.time() - startTime
     if elapsedTime > waitTime:
         break
-client.publish("openWB/LegacySmartHome/set/Devices/"+str(devicenumber)+"/ReqRelay", "0", qos=0, retain=True)
+client.publish("openWB/set/LegacySmartHome/Devices/"+str(devicenumber)+"/ReqRelay", "0", qos=0, retain=True)
 client.loop(timeout=2.0)
-client.publish("openWB/LegacySmartHome/set/Devices/"+str(devicenumber) +
+client.publish("openWB/set/LegacySmartHome/Devices/"+str(devicenumber) +
                "/Ueberschuss", payload=str(uberschuss), qos=0, retain=True)
 client.loop(timeout=2.0)
 client.disconnect()
-named_tuple = time.localtime()  # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S mqtt off.py", named_tuple)
-# standard
-file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_mqtt.log'
 file_stringpv = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
-if os.path.isfile(file_string):
-    f = open(file_string, 'a')
-else:
-    f = open(file_string, 'w')
-log.debug('%s devicenr %s ueberschuss %6d /ReqRelay = 0' % (time_string, devicenumber, uberschuss), file=f)
-f.close()
 pvmodus = 0
 f = open(file_stringpv, 'w')
 f.write(str(pvmodus))

--- a/packages/modules/smarthome/mqtt/on.py
+++ b/packages/modules/smarthome/mqtt/on.py
@@ -1,19 +1,15 @@
 #!/usr/bin/python3
 import sys
-import os
 import time
 import paho.mqtt.client as mqtt
-import logging
-
-log = logging.getLogger(__name__)
 numberOfSupportedDevices = 9  # limit number of smart home devices
 
 
-def on_connect(client, userdata, flags, rc):
-    client.subscribe("openWB/LegacySmartHome/set/Devices/#", 2)
+def on_connect(client, userdata, flags, rc) -> None:
+    client.subscribe("openWB/set/LegacySmartHome/Devices/#", 2)
 
 
-def on_message(client, userdata, msg):
+def on_message(client, userdata, msg) -> None:
     global numberOfSupportedDevices
 
 
@@ -31,22 +27,13 @@ while True:
     elapsedTime = time.time() - startTime
     if elapsedTime > waitTime:
         break
-client.publish("openWB/LegacySmartHome/set/Devices/"+str(devicenumber)+"/ReqRelay", "1", qos=0, retain=True)
+client.publish("openWB/set/LegacySmartHome/Devices/"+str(devicenumber)+"/ReqRelay", "1", qos=0, retain=True)
 client.loop(timeout=2.0)
-client.publish("openWB/LegacySmartHome/set/Devices/"+str(devicenumber) +
+client.publish("openWB/set/LegacySmartHome/Devices/"+str(devicenumber) +
                "/Ueberschuss", payload=str(uberschuss), qos=0, retain=True)
 client.loop(timeout=2.0)
 client.disconnect()
-named_tuple = time.localtime()  # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S mqtt on.py", named_tuple)
-file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_mqtt.log'
 file_stringpv = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_pv'
-if os.path.isfile(file_string):
-    f = open(file_string, 'a')
-else:
-    f = open(file_string, 'w')
-log.debug('%s devicenr %s ueberschuss %6d /ReqRelay = 1' % (time_string, devicenumber, uberschuss), file=f)
-f.close()
 f = open(file_stringpv, 'w')
 f.write(str(1))
 f.close()

--- a/packages/modules/smarthome/mqtt/watt.py
+++ b/packages/modules/smarthome/mqtt/watt.py
@@ -1,28 +1,27 @@
 #!/usr/bin/python3
 import sys
-import os
 import time
 import json
 import paho.mqtt.client as mqtt
 import re
-
+import os
 numberOfSupportedDevices = 9  # limit number of smart home devices
 
 
-def on_connect(client, userdata, flags, rc):
+def on_connect(client, userdata, flags, rc) -> None:
     global devicenumber
-    client.subscribe("openWB/LegacySmartHome/set/Devices/"+devicenumber + "/#", 2)
+    client.subscribe("openWB/set/LegacySmartHome/Devices/"+devicenumber + "/#", 2)
 
 
-def on_message(client, userdata, msg):
+def on_message(client, userdata, msg) -> None:
     global numberOfSupportedDevices
     global aktpower
     global powerc
-    if (("openWB/LegacySmartHome/set/Device" in msg.topic) and ("Aktpower" in msg.topic)):
+    if (("openWB/set/LegacySmartHome/Device" in msg.topic) and ("Aktpower" in msg.topic)):
         devicenumb = re.sub(r'\D', '', msg.topic)
         if (1 <= int(devicenumb) <= numberOfSupportedDevices):
             aktpower = int(msg.payload)
-    if (("openWB/LegacySmartHome/set/Device" in msg.topic) and ("Powerc" in msg.topic)):
+    if (("openWB/set/LegacySmartHome/Device" in msg.topic) and ("Powerc" in msg.topic)):
         devicenumb = re.sub(r'\D', '', msg.topic)
         if (1 <= int(devicenumb) <= numberOfSupportedDevices):
             powerc = int(msg.payload)
@@ -33,13 +32,6 @@ powerc = 0
 devicenumber = str(sys.argv[1])
 ipadr = str(sys.argv[2])
 uberschuss = int(sys.argv[3])
-file_string = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenumber) + '_mqtt.log'
-if os.path.isfile(file_string):
-    fx = open(file_string, 'a')
-else:
-    fx = open(file_string, 'w')
-named_tuple = time.localtime()  # getstruct_time
-time_string = time.strftime("%m/%d/%Y, %H:%M:%S mqtt watt.py", named_tuple)
 client = mqtt.Client("openWB-mqttsmarthomecust" + devicenumber)
 client.on_connect = on_connect
 client.on_message = on_message
@@ -51,7 +43,7 @@ while True:
     elapsedTime = time.time() - startTime
     if elapsedTime > waitTime:
         break
-client.publish("openWB/LegacySmartHome/set/Devices/"+str(devicenumber) +
+client.publish("openWB/set/LegacySmartHome/Devices/"+str(devicenumber) +
                "/Ueberschuss", payload=str(uberschuss), qos=0, retain=True)
 client.loop(timeout=2.0)
 client.disconnect()
@@ -66,4 +58,3 @@ answer = '{"power":' + str(aktpower) + ',"powerc":' + str(powerc) + ',"on":' + s
 f1 = open('/var/www/html/openWB/ramdisk/smarthome_device_ret' + str(devicenumber), 'w')
 json.dump(answer, f1)
 f1.close()
-fx.close()


### PR DESCRIPTION
Nur für openwb 2.0 nicht für openwb 1.9
der mqtt smarthomeclient
erwartet neu unter dem  topic
openWB/set/LegacySmartHome/Devices/"+devicenumber + /Aktpower (aktuelle Leistung)
openWB/set/LegacySmartHome/Devices/"+devicenumber + /Powerc (Zählerstand oder 0/ nicht geliefert)
es wird auch immer
"openWB/set/LegacySmartHome/Devices/"+devicenumber
 + /Ueberschuss gepublished.


bei on Bedingung wird
openWB/set/LegacySmartHome/Devices/"+devicenumber +"/ReqRelay", "1" und
"openWB/set/LegacySmartHome/Devices/"+devicenumber  + /Ueberschuss

bei off Bedingung wird
openWB/set/LegacySmartHome/Devices/"+devicenumber +"/ReqRelay", "0" und
"openWB/set/LegacySmartHome/Devices/"+devicenumber + /Ueberschuss gepublished.
separates log entfernt.