### PR TITLE
Anpassung Ziel-SoC/Limit-SoC

### DIFF
--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -755,7 +755,10 @@ class ChargeTemplate:
         duration = missing_amount/(plan.current * phases*230) * 3600
         return duration, missing_amount
 
-    SCHEDULED_CHARGING_REACHED_LIMIT_SOC = "Kein Zielladen, da der Ziel-Soc und das SoC-Limit bereits erreicht wurden."
+    SCHEDULED_REACHED_LIMIT_SOC = ("Kein Zielladen, da noch Zeit bis zum Zieltermin ist. "
+                                   "Kein Zielladen mit Überschuss, da das SoC-Limit erreicht wurde.")
+    SCHEDULED_CHARGING_REACHED_LIMIT_SOC = ("Kein Zielladen, da das Limit für Fahrzeug Laden mit Überschuss (SoC-Limit)"
+                                            " sowie der Fahrzeug-SoC (Ziel-SoC) bereits erreicht wurde.")
     SCHEDULED_CHARGING_REACHED_AMOUNT = "Kein Zielladen, da die Energiemenge bereits erreicht wurde."
     SCHEDULED_CHARGING_REACHED_SCHEDULED_SOC = ("Falls vorhanden wird mit EVU-Überschuss geladen, da der Ziel-Soc "
                                                 "für Zielladen bereits erreicht wurde.")
@@ -780,22 +783,22 @@ class ChargeTemplate:
                                         min_current: int,
                                         soc_request_intervall_offset: int) -> Tuple[float, str, str, int]:
         current = 0
-        mode = "stop"
+        submode = "stop"
         if plan_data is None:
             if len(self.data.chargemode.scheduled_charging.plans) == 0:
-                return current, mode, self.SCHEDULED_CHARGING_NO_PLANS_CONFIGURED, control_parameter_phases
+                return current, submode, self.SCHEDULED_CHARGING_NO_PLANS_CONFIGURED, control_parameter_phases
             else:
-                return current, mode, self.SCHEDULED_CHARGING_NO_DATE_PENDING, control_parameter_phases
+                return current, submode, self.SCHEDULED_CHARGING_NO_DATE_PENDING, control_parameter_phases
         current_plan = self.data.chargemode.scheduled_charging.plans[plan_data.num]
         limit = current_plan.limit
         phases = plan_data.phases
         log.debug("Verwendeter Plan: "+str(current_plan.name))
-        if limit.selected == "soc" and soc >= limit.soc_limit:
+        if limit.selected == "soc" and soc >= limit.soc_limit and soc >= limit.soc_scheduled:
             message = self.SCHEDULED_CHARGING_REACHED_LIMIT_SOC
         elif limit.selected == "soc" and limit.soc_scheduled <= soc < limit.soc_limit:
             message = self.SCHEDULED_CHARGING_REACHED_SCHEDULED_SOC
             current = min_current
-            mode = "pv_charging"
+            submode = "pv_charging"
             # bei Überschuss-Laden mit der Phasenzahl aus den control_parameter laden,
             # um die Umschaltung zu berücksichtigen.
             phases = control_parameter_phases
@@ -810,7 +813,7 @@ class ChargeTemplate:
             message = self.SCHEDULED_CHARGING_IN_TIME.format(
                 plan_data.available_current, limit_string, current_plan.time)
             current = plan_data.available_current
-            mode = "instant_charging"
+            submode = "instant_charging"
         # weniger als die berechnete Zeit verfügbar
         # Ladestart wurde um maximal 20 Min verpasst.
         elif plan_data.remaining_time <= 0 - soc_request_intervall_offset:
@@ -820,7 +823,7 @@ class ChargeTemplate:
                 current = min(plan_data.missing_amount/((plan_data.duration + plan_data.remaining_time) /
                               3600)/(phases*230), plan_data.max_current)
             message = self.SCHEDULED_CHARGING_MAX_CURRENT.format(round(current, 2))
-            mode = "instant_charging"
+            submode = "instant_charging"
         else:
             # Wenn Elektronische Tarife aktiv sind, prüfen, ob jetzt ein günstiger Zeitpunkt zum Laden
             # ist.
@@ -830,18 +833,24 @@ class ChargeTemplate:
                 if timecheck.is_list_valid(hourlist):
                     message = self.SCHEDULED_CHARGING_CHEAP_HOUR
                     current = plan_data.available_current
-                    mode = "instant_charging"
-                else:
+                    submode = "instant_charging"
+                if soc <= limit.soc_limit:
                     message = self.SCHEDULED_CHARGING_EXPENSIVE_HOUR
                     current = min_current
-                    mode = "pv_charging"
+                    submode = "pv_charging"
                     phases = control_parameter_phases
+                else:
+                    message = self.SCHEDULED_REACHED_LIMIT_SOC
             else:
