### PR TITLE
Add service battery SoC to CarState

### DIFF
--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -425,6 +425,8 @@ class SetData:
                 self._validate_value(msg, float)
             elif "/get/soc" in msg.topic:
                 self._validate_value(msg, float, [(0, 100)])
+            elif "/get/service_soc" in msg.topic:
+                self._validate_value(msg, float, [(0, 100)])
             elif "/get/range" in msg.topic:
                 self._validate_value(msg, float, [(0, 1000)])
             elif "/get/force_soc_update" in msg.topic:

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -135,6 +135,7 @@ class CarState:
             soc: actual state of charge in percent
             range: actual range in km
             soc_timestamp: timestamp of last request as unix timestamp
+            service_soc: service battery (12V battery) state of charge in percent
         """
         self.soc = soc
         self.range = range

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -130,7 +130,7 @@ class InverterState:
 
 @auto_str
 class CarState:
-    def __init__(self, soc: float, range: Optional[float] = None, soc_timestamp: float = 0):
+    def __init__(self, soc: float, range: Optional[float] = None, soc_timestamp: float = 0, service_soc: Optional[float] = None):
         """Args:
             soc: actual state of charge in percent
             range: actual range in km
@@ -139,6 +139,7 @@ class CarState:
         self.soc = soc
         self.range = range
         self.soc_timestamp = soc_timestamp
+        self.service_soc = service_soc
 
 
 @auto_str

--- a/packages/modules/common/store/_car.py
+++ b/packages/modules/common/store/_car.py
@@ -27,6 +27,8 @@ class CarValueStoreBroker(ValueStore[CarState]):
             pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/soc", self.state.soc, 2)
             if self.state.range:
                 pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/range", self.state.range, 2)
+            if self.state.service_soc:
+                pub_to_broker("openWB/set/vehicle/"+str(self.vehicle_id)+"/get/service_soc", self.state.service_soc, 2)
         except Exception as e:
             raise FaultState.from_exception(e)
 

--- a/packages/modules/vehicles/kia/api.py
+++ b/packages/modules/vehicles/kia/api.py
@@ -808,6 +808,8 @@ def getStatusFull(vehicle_id: str, control_token: str,
         response = getHTTP(url=url, headers=headers)
         response_dict = json.loads(response)
 
+        service_soc = int(response_dict['resMsg']['state']['Vehicle']['Electronics']['Battery']['Level'])
+
         soc = int(response_dict['resMsg']['state']['Vehicle']['Green']
                                ['BatteryManagement']['BatteryRemain']['Ratio'])
         range = float(response_dict['resMsg']['state']['Vehicle']['Drivetrain']
@@ -818,7 +820,7 @@ def getStatusFull(vehicle_id: str, control_token: str,
                       response)
         raise
 
-    return CarState(soc, range)
+    return CarState(soc, range, service_soc=service_soc)
 
 # ---------- main function ----------
 


### PR DESCRIPTION
This PR adds another property to the CarState which stores the car's service battery state of charge, while this is not necessarily needed for any computations it is helpful data. Multiple cars like the Ioniq 5 have a known issue where the 12V battery discharges even when plugged in. This very small addition gives users the ability to subscribe to the `openWB/vehicle/vehicle_id/get/service_soc`  topic which allows them to regularly check for and prevent unexpected 12v battery discharges.