### PR TITLE
polestar soc:trap failing api in fetch_soc

### DIFF
--- a/packages/modules/vehicles/polestar/api.py
+++ b/packages/modules/vehicles/polestar/api.py
@@ -55,7 +55,6 @@ class PolestarApi:
 
         return result['data']['getBatteryData']
 
-
     def check_vin(self) -> None:
         # get Vehicle Data
         params = {

--- a/packages/modules/vehicles/polestar/api.py
+++ b/packages/modules/vehicles/polestar/api.py
@@ -92,7 +92,11 @@ class PolestarApi:
 def fetch_soc(user_id: str, password: str, vin: str, vehicle: int) -> CarState:
     api = PolestarApi(user_id, password, vin)
     bat_data = api.get_battery_data()
-    soc = bat_data['batteryChargeLevelPercentage']
-    est_range = bat_data['estimatedDistanceToEmptyKm']
+    # preset values will be returned if api fails
+    soc = -1
+    est_range = -1
+    if bat_data is not None:
+        soc = bat_data['batteryChargeLevelPercentage']
+        est_range = bat_data['estimatedDistanceToEmptyKm']
 
     return CarState(soc, est_range, time.strftime("%m/%d/%Y, %H:%M:%S"))

--- a/packages/modules/vehicles/polestar/api.py
+++ b/packages/modules/vehicles/polestar/api.py
@@ -74,7 +74,9 @@ class PolestarApi:
             # get list of cars and store the ones not matching our vin
             cars = result['data']['getConsumerCarsV2']
             if len(cars) == 0:
-                raise Exception("Es konnten keine Fahrzeuge im Account gefunden werden. Bitte in den Einstellungen prüfen, ob der Besitzer-Account des Polestars eingetragen ist.")
+                raise Exception("Es konnten keine Fahrzeuge im Account gefunden werden. Bitte in den Einstellungen " +
+                "prüfen, ob der Besitzer-Account des Polestars eingetragen ist.")
+
             for i in range(0, len(cars)):
                 if cars[i]['vin'] == self.vin:
                     pass

--- a/packages/modules/vehicles/polestar/api.py
+++ b/packages/modules/vehicles/polestar/api.py
@@ -18,8 +18,7 @@ class PolestarApi:
     def query_params(self, params: dict, url='https://pc-api.polestar.com/eu-north-1/mystar-v2/') -> dict or None:
         access_token = self.auth.get_auth_token()
         if access_token is None:
-            log.error("query_params:not yet authenticated")
-            return None
+            raise Exception("query_params error:could not get auth token")
 
         headers = {
             "Content-Type": "application/json",
@@ -42,7 +41,6 @@ class PolestarApi:
             error_message = result_data['errors'][0]['message']
             raise Exception("query_params error: %s", error_message)
 
-        log.debug(result_data)
         return result_data
 
     def get_battery_data(self) -> dict or None:
@@ -55,11 +53,8 @@ class PolestarApi:
 
         result = self.query_params(params)
 
-        if result is not None and result['data'] is not None and result['data']['getBatteryData'] is not None \
-                and result['data']['getBatteryData']['batteryChargeLevelPercentage'] is not None:
-            return result['data']['getBatteryData']
-        else:
-            return None
+        return result['data']['getBatteryData']
+
 
     def check_vin(self) -> None:
         # get Vehicle Data
@@ -89,11 +84,7 @@ class PolestarApi:
 def fetch_soc(user_id: str, password: str, vin: str, vehicle: int) -> CarState:
     api = PolestarApi(user_id, password, vin)
     bat_data = api.get_battery_data()
-    # preset values will be returned if api fails
-    soc = 0
-    est_range = 0
-    if bat_data is not None:
-        soc = bat_data['batteryChargeLevelPercentage']
-        est_range = bat_data['estimatedDistanceToEmptyKm']
+    soc = bat_data['batteryChargeLevelPercentage']
+    est_range = bat_data['estimatedDistanceToEmptyKm']
 
     return CarState(soc, est_range, time.strftime("%m/%d/%Y, %H:%M:%S"))

--- a/packages/modules/vehicles/polestar/api.py
+++ b/packages/modules/vehicles/polestar/api.py
@@ -75,7 +75,7 @@ class PolestarApi:
             cars = result['data']['getConsumerCarsV2']
             if len(cars) == 0:
                 raise Exception("Es konnten keine Fahrzeuge im Account gefunden werden. Bitte in den Einstellungen " +
-                "prüfen, ob der Besitzer-Account des Polestars eingetragen ist.")
+                                "prüfen, ob der Besitzer-Account des Polestars eingetragen ist.")
 
             for i in range(0, len(cars)):
                 if cars[i]['vin'] == self.vin:


### PR DESCRIPTION
Hallo,

mir ist aufgefallen, dass das Modul einen Fehler schmeisst, wenn die Authorisierung scheitert, z.B.

`2024-05-07 01:33:44,450 - {modules.vehicles.polestar.api:21} - {ERROR:fetch soc_ev0} - query_params:not yet authenticated
2024-05-07 01:33:44,461 - {modules.common.fault_state:49} - {ERROR:fetch soc_ev0} - Polestar2: FaultState FaultStateLevel.ERROR, FaultStr <class 'TypeError'> ("'NoneType'
 object is not subscriptable",), Traceback: 
Traceback (most recent call last):
  File "/var/www/html/openWB/packages/modules/common/configurable_vehicle.py", line 66, in update
    car_state = self._get_carstate_by_source(vehicle_update_data, source)
  File "/var/www/html/openWB/packages/modules/common/configurable_vehicle.py", line 109, in _get_carstate_by_source
    return self.__component_updater(vehicle_update_data)
  File "/var/www/html/openWB/packages/modules/vehicles/polestar/soc.py", line 20, in updater
    return api.fetch_soc(
  File "/var/www/html/openWB/packages/modules/vehicles/polestar/api.py", line 94, in fetch_soc
    soc = bat_data['batteryChargeLevelPercentage']
TypeError: 'NoneType' object is not subscriptable
`

Deshalb würde ich die Variablen soc und est_range vorbelegen.
Momentan habe ich -1 gesetzt aber vielleicht habt ihr für diesen Fall einen anderen Wert vorgesehen?

Gruß,
Philipp