### PR TITLE
fix update_conf datastore_46

### DIFF
--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -41,7 +41,7 @@ NO_MODULE = {"type": None, "configuration": {}}
 
 
 class UpdateConfig:
-    DATASTORE_VERSION = 47
+    DATASTORE_VERSION = 48
     valid_topic = [
         "^openWB/bat/config/configured$",
         "^openWB/bat/set/charging_power_left$",
@@ -1497,42 +1497,45 @@ class UpdateConfig:
         Pub().pub("openWB/system/datastore_version", 44)
 
     def upgrade_datastore_44(self) -> None:
-        corrupt_days = ["20240620", "20240619", "20240618"]
-        for topic, payload in self.all_received_topics.items():
-            if topic == "openWB/counter/get/hierarchy":
-                top_entry = decode_payload(payload)[0]
-                if top_entry["type"] != "counter":
-                    raise Exception("First item in hierarchy must be a counter")
-                evu_counter_str = f"counter{top_entry['id']}"
-        for corrupt_day in corrupt_days:
+        try:
+            corrupt_days = ["20240620", "20240619", "20240618"]
+            for topic, payload in self.all_received_topics.items():
+                if topic == "openWB/counter/get/hierarchy":
+                    top_entry = decode_payload(payload)[0]
+                    if top_entry["type"] != "counter":
+                        raise Exception("First item in hierarchy must be a counter")
+                    evu_counter_str = f"counter{top_entry['id']}"
+            for corrupt_day in corrupt_days:
+                try:
+                    filepath = f"{self.base_path}/data/daily_log/{corrupt_day}.json"
+                    with open(filepath, "r") as jsonFile:
+                        content = json.load(jsonFile)
+                    for entry in content["entries"]:
+                        for counter_entry in entry["counter"]:
+                            if evu_counter_str == counter_entry and entry["counter"][counter_entry]["grid"] is False:
+                                entry["counter"][counter_entry]["grid"] = True
+                                break
+                        else:
+                            log.debug("all grid: False-bug does not exist in this installation")
+                            return
+                    write_and_check(filepath, content)
+                except Exception:
+                    log.exception(f"Logdatei '{filepath}' konnte nicht konvertiert werden.")
             try:
-                filepath = f"{self.base_path}/data/daily_log/{corrupt_day}.json"
+                filepath = f"{self.base_path}/data/monthly_log/202406.json"
                 with open(filepath, "r") as jsonFile:
                     content = json.load(jsonFile)
                 for entry in content["entries"]:
-                    for counter_entry in entry["counter"]:
-                        if evu_counter_str == counter_entry and entry["counter"][counter_entry]["grid"] is False:
-                            entry["counter"][counter_entry]["grid"] = True
-                            break
-                    else:
-                        log.debug("all grid: False-bug does not exist in this installation")
-                        return
+                    if entry["date"] in corrupt_days:
+                        for counter_entry in entry["counter"]:
+                            if evu_counter_str == counter_entry:
+                                entry["counter"][counter_entry]["grid"] = True
+                                break
                 write_and_check(filepath, content)
             except Exception:
                 log.exception(f"Logdatei '{filepath}' konnte nicht konvertiert werden.")
-        try:
-            filepath = f"{self.base_path}/data/monthly_log/202406.json"
-            with open(filepath, "r") as jsonFile:
-                content = json.load(jsonFile)
-            for entry in content["entries"]:
-                if entry["date"] in corrupt_days:
-                    for counter_entry in entry["counter"]:
-                        if evu_counter_str == counter_entry:
-                            entry["counter"][counter_entry]["grid"] = True
-                            break
-            write_and_check(filepath, content)
         except Exception:
-            log.exception(f"Logdatei '{filepath}' konnte nicht konvertiert werden.")
+            log.exception("Fehler beim Konvertieren der Logdateien")
         self.__update_topic("openWB/system/datastore_version", 45)
 
     def upgrade_datastore_45(self) -> None:

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -1551,7 +1551,6 @@ class UpdateConfig:
                 payload = decode_payload(payload)
                 if "disable_after_unplug" in payload:
                     updated_payload = payload
-                    disable_after_unplug = updated_payload["disable_after_payload"]
                     payload.pop("disable_after_unplug")
                     return {topic: updated_payload}
             if re.search("openWB/chargepoint/template/[0-9]+$", topic) is not None:
@@ -1561,9 +1560,16 @@ class UpdateConfig:
                     updated_payload["rfid_enabling"] = {}
                     payload.pop("rfid_enabling")
                     return {topic: updated_payload}
-                if "disable_after_unplug" not in payload:
-                    updated_payload = payload
-                    updated_payload.update({"disable_after_unplug": disable_after_unplug})
-                    return {topic: updated_payload}
         self._loop_all_received_topics(upgrade)
         self.__update_topic("openWB/system/datastore_version", 47)
+
+    def upgrade_datastore_47(self) -> None:
+        def upgrade(topic: str, payload) -> Optional[dict]:
+            if re.search("openWB/chargepoint/template/[0-9]+$", topic) is not None:
+                payload = decode_payload(payload)
+                if "disable_after_unplug" not in payload:
+                    updated_payload = payload
+                    updated_payload.update({"disable_after_unplug": False})
+                    return {topic: updated_payload}
+        self._loop_all_received_topics(upgrade)
+        self.__update_topic("openWB/system/datastore_version", 48)


### PR DESCRIPTION
Aufteilung datastore_46 in 46 und 47, damit die Änderungen beim ersten update übernommen werden und keine zwei Durchläufe benötigen

Stand 26.Juni 2024, getestet mit MQTT Explorer