### PR TITLE
use also surplus in mode scheduled charging submode instant charging

### DIFF
--- a/packages/control/algorithm/additional_current.py
+++ b/packages/control/algorithm/additional_current.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from control.algorithm import common
 from control.loadmanagement import LimitingValue, Loadmanagement
@@ -13,12 +12,14 @@ log = logging.getLogger(__name__)
 
 
 class AdditionalCurrent:
+    CONSIDERED_CHARGE_MODES = common.CHARGEMODES[0:8]
+
     def __init__(self) -> None:
         pass
 
-    def set_additional_current(self, mode_range: List[int]) -> None:
-        common.reset_current_by_chargemode(common.CHARGEMODES[0:8])
-        for mode_tuple, counter in common.mode_and_counter_generator(mode_range):
+    def set_additional_current(self) -> None:
+        common.reset_current_by_chargemode(self.CONSIDERED_CHARGE_MODES)
+        for mode_tuple, counter in common.mode_and_counter_generator(self.CONSIDERED_CHARGE_MODES):
             preferenced_chargepoints, preferenced_cps_without_set_current = get_preferenced_chargepoint_charging(
                 get_chargepoints_by_mode_and_counter(mode_tuple, f"counter{counter.num}"))
             if preferenced_chargepoints:

--- a/packages/control/algorithm/algorithm.py
+++ b/packages/control/algorithm/algorithm.py
@@ -31,14 +31,14 @@ class Algorithm:
             self.min_current.set_min_current()
             log.info("**Sollstrom setzen**")
             common.reset_current_to_target_current()
-            self.additional_current.set_additional_current([0, 8])
+            self.additional_current.set_additional_current()
             counter.limit_raw_power_left_to_surplus(self.evu_counter.calc_raw_surplus())
             self.surplus_controlled.check_switch_on()
             if self.evu_counter.data.set.surplus_power_left > 0:
                 log.info("**PV-geführten Strom setzen**")
                 common.reset_current_to_target_current()
                 self.surplus_controlled.set_required_current_to_max()
-                self.surplus_controlled.set_surplus_current([6, 12])
+                self.surplus_controlled.set_surplus_current()
             else:
                 log.info("**Keine Leistung für PV-geführtes Laden übrig.**")
             self.no_current.set_no_current()

--- a/packages/control/algorithm/common.py
+++ b/packages/control/algorithm/common.py
@@ -47,13 +47,8 @@ def reset_current_by_chargemode(mode_tuple: Tuple[Optional[str], str, bool]) -> 
             cp.data.set.current = None
 
 
-def mode_range_list_factory() -> List[int]:
-    return [0, -1]
-
-
-def mode_and_counter_generator(
-        mode_range: List[int] = mode_range_list_factory()) -> Iterable[Tuple[Tuple[Optional[str], str, bool], Counter]]:
-    for mode_tuple in CHARGEMODES[mode_range[0]: mode_range[1]]:
+def mode_and_counter_generator(chargemodes: List) -> Iterable[Tuple[Tuple[Optional[str], str, bool], Counter]]:
+    for mode_tuple in chargemodes:
         levels = data.data.counter_all_data.get_list_of_elements_per_level()
         for level in reversed(levels):
             for element in level:

--- a/packages/control/algorithm/filter_chargepoints.py
+++ b/packages/control/algorithm/filter_chargepoints.py
@@ -3,7 +3,6 @@ import logging
 from typing import List, Optional, Tuple
 
 from control import data
-from control.algorithm import common
 from control.chargepoint.chargepoint import Chargepoint
 
 log = logging.getLogger(__name__)
