### PR TITLE
MQTT: Allow other devices to use the branch other/#

### DIFF
--- a/data/config/mosquitto/mosquitto.acl
+++ b/data/config/mosquitto/mosquitto.acl
@@ -9,3 +9,5 @@ pattern write openWB/command/%c/messages/#
 topic read openWB/#
 # allow read access for remote support topics
 topic read openWB-remote/#
+# allow brach "others" for devices other than openWB
+topic readwrite others/#

--- a/data/config/mosquitto/mosquitto.acl
+++ b/data/config/mosquitto/mosquitto.acl
@@ -1,4 +1,4 @@
-# openwb-version:1
+# openwb-version:2
 # allow publishing set topics
 topic write openWB/set/#
 # allow clearing system messages


### PR DESCRIPTION
Create a readwrite branch in mosquitto.acl to allow other devices to use the broker without exposing the openwb branch

See also issue https://github.com/openWB/core/issues/1586