### PR TITLE
smarthome temperatur sensoren

### DIFF
--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -24,9 +24,9 @@ import os
 import math
 import logging
 log = logging.getLogger(__name__)
-mydevices = []  # type: List[Any]
+mydevices = []
 mqtt_cache = {}  # type: Dict[str, str]
-parammqtt = []  # type: List[Any]
+parammqtt = []
 # will be populated with open 1.9 / openwb 2.0 specifc param
 mqttcg = 'none'
 mqttcs = 'none'

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -42,7 +42,7 @@ maxspeicher = 0
 firststart = True
 
 
-def on_connect(client: mqtt.Client, userdata,  flags: Dict, rc: int) -> None:
+def on_connect(client: mqtt.Client, userdata, flags: Dict, rc: int) -> None:
     global mqttcg
     global mqttsdevstat
     #  mqttcg = 'openWB/config/get/SmartHome/'

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -16,7 +16,7 @@ from modules.smarthome.nxdacxx.smartnxdacxx import Snxdacxx
 from modules.smarthome.acthor.smartacthor import Sacthor
 from modules.smarthome.avmhomeautomation.smartavm import Savm
 from smarthome.smartbase import Sbase
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 import paho.mqtt.client as mqtt
 import re
 import time
@@ -42,7 +42,7 @@ maxspeicher = 0
 firststart = True
 
 
-def on_connect(client: mqtt.Client, userdata: Any, flags: Dict, rc: Any) -> None:
+def on_connect(client: mqtt.Client, userdata,  flags: Dict, rc: int) -> None:
     global mqttcg
     global mqttsdevstat
     #  mqttcg = 'openWB/config/get/SmartHome/'
@@ -79,7 +79,7 @@ def logmqgl(keyword: str, value: str) -> None:
                           '" -r -m "' + str(value) + '"'), file=f)
 
 
-def on_message(client: mqtt.Client, userdata: Any, msg: Any) -> None:
+def on_message(client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:
     # wenn exception hier wird mit nächster msg weitergemacht
     # macht paho unter phyton 3 immer so
     # für neuer python 3.7 version gibt es absturz

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -16,7 +16,7 @@ from modules.smarthome.nxdacxx.smartnxdacxx import Snxdacxx
 from modules.smarthome.acthor.smartacthor import Sacthor
 from modules.smarthome.avmhomeautomation.smartavm import Savm
 from smarthome.smartbase import Sbase
-from typing import Dict, Any, List, Tuple
+from typing import Any, Dict, List, Tuple
 import paho.mqtt.client as mqtt
 import re
 import time
@@ -42,7 +42,7 @@ maxspeicher = 0
 firststart = True
 
 
-def on_connect(client: Any, userdata: Any, flags: Any, rc: Any) -> None:
+def on_connect(client: mqtt.Client, userdata: Any, flags: Dict, rc: Any) -> None:
     global mqttcg
     global mqttsdevstat
     #  mqttcg = 'openWB/config/get/SmartHome/'
@@ -79,7 +79,7 @@ def logmqgl(keyword: str, value: str) -> None:
                           '" -r -m "' + str(value) + '"'), file=f)
 
 
-def on_message(client: Any, userdata: Any, msg: Any) -> None:
+def on_message(client: mqtt.Client, userdata: Any, msg: Any) -> None:
     # wenn exception hier wird mit nächster msg weitergemacht
     # macht paho unter phyton 3 immer so
     # für neuer python 3.7 version gibt es absturz
