### PR TITLE
Rabot dynamischer Tarif

### DIFF
--- a/packages/modules/electricity_tariffs/rabot/config.py
+++ b/packages/modules/electricity_tariffs/rabot/config.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+
+class RabotTariffConfiguration:
+    def __init__(self, token: Optional[str] = None):
+        self.token = token
+
+
+class RabotTariff:
+    def __init__(self,
+                 name: str = "Rabot",
+                 type: str = "rabot",
+                 configuration: RabotTariffConfiguration = None) -> None:
+        self.name = name
+        self.type = type
+        self.configuration = configuration or RabotTariffConfiguration()

--- a/packages/modules/electricity_tariffs/rabot/config.py
+++ b/packages/modules/electricity_tariffs/rabot/config.py
@@ -1,9 +1,24 @@
 from typing import Optional
 
 
+class RabotToken():
+    def __init__(self,
+                 access_token: Optional[str] = None,
+                 expires_in: Optional[str] = None,
+                 created_at: Optional[str] = None) -> None:
+        self.access_token = access_token  # don't show in UI
+        self.expires_in = expires_in  # don't show in UI
+        self.created_at = created_at  # don't show in UI
+
+
 class RabotTariffConfiguration:
-    def __init__(self, token: Optional[str] = None):
-        self.token = token
+    def __init__(self,
+                 client_id: Optional[str] = None,
+                 client_secret: Optional[str] = None,
+                 token: RabotToken = None):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.token = token or RabotToken()
 
 
 class RabotTariff:

--- a/packages/modules/electricity_tariffs/rabot/tariff.py
+++ b/packages/modules/electricity_tariffs/rabot/tariff.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from datetime import datetime, timezone
+from typing import Dict
+from helpermodules import timecheck
+
+from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_state import TariffState
+from modules.common.configurable_tariff import ConfigurableElectricityTariff
+from modules.common import req
+from modules.electricity_tariffs.rabot.config import RabotTariffConfiguration
+from modules.electricity_tariffs.rabot.config import RabotTariff
+
+
+# Demo-Token: 5K4MVS-OjfWhK_4yrjOlFe1F6kJXPVf7eQYggo8ebAE
+
+
+def _get_sorted_price_data(response_json: Dict, key: str):
+    return sorted(response_json['data']['viewer']['home']['currentSubscription']
+                  ['priceInfo'][key], key=lambda k: (k['startsAt'], k['total']))
+
+
+def fetch_prices(config: RabotTariffConfiguration) -> Dict[int, float]:
+    headers = {'Authorization': 'Bearer ' + config.token, 'Content-Type': 'application/json'}
+    data = '{ XXX" }'
+    # raw_prices = req.get_http_session().get(url).json()
+    response = req.get_http_session().post('XXX', headers=headers, data=data, timeout=6)
+    response_json = response.json()
+    if response_json.get("errors") is None:
+        today_prices = _get_sorted_price_data(response_json, 'today')
+        tomorrow_prices = _get_sorted_price_data(response_json, 'tomorrow')
+        sorted_marketprices = today_prices + tomorrow_prices
+        prices: Dict[int, float] = {}
+        i = 0
+        for price_data in sorted_marketprices:
+            # konvertiere Time-String (Format 2021-02-06T00:00:00+01:00) ()':' nicht von strptime unterstützt)
+            time_str = ''.join(price_data['startsAt'].rsplit(':', 1))
+            startzeit_localized = datetime.strptime(time_str, '%Y-%m-%dT%H:%M:%S.%f%z')
+            starttime_utc = int(startzeit_localized.astimezone(timezone.utc).timestamp())
+            if timecheck.create_unix_timestamp_current_full_hour() <= starttime_utc:
+                if i < 24:
+                    prices.update({starttime_utc: price_data['total'] / 1000})
+                    i += 1
+                else:
+                    break
+    else:
+        error = response_json['errors'][0]['message']
+        raise Exception(error)
+    return prices
+
+
+def create_electricity_tariff(config: RabotTariff):
+    def updater():
+        return TariffState(prices=fetch_prices(config.configuration))
+    return ConfigurableElectricityTariff(config=config, component_updater=updater)
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=RabotTariff)

--- a/packages/modules/electricity_tariffs/rabot/tariff.py
+++ b/packages/modules/electricity_tariffs/rabot/tariff.py
@@ -63,7 +63,7 @@ def fetch(config: RabotTariff) -> None:
     raw_prices = get_raw_prices()
     prices: Dict[int, float] = {}
     for data in raw_prices:
-        formatted_price = data["priceInCentPerKwh"]/1000000  # €/MWh -> €/Wh
+        formatted_price = data["priceInCentPerKwh"]/100000  # Cent/kWh -> €/Wh
         timestamp = datetime.datetime.fromisoformat(data["timestamp"]).astimezone(
             pytz.timezone("Europe/Berlin")).timestamp()
         prices.update({int(timestamp): formatted_price})


### PR DESCRIPTION
Der dynamische Tarif von Rabot wurde bei Anbietern hinzugefügt (fast gleich wie bei Voltego) und mit den von Rabot zur Verfügung gestellten credentials client_id und client_secret erfolgreich getestet