@@ -53,19 +52,6 @@ def get_preferenced_chargepoint_charging(
             preferenced_chargepoints_with_set_current.append(cp)
     return preferenced_chargepoints_with_set_current, preferenced_chargepoints_without_set_current
 
-
-def get_chargepoints_pv_charging() -> List[Chargepoint]:
-    chargepoints: List[Chargepoint] = []
-    for mode in common.CHARGEMODES[8: 12]:
-        chargepoints.extend(get_chargepoints_by_mode(mode))
-    return chargepoints
-
-
-def get_chargepoints_surplus_controlled() -> List[Chargepoint]:
-    chargepoints: List[Chargepoint] = []
-    for mode in common.CHARGEMODES[6: 12]:
-        chargepoints.extend(get_chargepoints_by_mode(mode))
-    return chargepoints
 
 # tested
 

--- a/packages/control/algorithm/filter_chargepoints_test.py
+++ b/packages/control/algorithm/filter_chargepoints_test.py
@@ -163,28 +163,3 @@ def test_get_chargepoints_by_mode_and_counter(chargepoints_of_counter: List[str]
 
     # assertion
     assert valid_chargepoints == expected_chargepoints
-
-
-@pytest.mark.parametrize(
-    "submode_1, submode_2, expected_chargepoints",
-    [
-        pytest.param(Chargemode.PV_CHARGING, Chargemode.PV_CHARGING, [mock_cp2, mock_cp1]),
-        pytest.param(Chargemode.SCHEDULED_CHARGING, Chargemode.PV_CHARGING, [mock_cp2]),
-        pytest.param(Chargemode.SCHEDULED_CHARGING, Chargemode.INSTANT_CHARGING, []),
-    ])
-def test_get_chargepoints_submode_pv_charging(submode_1: Chargemode,
-                                              submode_2: Chargemode,
-                                              expected_chargepoints: List[Chargepoint]):
-    # setup
-    def setup_cp(cp: Chargepoint, submode: str) -> Chargepoint:
-        cp.data.set.charging_ev = Ev(0)
-        cp.data.control_parameter.submode = submode
-        return cp
-    data.data.cp_data = {"cp1": setup_cp(mock_cp1, submode_1),
-                         "cp2": setup_cp(mock_cp2, submode_2)}
-
-    # evaluation
-    chargepoints = filter_chargepoints.get_chargepoints_pv_charging()
-
-    # assertion
-    assert chargepoints == expected_chargepoints

--- a/packages/control/algorithm/min_current.py
+++ b/packages/control/algorithm/min_current.py
@@ -8,11 +8,13 @@ log = logging.getLogger(__name__)
 
 
 class MinCurrent:
+    CONSIDERED_CHARGE_MODES = common.CHARGEMODES[0:-1]
+
     def __init__(self) -> None:
         pass
 
     def set_min_current(self) -> None:
-        for mode_tuple, counter in common.mode_and_counter_generator():
+        for mode_tuple, counter in common.mode_and_counter_generator(self.CONSIDERED_CHARGE_MODES):
             preferenced_chargepoints = get_chargepoints_by_mode_and_counter(mode_tuple, f"counter{counter.num}")
             if preferenced_chargepoints:
                 log.info(f"Mode-Tuple {mode_tuple[0]} - {mode_tuple[1]} - {mode_tuple[2]}, Zähler {counter.num}")

--- a/packages/control/algorithm/surplus_controlled.py
+++ b/packages/control/algorithm/surplus_controlled.py
@@ -6,22 +6,25 @@ from control.algorithm import common
 from control.loadmanagement import LimitingValue, Loadmanagement
 from control.counter import Counter
 from control.chargepoint.chargepoint import Chargepoint
-from control.algorithm.filter_chargepoints import (get_chargepoints_by_mode_and_counter,
-                                                   get_preferenced_chargepoint_charging, get_chargepoints_pv_charging,
-                                                   get_chargepoints_surplus_controlled)
+from control.algorithm.filter_chargepoints import (get_chargepoints_by_mode, get_chargepoints_by_mode_and_counter,
+                                                   get_preferenced_chargepoint_charging)
 from control.chargepoint.chargepoint_state import ChargepointState, CHARGING_STATES
 from modules.common.utils.component_parser import get_component_name_by_id
 
 log = logging.getLogger(__name__)
 
+CONSIDERED_CHARGE_MODES = common.CHARGEMODES[0:2] + common.CHARGEMODES[6:12]
+CONSIDERED_CHARGE_MODES_PV = common.CHARGEMODES[8:12]
+
 
 class SurplusControlled:
+
     def __init__(self) -> None:
         pass
 
-    def set_surplus_current(self, mode_range) -> None:
-        common.reset_current_by_chargemode(common.CHARGEMODES[6:12])
-        for mode_tuple, counter in common.mode_and_counter_generator(mode_range):
+    def set_surplus_current(self) -> None:
+        common.reset_current_by_chargemode(CONSIDERED_CHARGE_MODES)
+        for mode_tuple, counter in common.mode_and_counter_generator(CONSIDERED_CHARGE_MODES):
             preferenced_chargepoints, preferenced_cps_without_set_current = get_preferenced_chargepoint_charging(
                 get_chargepoints_by_mode_and_counter(mode_tuple, f"counter{counter.num}"))
             cp_with_feed_in, cp_without_feed_in = self.filter_by_feed_in_limit(preferenced_chargepoints)
@@ -168,3 +171,17 @@ class SurplusControlled:
 
             control_parameter.required_currents = [max_current if required_currents[i] != 0 else 0 for i in range(3)]
             control_parameter.required_current = max_current
+
+
+def get_chargepoints_pv_charging() -> List[Chargepoint]:
+    chargepoints: List[Chargepoint] = []
+    for mode in CONSIDERED_CHARGE_MODES_PV:
+        chargepoints.extend(get_chargepoints_by_mode(mode))
+    return chargepoints
+
+
+def get_chargepoints_surplus_controlled() -> List[Chargepoint]:
+    chargepoints: List[Chargepoint] = []
+    for mode in CONSIDERED_CHARGE_MODES:
+        chargepoints.extend(get_chargepoints_by_mode(mode))
+    return chargepoints

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -767,7 +767,8 @@ class ChargeTemplate:
                                       "Es wird bis max. 20 Minuten nach dem angegebenen Zieltermin geladen.")
     SCHEDULED_CHARGING_LIMITED_BY_SOC = 'einen SoC von {}%'
     SCHEDULED_CHARGING_LIMITED_BY_AMOUNT = '{}kWh geladene Energie'
-    SCHEDULED_CHARGING_IN_TIME = 'Zielladen mit {}A, um {}  um {} zu erreichen.'
+    SCHEDULED_CHARGING_IN_TIME = ('Zielladen mit mindestens {}A, um {} um {} zu erreichen. Falls vorhanden wird '
+                                  'zusätzlich EVU-Überschuss geladen.')
     SCHEDULED_CHARGING_CHEAP_HOUR = "Zielladen, da ein günstiger Zeitpunkt zum preisbasierten Laden ist."
     SCHEDULED_CHARGING_EXPENSIVE_HOUR = ("Zielladen ausstehend, da jetzt kein günstiger Zeitpunkt zum preisbasierten "
                                          "Laden ist. Falls vorhanden, wird mit Überschuss geladen.")


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?t=8638

Überschuss beim Zielladen auch nutzen, wenn mit der berechneten Stromstärke geladen wird, um das Ziel zu erreichen.
Wird mit Überschuss geladen, reduziert sich die berechnete Stromstärke kontinuierlich, da schneller geladen wird. Es tritt dadurch kein Schwingen auf, sondern der Ziel-SoC wird früher erreicht.