### PR TITLE
Hook uncaught exceptions

### DIFF
--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -16,6 +16,7 @@ from control.chargepoint import chargepoint
 from control.chargepoint.chargepoint_template import get_autolock_plan_default, get_chargepoint_template_default
 
 # ToDo: move to module commands if implemented
+from helpermodules.utils.run_command import run_command
 from modules.backup_clouds.onedrive.api import generateMSALAuthCode, retrieveMSALTokens
 
 from helpermodules.broker import InternalBrokerClient
@@ -537,8 +538,8 @@ class Command:
         pub_user_message(payload, connection_id, "Systembericht wird erstellt...", MessageType.INFO)
         parent_file = Path(__file__).resolve().parents[2]
         previous_log_level = SubData.system_data["system"].data["debug_level"]
-        subprocess.run([str(parent_file / "runs" / "send_debug.sh"),
-                        json.dumps(payload["data"]), parse_send_debug_data()])
+        run_command([str(parent_file / "runs" / "send_debug.sh"),
+                     json.dumps(payload["data"]), parse_send_debug_data()])
         Pub().pub("openWB/set/system/debug_level", previous_log_level)
         pub_user_message(payload, connection_id, "Systembericht wurde versandt.", MessageType.SUCCESS)
 
@@ -559,21 +560,17 @@ class Command:
 
     def initCloud(self, connection_id: str, payload: dict) -> None:
         parent_file = Path(__file__).resolve().parents[2]
-        try:
-            result = subprocess.check_output(
-                ["php", "-f", str(parent_file / "runs" / "cloudRegister.php"), json.dumps(payload["data"])]
-            )
-            # exit status = 0 is success, std_out contains json: {"username", "password"}
-            result_dict = json.loads(result)
-            connect_payload = {
-                "data": result_dict
-            }
-            connect_payload["data"]["partner"] = payload["data"]["partner"]
-            self.connectCloud(connection_id, connect_payload)
-            pub_user_message(payload, connection_id, "Verbindung zur Cloud wurde eingerichtet.", MessageType.SUCCESS)
-        except subprocess.CalledProcessError as error:
-            # exit status = 1 is failure, std_out contains error message
-            pub_user_message(payload, connection_id, error.output.decode("utf-8", MessageType.ERROR))
+        result = run_command(
+            ["php", "-f", str(parent_file / "runs" / "cloudRegister.php"), json.dumps(payload["data"])]
+        )
+        # exit status = 0 is success, std_out contains json: {"username", "password"}
+        result_dict = json.loads(result)
+        connect_payload = {
+            "data": result_dict
+        }
+        connect_payload["data"]["partner"] = payload["data"]["partner"]
+        self.connectCloud(connection_id, connect_payload)
+        pub_user_message(payload, connection_id, "Verbindung zur Cloud wurde eingerichtet.", MessageType.SUCCESS)
 
     def connectCloud(self, connection_id: str, payload: dict) -> None:
         cloud_config = bridge.get_cloud_config()
@@ -610,12 +607,12 @@ class Command:
     def systemReboot(self, connection_id: str, payload: dict) -> None:
         pub_user_message(payload, connection_id, "Neustart wird ausgeführt.", MessageType.INFO)
         parent_file = Path(__file__).resolve().parents[2]
-        subprocess.run([str(parent_file / "runs" / "reboot.sh")])
+        run_command([str(parent_file / "runs" / "reboot.sh")])
 
     def systemShutdown(self, connection_id: str, payload: dict) -> None:
         pub_user_message(payload, connection_id, "openWB wird heruntergefahren.", MessageType.INFO)
         parent_file = Path(__file__).resolve().parents[2]
-        subprocess.run([str(parent_file / "runs" / "shutdown.sh")])
+        run_command([str(parent_file / "runs" / "shutdown.sh")])
 
     def systemUpdate(self, connection_id: str, payload: dict) -> None:
         log.info("Update requested")
