### PR TITLE
Rfid redesign

### DIFF
--- a/packages/control/chargepoint/chargepoint_template.py
+++ b/packages/control/chargepoint/chargepoint_template.py
@@ -90,7 +90,7 @@ class CpTemplate:
             if data.data.optional_data.data.rfid.active and (rfid is not None or vehicle_id is not None):
                 vehicle = ev_module.get_ev_to_rfid(rfid, vehicle_id)
                 if vehicle is None:
-                    if self.data.rfid_enabling and len(self.data.valid_tags) == 0 or not self.data.rfid_enabling:
+                    if self.data.rfid_enabling and len(self.data.valid_tags) == 0:
                         num = -1
                         message = (
                             f"Keine Ladung, da dem ID-Tag {rfid} kein Fahrzeug-Profil zugeordnet werden kann. Eine "

--- a/packages/control/chargepoint/chargepoint_template.py
+++ b/packages/control/chargepoint/chargepoint_template.py
@@ -90,11 +90,11 @@ class CpTemplate:
             if data.data.optional_data.data.rfid.active and (rfid is not None or vehicle_id is not None):
                 vehicle = ev_module.get_ev_to_rfid(rfid, vehicle_id)
                 if vehicle is None:
-                    if self.data.rfid_enabling:
+                    if self.data.rfid_enabling and len(self.data.valid_tags) == 0 or not self.data.rfid_enabling:
                         num = -1
                         message = (
                             f"Keine Ladung, da dem ID-Tag {rfid} kein Fahrzeug-Profil zugeordnet werden kann. Eine "
-                            "Freischaltung ist nur mit gültigen ID-Tag möglich.")
+                            "Freischaltung ist nur mit gültigem ID-Tag möglich.")
                     else:
                         num = assigned_ev
                 else:

--- a/packages/control/chargepoint/rfid.py
+++ b/packages/control/chargepoint/rfid.py
@@ -51,6 +51,12 @@ class ChargepointRfidMixin:
                         Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp",
                                   self.data.get.rfid_timestamp)
                         return
+                    if rfid not in self.template.data.valid_tags and self.template.data.rfid_enabling:
+                        self.data.get.rfid = None
+                        Pub().pub("openWB/chargepoint/"+str(self.num)+"/get/rfid", None)
+                        self.data.get.rfid_timestamp = None
+                        Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp", None)
+                        msg = f"Der ID-Tag {rfid} ist an diesem Ladepunkt nicht gültig."
                     else:
                         if (timecheck.check_timestamp(self.data.get.rfid_timestamp, 300) or
                                 self.data.get.plug_state is True):


### PR DESCRIPTION
Auflistung RFID Funktionalität Stand 02. Mai 2024 mit PR 1596
RFID Enabling (Optionale Hardware -> Identifikation aktivieren AN)

Ladepunkt gesperrt + Ladepunkt Freigabe durch ID-Tags in Ladepunkt Profil Aus
Nur manuelle Entsperrung in der UI (keine sinnvolle Anwendung, aber möglich)

3 Fälle:

1. Ladepunkt entsperrt und Freigabe durch ID-Tags in Ladepunkt Profil Aus
Standardfahrzeug ausgewählt mit Lademodus Stop
ID Tag in Fahrzeug eingetragen -> Fahrzeug mit entsprechendem ID Tag startet Ladevorgang

2. Ladepunkt gesperrt + Ladepunkt Freigabe durch ID-Tags in Ladepunkt Profil An
Automatische Entsperrung des Ladepunktes durch einem dem Ladepunkt zugeordneten ID-Tag
a) ID-Tag nur in Ladepunkt, dann nur Ladepunkt entsperrt -> Letztes ausgewähltes Fahrzeug startet Ladevorgang
b) ID-Tag in Ladepunkt + einem Fahrzeug zugeordnet -> Ladepunkt entsperrt + dem ID-Tag zugeordnetes Fahrzeug startet Ladevorgang

Getestet mit VM + Simulator + MQTT Explorer