@@ -191,7 +191,7 @@ def getdevicevalues(uberschuss: int, uberschussoffset: int, pvwatt: int, charges
     sendmq(mqtt_all)
 
 
-def pub(client: Any, key: str, value: str) -> None:
+def pub(client: mqtt.Client, key: str, value: str) -> None:
     if ("TemperatureSensor" in key and "300" in value):
         client.publish(key, payload="", qos=0, retain=True)
     else:
@@ -213,7 +213,6 @@ def sendmq(mqtt_input: Dict[str, str]) -> None:
                 log.info("Mq no caching " + str(key))
             else:
                 mqtt_cache[key] = value
-            # client.publish(key, payload=value, qos=0, retain=True)
             pub(client, key, value)
             client.loop(timeout=2.0)
     client.disconnect()
@@ -323,7 +322,6 @@ def update_devices() -> None:
                         log.info("Mq pub " + str(key) + "=" +
                                  str(value) + " old " + str(valueold))
                         pub(client, key, value)
-                        # client.publish(key, payload=value, qos=0, retain=True)
                         client.loop(timeout=2.0)
                     mydevice.device_nummer = 0
                     mydevice._device_configured = '9'

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -16,7 +16,7 @@ from modules.smarthome.nxdacxx.smartnxdacxx import Snxdacxx
 from modules.smarthome.acthor.smartacthor import Sacthor
 from modules.smarthome.avmhomeautomation.smartavm import Savm
 from smarthome.smartbase import Sbase
-from typing import Dict, List, Any, Tuple
+from typing import Dict, Any, List, Tuple
 import paho.mqtt.client as mqtt
 import re
 import time
@@ -42,7 +42,7 @@ maxspeicher = 0
 firststart = True
 
 
-def on_connect(client, userdata, flags, rc) -> None:
+def on_connect(client: Any, userdata: Any, flags: Any, rc: Any) -> None:
     global mqttcg
     global mqttsdevstat
     #  mqttcg = 'openWB/config/get/SmartHome/'
@@ -79,7 +79,7 @@ def logmqgl(keyword: str, value: str) -> None:
                           '" -r -m "' + str(value) + '"'), file=f)
 
 
-def on_message(client, userdata, msg) -> None:
+def on_message(client: Any, userdata: Any, msg: Any) -> None:
     # wenn exception hier wird mit nächster msg weitergemacht
     # macht paho unter phyton 3 immer so
     # für neuer python 3.7 version gibt es absturz
@@ -191,6 +191,13 @@ def getdevicevalues(uberschuss: int, uberschussoffset: int, pvwatt: int, charges
     sendmq(mqtt_all)
 
 
+def pub(client: Any, key: str, value: str) -> None:
+    if ("TemperatureSensor" in key and "300" in value):
+        client.publish(key, payload="", qos=0, retain=True)
+    else:
+        client.publish(key, payload=value, qos=0, retain=True)
+
+
 def sendmq(mqtt_input: Dict[str, str]) -> None:
     global mqtt_cache
     client = mqtt.Client("openWB-SmartHome-bulkpublisher-" + str(os.getpid()))
@@ -206,7 +213,8 @@ def sendmq(mqtt_input: Dict[str, str]) -> None:
                 log.info("Mq no caching " + str(key))
             else:
                 mqtt_cache[key] = value
-            client.publish(key, payload=value, qos=0, retain=True)
+            # client.publish(key, payload=value, qos=0, retain=True)
+            pub(client, key, value)
             client.loop(timeout=2.0)
     client.disconnect()
 
@@ -314,7 +322,8 @@ def update_devices() -> None:
                         valueold = mqtt_cache.pop(key, 'not in cache')
                         log.info("Mq pub " + str(key) + "=" +
                                  str(value) + " old " + str(valueold))
-                        client.publish(key, payload=value, qos=0, retain=True)
+                        pub(client, key, value)
+                        # client.publish(key, payload=value, qos=0, retain=True)
                         client.loop(timeout=2.0)
                     mydevice.device_nummer = 0
                     mydevice._device_configured = '9'

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -16,7 +16,7 @@ from modules.smarthome.nxdacxx.smartnxdacxx import Snxdacxx
 from modules.smarthome.acthor.smartacthor import Sacthor
 from modules.smarthome.avmhomeautomation.smartavm import Savm
 from smarthome.smartbase import Sbase
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 import paho.mqtt.client as mqtt
 import re
 import time


### PR DESCRIPTION
Nur für openwb 2.0 übernehmen
Neu werden temperaturtopics  (TemperatureSensor0/1/2) explizit im mqtt geschlöscht wenn nicht mehr gebraucht. Das vereinfacht das daily log im Json