@@ -639,13 +636,13 @@ class Command:
                 payload, connection_id,
                 f'Wechsel auf Zweig \'{payload["data"]["branch"]}\' Tag \'{payload["data"]["tag"]}\' gestartet.',
                 MessageType.SUCCESS)
-            subprocess.run([
+            run_command([
                 str(parent_file / "runs" / "update_self.sh"),
                 str(payload["data"]["branch"]),
                 str(payload["data"]["tag"])])
         else:
             pub_user_message(payload, connection_id, "Update gestartet.", MessageType.INFO)
-            subprocess.run([
+            run_command([
                 str(parent_file / "runs" / "update_self.sh"),
                 SubData.system_data["system"].data["current_branch"]])
 
@@ -653,31 +650,20 @@ class Command:
         log.info("Fetch versions requested")
         pub_user_message(payload, connection_id, "Versionsliste wird aktualisiert...", MessageType.INFO)
         parent_file = Path(__file__).resolve().parents[2]
-        result = subprocess.run([str(parent_file / "runs" / "update_available_versions.sh")])
-        if result.returncode == 0:
-            pub_user_message(payload, connection_id, "Versionsliste erfolgreich aktualisiert.", MessageType.SUCCESS)
-        else:
-            pub_user_message(
-                payload, connection_id,
-                f'Version-Status: {result.returncode}<br />Meldung: {result.stdout.decode("utf-8", MessageType.ERROR)}')
+        run_command([str(parent_file / "runs" / "update_available_versions.sh")])
+        pub_user_message(payload, connection_id, "Versionsliste erfolgreich aktualisiert.", MessageType.SUCCESS)
 
     def createBackup(self, connection_id: str, payload: dict) -> None:
         pub_user_message(payload, connection_id, "Backup wird erstellt...", MessageType.INFO)
         parent_file = Path(__file__).resolve().parents[2]
-        result = subprocess.run(
+        result = run_command(
             [str(parent_file / "runs" / "backup.sh"),
-             "1" if "use_extended_filename" in payload["data"] and payload["data"]["use_extended_filename"] else "0"],
-            stdout=subprocess.PIPE)
-        if result.returncode == 0:
-            file_name = result.stdout.decode("utf-8").rstrip('\n')
-            file_link = "/openWB/data/backup/" + file_name
-            pub_user_message(payload, connection_id,
-                             "Backup erfolgreich erstellt.<br />"
-                             f'Jetzt <a href="{file_link}" target="_blank">herunterladen</a>.', MessageType.SUCCESS)
-        else:
-            pub_user_message(payload, connection_id,
-                             f'Backup-Status: {result.returncode}<br />Meldung: {result.stdout.decode("utf-8")}',
-                             MessageType.ERROR)
+             "1" if "use_extended_filename" in payload["data"] and payload["data"]["use_extended_filename"] else "0"])
+        file_name = result.rstrip('\n')
+        file_link = "/openWB/data/backup/" + file_name
+        pub_user_message(payload, connection_id,
+                         "Backup erfolgreich erstellt.<br />"
+                         f'Jetzt <a href="{file_link}" target="_blank">herunterladen</a>.', MessageType.SUCCESS)
 
     def createCloudBackup(self, connection_id: str, payload: dict) -> None:
         if SubData.system_data["system"].backup_cloud is not None:
@@ -692,18 +678,11 @@ class Command:
 
     def restoreBackup(self, connection_id: str, payload: dict) -> None:
         parent_file = Path(__file__).resolve().parents[2]
-        result = subprocess.run(
-            [str(parent_file / "runs" / "prepare_restore.sh")],
-            stdout=subprocess.PIPE)
-        if result.returncode == 0:
-            pub_user_message(payload, connection_id,
-                             "Wiederherstellung wurde vorbereitet. openWB wird jetzt zum Abschluss neu gestartet.",
-                             MessageType.INFO)
-            self.systemReboot(connection_id, payload)
-        else:
-            pub_user_message(payload, connection_id,
-                             f'Restore-Status: {result.returncode}<br />Meldung: {result.stdout.decode("utf-8")}',
-                             MessageType.ERROR)
+        run_command([str(parent_file / "runs" / "prepare_restore.sh")])
+        pub_user_message(payload, connection_id,
+                         "Wiederherstellung wurde vorbereitet. openWB wird jetzt zum Abschluss neu gestartet.",
+                         MessageType.INFO)
+        self.systemReboot(connection_id, payload)
 
     # ToDo: move to module commands if implemented
     def requestMSALAuthCode(self, connection_id: str, payload: dict) -> None:
@@ -760,6 +739,12 @@ class ErrorHandlingContext:
             pub_user_message(self.payload, self.connection_id,
                              f'Es ist ein interner Fehler aufgetreten: {exception}', MessageType.ERROR)
             log.error({traceback.format_exc()})
+            return True
+        elif isinstance(exception, subprocess.CalledProcessError):
+            log.debug(exception.stdout)
+            pub_user_message(self.payload, self.connection_id,
+                             f'Fehler-Status: {exception.returncode}<br />Meldung: {exception.stderr}',
+                             MessageType.ERROR)
             return True
         else:
             return False

--- a/packages/helpermodules/graph.py
+++ b/packages/helpermodules/graph.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass, field
 import json
 from pathlib import Path
-import subprocess
 import time
 import datetime
 import logging
 
 from control import data
 from helpermodules.pub import Pub
+from helpermodules.utils.run_command import run_command
 from modules.common.fault_state import FaultStateLevel
 
 log = logging.getLogger(__name__)
@@ -64,7 +64,7 @@ class Graph:
             Pub().pub("openWB/set/system/lastlivevaluesJson", data_line)
             with open(str(Path(__file__).resolve().parents[2] / "ramdisk"/"graph_live.json"), "a") as f:
                 f.write(f"{json.dumps(data_line, separators=(',', ':'))}\n")
-            subprocess.run([str(Path(__file__).resolve().parents[2] / "runs"/"graphing.sh"),
-                            str(self.data.config.duration*6)])
+            run_command([str(Path(__file__).resolve().parents[2] / "runs"/"graphing.sh"),
+                         str(self.data.config.duration*6)])
         except Exception:
             log.exception("Fehler im Graph-Modul")

--- a/packages/helpermodules/logger.py
+++ b/packages/helpermodules/logger.py
@@ -2,6 +2,8 @@ import functools
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+import sys
+import threading
 import typing_extensions
 
 FORMAT_STR_DETAILED = '%(asctime)s - {%(name)s:%(lineno)s} - {%(levelname)s:%(threadName)s} - %(message)s'
@@ -79,6 +81,15 @@ def setup_logging() -> None:
 
     logging.getLogger("pymodbus").setLevel(logging.WARNING)
     logging.getLogger("uModbus").setLevel(logging.WARNING)
+
+    def threading_excepthook(args):
+        logging.getLogger(__name__).error("Uncaught exception in threading.excepthook:", exc_info=(
+            args.exc_type, args.exc_value, args.exc_traceback))
+    threading.excepthook = threading_excepthook
+
+    def handle_unhandled_exception(exc_type, exc_value, exc_traceback):
+        logging.getLogger(__name__).error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
+    sys.excepthook = handle_unhandled_exception
 
 
 log = logging.getLogger(__name__)

--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -23,6 +23,7 @@ from helpermodules import graph
 from helpermodules.abstract_plans import AutolockPlan
 from helpermodules.broker import InternalBrokerClient
 from helpermodules.messaging import MessageType, pub_system_message
+from helpermodules.utils.run_command import run_command
 from helpermodules.utils.topic_parser import decode_payload, get_index, get_second_index
 from control import optional
 from helpermodules.pub import Pub
@@ -602,9 +603,9 @@ class SubData:
                         # 5 Min Handler bis auf Heartbeat, Cleanup, ... beenden
                         self.event_jobs_running.clear()
                     self.set_json_payload_class(var.data, msg)
-                    subprocess.run([
+                    run_command([
                         str(Path(__file__).resolve().parents[2] / "runs" / "setup_network.sh")
-                    ])
+                    ], process_exception=True)
                 elif "openWB/general/modbus_control" == msg.topic:
                     if decode_payload(msg.payload) and self.general_data.data.extern:
                         self.event_modbus_server.set()
@@ -633,9 +634,9 @@ class SubData:
                     self.set_json_payload_class(var.data.int_display, msg)
                     if re.search("/(standby|active|rotation)$", msg.topic) is not None:
                         # some topics require an update of the display manager or boot settings
-                        subprocess.run([
+                        run_command([
                             str(Path(__file__).resolve().parents[2] / "runs" / "update_local_display.sh")
-                        ])
+                        ], process_exception=True)
                 elif re.search("/optional/et/", msg.topic) is not None:
                     if re.search("/optional/et/get/prices", msg.topic) is not None:
                         var.data.et.get.prices = decode_payload(msg.payload)
@@ -759,12 +760,14 @@ class SubData:
                 if self.event_subdata_initialized.is_set():
                     index = get_index(msg.topic)
                     parent_file = Path(__file__).resolve().parents[2]
-                    result = subprocess.run(
-                        ["php", "-f", str(parent_file / "runs" / "save_mqtt.php"), index, msg.payload],
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-                    if len(result.stdout) > 0:
-                        pub_system_message(msg.payload, result.stdout,
-                                           MessageType.SUCCESS if result.returncode == 0 else MessageType.ERROR)
+                    try:
+                        result = run_command(
+                            ["php", "-f", str(parent_file / "runs" / "save_mqtt.php"), index, msg.payload])
+                        pub_system_message(msg.payload, result, MessageType.SUCCESS)
+                    except subprocess.CalledProcessError as e:
+                        log.debug(e.stdout)
+                        pub_system_message(msg.payload, f'Fehler-Status: {e.returncode}<br />Meldung: {e.stderr}',
+                                           MessageType.ERROR)
                 else:
                     log.debug("skipping mqtt bridge message on startup")
             elif "mqtt" and "valid_partner_ids" in msg.topic:
@@ -779,8 +782,8 @@ class SubData:
                 token = splitted[0]
                 port = splitted[1] if len(splitted) > 1 else "2223"
                 user = splitted[2] if len(splitted) > 2 else "getsupport"
-                subprocess.run([str(Path(__file__).resolve().parents[2] / "runs" / "start_remote_support.sh"),
-                                token, port, user])
+                run_command([str(Path(__file__).resolve().parents[2] / "runs" / "start_remote_support.sh"),
+                             token, port, user], process_exception=True)
             elif "openWB/system/backup_cloud/config" in msg.topic:
                 config_dict = decode_payload(msg.payload)
                 if config_dict["type"] is None:

--- a/packages/helpermodules/system.py
+++ b/packages/helpermodules/system.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from helpermodules import pub
 from control import data
+from helpermodules.utils.run_command import run_command
 from modules.common.configurable_backup_cloud import ConfigurableBackupCloud
 
 log = logging.getLogger(__name__)
@@ -40,8 +41,8 @@ class System:
             self._trigger_ext_update(train)
             time.sleep(15)
             # aktuell soll kein Update für den Master durchgeführt werden.
-            # subprocess.run([str(Path(__file__).resolve().parents[2]/"runs"/"update_self.sh"), train])
-            subprocess.run(str(Path(__file__).resolve().parents[2]/"runs"/"atreboot.sh"))
+            # run_command([str(Path(__file__).resolve().parents[2]/"runs"/"update_self.sh"), train])
+            run_command(str(Path(__file__).resolve().parents[2]/"runs"/"atreboot.sh"), process_exception=True)
         except Exception:
             log.exception("Fehler im System-Modul")
 
@@ -99,12 +100,13 @@ class System:
             log.debug('Nächtliche Sicherung erstellt und hochgeladen.')
 
     def create_backup(self) -> str:
-        result = subprocess.run([str(self._get_parent_file() / "runs" / "backup.sh"), "1"], stdout=subprocess.PIPE)
-        if result.returncode == 0:
-            file_name = result.stdout.decode("utf-8").rstrip('\n')
+        try:
+            result = run_command([str(self._get_parent_file() / "runs" / "backup.sh"), "1"])
+            file_name = result.rstrip('\n')
             return file_name
-        else:
-            raise Exception(f'Backup-Status: {result.returncode}, Meldung: {result.stdout.decode("utf-8")}')
+        except subprocess.CalledProcessError as e:
+            log.debug(e.stdout)
+            raise Exception(f'Backup-Status: {e.returncode}, Meldung: {e.stderr}')
 
     def _get_parent_file(self) -> Path:
         return Path(__file__).resolve().parents[2]

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -5,7 +5,6 @@ import json
 import logging
 from pathlib import Path
 import re
-import subprocess
 import time
 from typing import List, Optional
 from paho.mqtt.client import Client as MqttClient, MQTTMessage
@@ -24,6 +23,7 @@ from helpermodules.measurement_logging.write_log import get_names
 from helpermodules.messaging import MessageType, pub_system_message
 from helpermodules.pub import Pub
 from helpermodules.utils.json_file_handler import write_and_check
+from helpermodules.utils.run_command import run_command
 from helpermodules.utils.topic_parser import decode_payload, get_index, get_second_index
 from control import counter_all
 from control import ev
@@ -771,12 +771,12 @@ class UpdateConfig:
     def upgrade_datastore_4(self) -> None:
         moved_file = False
         for path in Path("/etc/mosquitto/conf.d").glob('99-bridge-openwb-*.conf'):
-            subprocess.run(["sudo", "mv", str(path), str(path).replace("conf.d", "conf_local.d")])
+            run_command(["sudo", "mv", str(path), str(path).replace("conf.d", "conf_local.d")], process_exception=True)
             moved_file = True
         self.__update_topic("openWB/system/datastore_version", 5)
         if moved_file:
             time.sleep(1)
-            subprocess.run([str(self.base_path / "runs" / "reboot.sh")])
+            run_command([str(self.base_path / "runs" / "reboot.sh")], process_exception=True)
 
     def upgrade_datastore_5(self) -> None:
         def upgrade(topic: str, payload) -> Optional[dict]:
@@ -1062,16 +1062,11 @@ class UpdateConfig:
                 bridge_configuration = decode_payload(payload)
                 if bridge_configuration["remote"]["is_openwb_cloud"]:
                     index = get_index(topic)
-                    result = subprocess.run(
-                        ["php", "-f", str(self.base_path / "runs" / "save_mqtt.php"), index, payload],
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-                    if result.returncode == 0:
-                        log.info("successfully updated configuration of bridge "
-                                 f"'{bridge_configuration['name']}' ({index})")
-                        pub_system_message(payload, result.stdout, MessageType.SUCCESS)
-                    else:
-                        log.error("update of configuration for bridge "
-                                  f"'{bridge_configuration['name']}' ({index}) failed! {result.stdout}")
+                    result = run_command(["php", "-f", str(self.base_path / "runs" / "save_mqtt.php"), index, payload],
+                                         process_exception=True)
+                    log.info("successfully updated configuration of bridge "
+                             f"'{bridge_configuration['name']}' ({index})")
+                    pub_system_message(payload, result, MessageType.SUCCESS)
         self._loop_all_received_topics(upgrade)
         self.__update_topic("openWB/system/datastore_version", 24)
 

--- a/packages/helpermodules/utils/run_command.py
+++ b/packages/helpermodules/utils/run_command.py
@@ -1,0 +1,23 @@
+import logging
+import subprocess
+
+log = logging.getLogger(__name__)
+
+
+def run_command(command, process_exception: bool = False):
+    # if return is non-zero a CalledProcessError is raised
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        if process_exception:
+            log.debug(e.stdout)
+            log.exception(e.stderr)
+        else:
+            raise e

--- a/packages/main.py
+++ b/packages/main.py
@@ -1,43 +1,41 @@
 #!/usr/bin/env python3
-# flake8: noqa: F402
 """Starten der benötigten Prozesse
 """
+from smarthome.smarthome import readmq, smarthome_handler
+from modules.utils import wait_for_module_update_completed
+from modules.internal_chargepoint_handler.rfid import RfidReader
+from modules.internal_chargepoint_handler.internal_chargepoint_handler import GeneralInternalChargepointHandler
+from modules import update_soc
+from helpermodules.utils import exit_after
+from control.algorithm import algorithm
+from control import process
+from control import data
+from control import prepare
+from helpermodules.pub import Pub
+from helpermodules.modbusserver import start_modbus_server
+from helpermodules import command
+from helpermodules import setdata
+from helpermodules import subdata
+from helpermodules import timecheck, update_config
+from modules import configuration
+from modules import loadvars
+from helpermodules.measurement_logging.write_log import LogType, save_log
+from helpermodules.measurement_logging.update_yields import update_daily_yields, update_pv_monthly_yearly_yields
+from helpermodules.changed_values_handler import ChangedValuesContext
+from control.chargelog.chargelog import calculate_charge_cost
+from threading import Thread
+import traceback
+import threading
+import time
+import schedule
+from random import randrange
+from pathlib import Path
 import logging
 from helpermodules import logger
 # als erstes logging initalisieren, damit auch ImportError geloggt werden
 logger.setup_logging()  # ignore E402
 log = logging.getLogger()  # ignore E402
 
-from pathlib import Path
-from random import randrange
-import schedule
-import time
-import threading
-import traceback
-from threading import Thread
-from control.chargelog.chargelog import calculate_charge_cost
-
-from helpermodules.changed_values_handler import ChangedValuesContext
-from helpermodules.measurement_logging.update_yields import update_daily_yields, update_pv_monthly_yearly_yields
-from helpermodules.measurement_logging.write_log import LogType, save_log
-from modules import loadvars
-from modules import configuration
-from helpermodules import timecheck, update_config
-from helpermodules import subdata
-from helpermodules import setdata
-from helpermodules import command
-from helpermodules.modbusserver import start_modbus_server
-from helpermodules.pub import Pub
-from control import prepare
-from control import data
-from control import process
-from control.algorithm import algorithm
-from helpermodules.utils import exit_after
-from modules import update_soc
-from modules.internal_chargepoint_handler.internal_chargepoint_handler import GeneralInternalChargepointHandler
-from modules.internal_chargepoint_handler.rfid import RfidReader
-from modules.utils import wait_for_module_update_completed
-from smarthome.smarthome import readmq, smarthome_handler
 
 logger.setup_logging()
 log = logging.getLogger()

--- a/packages/main.py
+++ b/packages/main.py
@@ -1,41 +1,43 @@
 #!/usr/bin/env python3
 """Starten der benötigten Prozesse
 """
-from smarthome.smarthome import readmq, smarthome_handler
-from modules.utils import wait_for_module_update_completed
-from modules.internal_chargepoint_handler.rfid import RfidReader
-from modules.internal_chargepoint_handler.internal_chargepoint_handler import GeneralInternalChargepointHandler
-from modules import update_soc
-from helpermodules.utils import exit_after
-from control.algorithm import algorithm
-from control import process
-from control import data
-from control import prepare
-from helpermodules.pub import Pub
-from helpermodules.modbusserver import start_modbus_server
-from helpermodules import command
-from helpermodules import setdata
-from helpermodules import subdata
-from helpermodules import timecheck, update_config
-from modules import configuration
-from modules import loadvars
-from helpermodules.measurement_logging.write_log import LogType, save_log
-from helpermodules.measurement_logging.update_yields import update_daily_yields, update_pv_monthly_yearly_yields
-from helpermodules.changed_values_handler import ChangedValuesContext
-from control.chargelog.chargelog import calculate_charge_cost
-from threading import Thread
-import traceback
-import threading
-import time
-import schedule
-from random import randrange
-from pathlib import Path
+# flake8: noqa: F402
 import logging
 from helpermodules import logger
 # als erstes logging initalisieren, damit auch ImportError geloggt werden
-logger.setup_logging()  # ignore E402
-log = logging.getLogger()  # ignore E402
+logger.setup_logging()
+log = logging.getLogger()
 
+from pathlib import Path
+from random import randrange
+import schedule
+import time
+import threading
+import traceback
+from threading import Thread
+from control.chargelog.chargelog import calculate_charge_cost
+
+from helpermodules.changed_values_handler import ChangedValuesContext
+from helpermodules.measurement_logging.update_yields import update_daily_yields, update_pv_monthly_yearly_yields
+from helpermodules.measurement_logging.write_log import LogType, save_log
+from modules import loadvars
+from modules import configuration
+from helpermodules import timecheck, update_config
+from helpermodules import subdata
+from helpermodules import setdata
+from helpermodules import command
+from helpermodules.modbusserver import start_modbus_server
+from helpermodules.pub import Pub
+from control import prepare
+from control import data
+from control import process
+from control.algorithm import algorithm
+from helpermodules.utils import exit_after
+from modules import update_soc
+from modules.internal_chargepoint_handler.internal_chargepoint_handler import GeneralInternalChargepointHandler
+from modules.internal_chargepoint_handler.rfid import RfidReader
+from modules.utils import wait_for_module_update_completed
+from smarthome.smarthome import readmq, smarthome_handler
 
 logger.setup_logging()
 log = logging.getLogger()

--- a/packages/main.py
+++ b/packages/main.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
+# flake8: noqa: F402
 """Starten der benötigten Prozesse
 """
 import logging
+from helpermodules import logger
+# als erstes logging initalisieren, damit auch ImportError geloggt werden
+logger.setup_logging()  # ignore E402
+log = logging.getLogger()  # ignore E402
+
 from pathlib import Path
 from random import randrange
 import schedule
@@ -19,7 +25,6 @@ from modules import configuration
 from helpermodules import timecheck, update_config
 from helpermodules import subdata
 from helpermodules import setdata
-from helpermodules import logger
 from helpermodules import command
 from helpermodules.modbusserver import start_modbus_server
 from helpermodules.pub import Pub

--- a/packages/modules/common/store/_api.py
+++ b/packages/modules/common/store/_api.py
@@ -27,8 +27,14 @@ class LoggingValueStore(Generic[T], ValueStore[T]):
         self.delegate.set(state)
 
     def update(self) -> None:
-        log.info("Saving %s", self.delegate.state)
-        self.delegate.update()
+        try:
+            log.info("Saving %s", self.delegate.state)
+            self.delegate.update()
+        except AttributeError:
+            # Wenn keine Daten ausgelesen werden, fehlt das state-Attribut.
+            pass
+        except Exception:
+            log.exception("Error while publishing module data")
 
 
 def update_values(component):


### PR DESCRIPTION
Es werden keine Fehlermeldungen mehr ins syslog geschrieben. stdout und stderr werden ins main.log umgeleitet und alle nicht-abgefangenen Exceptions werden mit einem Hook abgefangen.
Das syslog wird wöchentlich rotiert, in manchen Fällen ist es vorher voll gelaufen.

Damit auch Import-Error geloggt werden, muss das Logging vor den Imports initialisiert werden. Was gegen die Flake8-Richtlinien verstößt, die in diesem Fall ignoriert werden.