### PR TITLE
Hausverbrauch bei Hausverbrauchszählern

### DIFF
--- a/packages/conftest.py
+++ b/packages/conftest.py
@@ -134,3 +134,43 @@ def data_() -> None:
             imported=14000, exported=18000),
             config=Mock(spec=CounterConfig, max_currents=[32]*3),
             set=Mock(spec=CounterSet, raw_currents_left=[31]*3)))})
+
+
+def hierarchy_hc_counter() -> CounterAll:
+    # counter0
+    #        |
+    #        - counter6
+    #                  |
+    #                   - cp3
+    #        - inverter1
+    #        - bat2
+    c = CounterAll()
+    c.data.get.hierarchy = [{"id": 0, "type": "counter",
+                             "children": [
+                                 {"id": 6, "type": "counter",
+                                  "children": [
+                                      {"id": 3, "type": "cp", "children": []}]},
+                                 {"id": 1, "type": "inverter", "children": []},
+                                 {"id": 2, "type": "bat", "children": []}]}]
+    return c
+
+
+@pytest.fixture()
+def data_hc_counter_() -> None:
+    data.data_init(Mock())
+    data.data.cp_data = {
+        "cp3": Mock(spec=Chargepoint, data=Mock(spec=ChargepointData,
+                                                config=Mock(spec=Config, phase_1=1),
+                                                get=Mock(spec=Get, currents=[30, 0, 0], power=6900,
+                                                         daily_imported=10000, daily_exported=0, imported=56000),
+                                                set=Mock(spec=Set, loadmanagement_available=True)))}
+    data.data.pv_data.update({"pv1": Mock(spec=Pv, data=Mock(
+        spec=PvData, get=Mock(spec=PvGet, power=-10000, daily_exported=6000, exported=27000, currents=None)))})
+    data.data.counter_data.update({
+        "counter0": Mock(spec=Counter, data=Mock(spec=CounterData, get=Mock(
+            spec=CounterGet, currents=[40]*3, power=-2000, daily_imported=45000, daily_exported=3000))),
+        "counter6": Mock(spec=Counter, data=Mock(spec=CounterData, get=Mock(
+            spec=CounterGet, currents=[25, 10, 25], power=8000, daily_imported=20000, daily_exported=0,
+            imported=14000, exported=18000),
+            config=Mock(spec=CounterConfig, max_currents=[32]*3),
+            set=Mock(spec=CounterSet, raw_currents_left=[31]*3)))})

--- a/packages/helpermodules/measurement_logging/write_log.py
+++ b/packages/helpermodules/measurement_logging/write_log.py
@@ -209,13 +209,14 @@ def create_entry(log_type: LogType, sh_log_data: LegacySmartHomeLogData, previou
             log.exception("Fehler im Werte-Logging-Modul für EV "+str(ev))
 
     counter_dict = {}
-    for counter in data.data.counter_data:
+    for counter in data.data.counter_data.values():
         try:
-            if "counter" in counter and counter != data.data.counter_all_data.data.get.home_consumption_source:
+            if ("counter" in counter and
+                    counter.num != data.data.counter_all_data.data.config.home_consumption_source_id):
                 counter_dict.update(
-                    {counter: {
-                        "imported": data.data.counter_data[counter].data.get.imported,
-                        "exported": data.data.counter_data[counter].data.get.exported,
+                    {f"counter{counter.num}": {
+                        "imported": counter.data.get.imported,
+                        "exported": counter.data.get.exported,
                         "grid": True if data.data.counter_all_data.get_evu_counter_str() == counter else False}})
         except Exception:
             log.exception("Fehler im Werte-Logging-Modul für Zähler "+str(counter))

--- a/packages/helpermodules/measurement_logging/write_log.py
+++ b/packages/helpermodules/measurement_logging/write_log.py
@@ -211,7 +211,7 @@ def create_entry(log_type: LogType, sh_log_data: LegacySmartHomeLogData, previou
     counter_dict = {}
     for counter in data.data.counter_data:
         try:
-            if "counter" in counter:
+            if "counter" in counter and counter != data.data.counter_all_data.data.get.home_consumption_source:
                 counter_dict.update(
                     {counter: {
                         "imported": data.data.counter_data[counter].data.get.imported,

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -873,12 +873,12 @@ class SetData:
                 self._validate_value(msg, float, [(0, float("inf"))])
             elif "openWB/set/counter/get/hierarchy" in msg.topic:
                 self._validate_value(msg, None)
+            elif "openWB/set/counter/config/home_consumption_source_id" in msg.topic:
+                self._validate_value(msg, int)
             elif "openWB/set/counter/set/simulation" in msg.topic:
                 self._validate_value(msg, "json")
             elif "/set/consumption_left" in msg.topic:
                 self._validate_value(msg, float)
-            elif "/config/selected" in msg.topic:
-                self._validate_value(msg, str)
             elif "/module" in msg.topic:
                 self._validate_value(msg, "json")
             elif "/config/max_currents" in msg.topic:

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -130,6 +130,7 @@ class UpdateConfig:
         "^openWB/command/todo$",
 
         "^openWB/counter/config/reserve_for_not_charging$",
+        "^openWB/counter/config/home_consumption_source_id$",
         "^openWB/counter/get/hierarchy$",
         "^openWB/counter/set/disengageable_smarthome_power$",
         "^openWB/counter/set/imported_home_consumption$",
@@ -408,6 +409,7 @@ class UpdateConfig:
         ("openWB/chargepoint/template/0", get_chargepoint_template_default()),
         ("openWB/counter/get/hierarchy", []),
         ("openWB/counter/config/reserve_for_not_charging", counter_all.Config().reserve_for_not_charging),
+        ("openWB/counter/config/home_consumption_source_id", counter_all.Config().home_consumption_source_id),
         ("openWB/vehicle/0/name", "Standard-Fahrzeug"),
         ("openWB/vehicle/0/charge_template", ev.Ev(0).charge_template.ct_num),
         ("openWB/vehicle/0/soc_module/config", NO_MODULE),


### PR DESCRIPTION
Bei Zählern, die am EVU-Punkt installiert sind, wird der Hausverbrauch rechnerisch ermittelt. Mit diesem PR gibt es für Hausverbrauchszähler nun die Möglichkeit zu sagen, "Dieser Zähler zählt den Hausverbrauch".

UI https://github.com/openWB/openwb-ui-settings/pull/475