-                message = self.SCHEDULED_CHARGING_USE_PV
-                current = min_current
-                mode = "pv_charging"
-                phases = control_parameter_phases
-        return current, mode, message, phases
+                # Wenn SoC-Limit erreicht wurde, soll nicht mehr mit Überschuss geladen werden
+                if soc >= limit.soc_limit:
+                    message = self.SCHEDULED_REACHED_LIMIT_SOC
+                else:
+                    message = self.SCHEDULED_CHARGING_USE_PV
+                    current = min_current
+                    submode = "pv_charging"
+                    phases = control_parameter_phases
+        return current, submode, message, phases
 
     def standby(self) -> Tuple[int, str, str]:
         return 0, "standby", "Keine Ladung, da der Lademodus Standby aktiv ist."

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -756,7 +756,8 @@ class ChargeTemplate:
         return duration, missing_amount
 
     SCHEDULED_REACHED_LIMIT_SOC = ("Kein Zielladen, da noch Zeit bis zum Zieltermin ist. "
-                                   "Kein Zielladen mit Überschuss, da das SoC-Limit für Überschuss-Laden erreicht wurde.")
+                                   "Kein Zielladen mit Überschuss, da das SoC-Limit für Überschuss-Laden " +
+                                   "erreicht wurde.")
     SCHEDULED_CHARGING_REACHED_LIMIT_SOC = ("Kein Zielladen, da das Limit für Fahrzeug Laden mit Überschuss (SoC-Limit)"
                                             " sowie der Fahrzeug-SoC (Ziel-SoC) bereits erreicht wurde.")
     SCHEDULED_CHARGING_REACHED_AMOUNT = "Kein Zielladen, da die Energiemenge bereits erreicht wurde."

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -834,7 +834,7 @@ class ChargeTemplate:
                     message = self.SCHEDULED_CHARGING_CHEAP_HOUR
                     current = plan_data.available_current
                     submode = "instant_charging"
-                if soc <= limit.soc_limit:
+                elif soc <= limit.soc_limit:
                     message = self.SCHEDULED_CHARGING_EXPENSIVE_HOUR
                     current = min_current
                     submode = "pv_charging"

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -756,7 +756,7 @@ class ChargeTemplate:
         return duration, missing_amount
 
     SCHEDULED_REACHED_LIMIT_SOC = ("Kein Zielladen, da noch Zeit bis zum Zieltermin ist. "
-                                   "Kein Zielladen mit Überschuss, da das SoC-Limit erreicht wurde.")
+                                   "Kein Zielladen mit Überschuss, da das SoC-Limit für Überschuss-Laden erreicht wurde.")
     SCHEDULED_CHARGING_REACHED_LIMIT_SOC = ("Kein Zielladen, da das Limit für Fahrzeug Laden mit Überschuss (SoC-Limit)"
                                             " sowie der Fahrzeug-SoC (Ziel-SoC) bereits erreicht wurde.")
     SCHEDULED_CHARGING_REACHED_AMOUNT = "Kein Zielladen, da die Energiemenge bereits erreicht wurde."


### PR DESCRIPTION
Stellt man im Lade-Profil der Fahrzeuge auf **Zielladen** ein und hinterlegt einen Plan mit Uhrzeit und stellt Ziel auf SoC können **Ziel-SoC** (Akkustand, der zum Zeitpunkt erreicht werden muss) und **SoC-Limit** (Akkustand, der zum Zeitpunkt mit PV-Überschuss erreicht werden kann) per Slider (5 - 100 %) eingestellt werden.

Ziel-SoC beschreibt hier den Akkustand zum Zielzeitpunkt (Sofortladen des Fahrzeuges) und SoC-Limit (Laden des Fahrzeuges mit PV-Überschuss) beschreibt das Laden mit PV-Überschuss, wenn PV-Überschuss vorhanden und noch genug Zeit für das Erreichen des Ladeziels vorhanden ist

Problem:
Wird der Ziel-SoC kleiner als das SoC-Limit gewählt, dann stoppt momentan der Ladevorgang beim Erreichen des SoC-Limits, obwohl der Ziel-SoC noch nicht erreicht wurde.

Lösung: Anpassung des Codes
Der Ladevorgang stoppt erst, wenn Ziel-SoC UND SoC-Limit erreicht wurde.
Wird der SoC-Limit erreicht, stoppen jegliche Ladevorgänge mit PV-Überschuss. Nur wenn sich der soc unterhalb des SoC-Limits befindet, ist eine PV-Überschuss Ladung möglich (auch bei preisbasiertem Laden).
Liegt der Zielzeitpunkt zu weit entfernt, wird immer in den Modus Sofortladen gewechselt, sodass der Ladevorgang rechtzeitig abgeschlossen wird und die Stromstärke entsprechend angepasst.
Preisbasiertes Laden hat trotzdem Priorität, falls es aktiviert wurde und Überschuss vorhanden ist. Werden günstige Stunden ermittelt und ist noch genügend Zeit vorhanden, dann startet der Ladevorgang im Modus Sofortladen, auch wenn PV-Überschuss vorhanden ist. 
Sind keine günstigen Stunden ermittelt worden und ist das SoC-Limit erreicht, dann findet auch trotz PV-Überschuss kein Laden mit Überschuss statt. 
Sind keine günstigen Stunden ermittelt worden und ist das SoC-Limit nicht erreicht, dann wird mit Überschuss geladen.

Allerdings wurde hier nicht überprüft, ob die Zeiten korrekt ermittelt wurden. Im MQTT Explorer werden die Zeiten zum Erreichen des Ladeziels anders ermittelt als im Betrieb. Der Mechanismus zum Ermitteln und Umschalten aber funktioniert. 
Es sieht so aus, dass wenn das Zielladen startet, der Strom aus PV-Anlage und Netz gleichermassen entnommen wird, falls PV-Überschuss vorhanden. Der Speicher entleert sich anteilig.

Wenn das Ziel-SoC noch nicht erreicht wurde, aber noch genug Zeit zum Erreichen vorhanden ist, wird der Fahrzeug-Akku nicht mit PV-Überschuss gefüllt wird, wenn das SoC-Limit bereits erreicht wurde.

Getestet mit MQTT-Explorer Stand 12. Juni 2024