### PR TITLE
rfid fix

### DIFF
--- a/packages/control/chargepoint/rfid.py
+++ b/packages/control/chargepoint/rfid.py
@@ -51,6 +51,12 @@ class ChargepointRfidMixin:
                         Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp",
                                   self.data.get.rfid_timestamp)
                         return
+                    if rfid not in self.template.data.valid_tags and self.template.data.rfid_enabling:
+                        self.data.get.rfid = None
+                        Pub().pub("openWB/chargepoint/"+str(self.num)+"/get/rfid", None)
+                        self.data.get.rfid_timestamp = None
+                        Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp", None)
+                        msg = f"Der ID-Tag {rfid} ist an diesem Ladepunkt nicht gültig."
                     else:
                         if (timecheck.check_timestamp(self.data.get.rfid_timestamp, 300) or
                                 self.data.get.plug_state is True):


### PR DESCRIPTION
RFID Fix
added missing comparison of RFID Tags of charge point with RFID Tags of electrical vehicle

with this fix charging will not start for a vehicle if in charging profile access is restricted to TAGs which do not match TAGs in cp and ev
without this fix it is possible to start charging vehicles with TAGs that are not included in chargepoint profiles but only included in vehicles even if access is restricted with ID-Tags (Freigabe durch ID-Tags) and only limited to assigned ID Tags