### PR TITLE
Fehlerbehandlung Option Sicherung vor Update

### DIFF
--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -641,11 +641,13 @@ class Command:
             pub_user_message(payload, connection_id,
                              ("Fehler beim Erstellen der Cloud-Sicherung."
                               f" {traceback.format_exc()}<br />Update wird abgebrochen.."), MessageType.WARNING)
+            time.sleep(1)
             pub_user_message(payload, connection_id,
                              ("Update abgebrochen! Bitte Fehlerstatus überprüfen!. " +
                               "Option Sicherung vor System Update kann unter Datenverwaltung deaktiviert werden."
                               ), MessageType.WARNING)
             Pub().pub("openWB/system/update_in_progress", False)
+            time.sleep(1)
         if SubData.system_data["system"].data["update_in_progress"]:
             parent_file = Path(__file__).resolve().parents[2]
             if "branch" in payload["data"] and "tag" in payload["data"]:

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -641,7 +641,7 @@ class Command:
             pub_user_message(payload, connection_id,
                              ("Fehler beim Erstellen der Cloud-Sicherung."
                               f" {traceback.format_exc()}<br />Update abgebrochen!"
-                              " Bitte Fehlerstatus überprüfen!. " +
+                              "Bitte Fehlerstatus überprüfen!. " +
                               "Option Sicherung vor System Update kann unter Datenverwaltung deaktiviert werden."),
                              MessageType.WARNING)
             Pub().pub("openWB/system/update_in_progress", False)

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -640,22 +640,28 @@ class Command:
         except Exception:
             pub_user_message(payload, connection_id,
                              ("Fehler beim Erstellen der Cloud-Sicherung."
-                              f" {traceback.format_exc()}<br />Fahre mit Update fort..."), MessageType.WARNING)
-        parent_file = Path(__file__).resolve().parents[2]
-        if "branch" in payload["data"] and "tag" in payload["data"]:
-            pub_user_message(
-                payload, connection_id,
-                f'Wechsel auf Zweig \'{payload["data"]["branch"]}\' Tag \'{payload["data"]["tag"]}\' gestartet.',
-                MessageType.SUCCESS)
-            subprocess.run([
-                str(parent_file / "runs" / "update_self.sh"),
-                str(payload["data"]["branch"]),
-                str(payload["data"]["tag"])])
-        else:
-            pub_user_message(payload, connection_id, "Update gestartet.", MessageType.INFO)
-            subprocess.run([
-                str(parent_file / "runs" / "update_self.sh"),
-                SubData.system_data["system"].data["current_branch"]])
+                              f" {traceback.format_exc()}<br />Update wird abgebrochen.."), MessageType.WARNING)
+            pub_user_message(payload, connection_id,
+                             ("Update abgebrochen! Bitte Fehlerstatus überprüfen!. " +
+                              "Option Sicherung vor System Update kann unter Datenverwaltung deaktiviert werden."
+                              ), MessageType.WARNING)
+            Pub().pub("openWB/system/update_in_progress", False)
+        if SubData.system_data["system"].data["update_in_progress"]:
+            parent_file = Path(__file__).resolve().parents[2]
+            if "branch" in payload["data"] and "tag" in payload["data"]:
+                pub_user_message(
+                    payload, connection_id,
+                    f'Wechsel auf Zweig \'{payload["data"]["branch"]}\' Tag \'{payload["data"]["tag"]}\' gestartet.',
+                    MessageType.SUCCESS)
+                subprocess.run([
+                    str(parent_file / "runs" / "update_self.sh"),
+                    str(payload["data"]["branch"]),
+                    str(payload["data"]["tag"])])
+            else:
+                pub_user_message(payload, connection_id, "Update gestartet.", MessageType.INFO)
+                subprocess.run([
+                    str(parent_file / "runs" / "update_self.sh"),
+                    SubData.system_data["system"].data["current_branch"]])
 
     def systemFetchVersions(self, connection_id: str, payload: dict) -> None:
         log.info("Fetch versions requested")

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -640,14 +640,12 @@ class Command:
         except Exception:
             pub_user_message(payload, connection_id,
                              ("Fehler beim Erstellen der Cloud-Sicherung."
-                              f" {traceback.format_exc()}<br />Update wird abgebrochen.."), MessageType.WARNING)
-            time.sleep(1)
-            pub_user_message(payload, connection_id,
-                             ("Update abgebrochen! Bitte Fehlerstatus überprüfen!. " +
-                              "Option Sicherung vor System Update kann unter Datenverwaltung deaktiviert werden."
-                              ), MessageType.WARNING)
+                              f" {traceback.format_exc()}<br />Update abgebrochen!"
+                              " Bitte Fehlerstatus überprüfen!. " +
+                              "Option Sicherung vor System Update kann unter Datenverwaltung deaktiviert werden."),
+                             MessageType.WARNING)
             Pub().pub("openWB/system/update_in_progress", False)
-            time.sleep(1)
+            return
         if SubData.system_data["system"].data["update_in_progress"]:
             parent_file = Path(__file__).resolve().parents[2]
             if "branch" in payload["data"] and "tag" in payload["data"]:

--- a/packages/modules/backup_clouds/nextcloud/backup_cloud.py
+++ b/packages/modules/backup_clouds/nextcloud/backup_cloud.py
@@ -27,7 +27,7 @@ def upload_backup(config: NextcloudBackupCloudConfiguration, backup_filename: st
         headers={'X-Requested-With': 'XMLHttpRequest', },
         data=backup_file,
         auth=(user, '' if config.password is None else config.password),
-        timeout=30
+        timeout=120
     )
 
 

--- a/packages/modules/backup_clouds/nextcloud/backup_cloud.py
+++ b/packages/modules/backup_clouds/nextcloud/backup_cloud.py
@@ -27,7 +27,7 @@ def upload_backup(config: NextcloudBackupCloudConfiguration, backup_filename: st
         headers={'X-Requested-With': 'XMLHttpRequest', },
         data=backup_file,
         auth=(user, '' if config.password is None else config.password),
-        timeout=120
+        timeout=30
     )
 
 


### PR DESCRIPTION
Geht die Sicherung schief, wird kein Update durchgeführt, wenn die Option Sicherung vor Update unter Datenverwaltung aktiviert ist