### PR TITLE
fix Errorhandling Backup vor Update

### DIFF
--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -643,7 +643,7 @@ class Command:
                                   "Bitte Fehlerstatus überprüfen!. " +
                                   "Option Sicherung vor System Update kann unter Datenverwaltung deaktiviert werden."),
                                  MessageType.ERROR)
-                log.exception("Fehler beim Erstellen der Cloud-Sicherung: ", Exception)
+                log.exception("Fehler beim Erstellen der Cloud-Sicherung: ")
                 Pub().pub("openWB/system/update_in_progress", False)
                 return
         parent_file = Path(__file__).resolve().parents[2]
@@ -772,7 +772,7 @@ class ErrorHandlingContext:
         if isinstance(exception, Exception):
             pub_user_message(self.payload, self.connection_id,
                              f'Es ist ein interner Fehler aufgetreten: {exception}', MessageType.ERROR)
-            log.debug({traceback.format_exc()})
+            log.error({traceback.format_exc()})
             return True
         else:
             return False

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -639,11 +639,11 @@ class Command:
                 self.createCloudBackup(connection_id, {})
             except Exception:
                 pub_user_message(payload, connection_id,
-                                 ("Fehler beim Erstellen der Cloud-Sicherung."
-                                  f" {traceback.format_exc()}<br />Update abgebrochen!"
+                                 ("Fehler beim Erstellen der Cloud-Sicherung. Update abgebrochen!"
                                   "Bitte Fehlerstatus überprüfen!. " +
                                   "Option Sicherung vor System Update kann unter Datenverwaltung deaktiviert werden."),
-                                 MessageType.WARNING)
+                                 MessageType.ERROR)
+                log.exception("Fehler beim Erstellen der Cloud-Sicherung: ", Exception)
                 Pub().pub("openWB/system/update_in_progress", False)
                 return
         parent_file = Path(__file__).resolve().parents[2]
@@ -771,7 +771,8 @@ class ErrorHandlingContext:
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
         if isinstance(exception, Exception):
             pub_user_message(self.payload, self.connection_id,
-                             f'Es ist ein interner Fehler aufgetreten: {traceback.format_exc()}', MessageType.ERROR)
+                             f'Es ist ein interner Fehler aufgetreten: {exception}', MessageType.ERROR)
+            log.debug({traceback.format_exc()})
             return True
         else:
             return False

--- a/packages/modules/backup_clouds/nextcloud/backup_cloud.py
+++ b/packages/modules/backup_clouds/nextcloud/backup_cloud.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 def upload_backup(config: NextcloudBackupCloudConfiguration, backup_filename: str, backup_file: bytes) -> None:
     if config.user is None:
-        url_match = re.fullmatch(r'(http[s]?):\/\/([^/]+)\/(?:index.php\/)?s\/(.+)', config.ip_address)
+        url_match = re.fullmatch(r'(http[s]?):\/\/([\S^/]+)\/(?:index.php\/)?s\/(.+)', config.ip_address)
         if not url_match:
             raise ValueError(f"URL '{config.ip_address}' hat nicht die erwartete Form "
                              "'https://server/index.php/s/user_token' oder 'https://server/s/user_token'")


### PR DESCRIPTION
-->Leider hatte ich die Änderungen in meinem Master branch und beim Aktualisieren+rebase, hab ich diese Änderungen (Konflikt merge) gelöscht und den dazugehörigen PR automatisch geschlossen. Dadurch sind beim pushen hier die Änderungen weg gelöscht worden. Beim nächsten Mal nur noch branches und nicht aus dem Master direkt.<---

***Daher hier nochmal die Änderungen. Sorry***

Im Frontend werden keine Tracebacks mehr angezeigt
Diese werden jetzt ins log geschrieben

Bei der Option Backup vor Update wurde zusätzlich ein raise ValueError eingefügt, da durch den Try Except Block die ursprüngliche Exception (z.B.: ValueError aus backup_cloud.py l. 17) sonst nicht übergeben wird
-> command.py l. 772 Exception ist sonst None
Jetzt wird diese Exception zusammen mit vorherigen Exceptions z.B. ValueError aus backup_cloud.py l.17 im Log mit Traceback ausgegeben, wobei im Frontend lediglich der ValueError angezeigt wird

Zusätzlich: Korrektur zweier Rechtschreibfehler