### PR TITLE
Ocppv1.6 Backlog Zweite Version

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -716,7 +716,7 @@ class Chargepoint(ChargepointRfidMixin):
                 self._pub_configured_ev(ev_list)
             # OCPP Start Transaction nach Anstecken
             if (self.data.set.rfid is None and self.data.get.plug_state and
-                    self.data.set.plug_state_prev is False):
+                    self.data.set.plug_state_prev is False and self.data.set.manual_lock is False):
                 try:
                     self.data.set.ocpp_transaction_id = asyncio.run(
                         optional.OCPPClient._start_transaction(

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -221,8 +221,9 @@ class Chargepoint(ChargepointRfidMixin):
                 rfid = "0"
             transaction_id = self.data.set.ocpp_transaction_id
             try:
+                ocpp_client = optional.OCPPClient()
                 asyncio.run(
-                    optional.OCPPClient._stop_transaction(
+                    ocpp_client._stop_transaction(
                         int(self.data.get.imported), transaction_id,
                         rfid))
             except Exception:
@@ -713,6 +714,9 @@ class Chargepoint(ChargepointRfidMixin):
             else:
                 self._pub_configured_ev(ev_list)
             # OCPP Start Transaction nach Anstecken
+            # self.data.set.ocpp_transaction_active = False
+            # Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/ocpp_transaction_active",
+            #          self.data.set.ocpp_transaction_active)
             if (self.data.get.plug_state and
                     self.data.set.ocpp_transaction_active is False and
                     self.data.set.manual_lock is False):
@@ -721,8 +725,9 @@ class Chargepoint(ChargepointRfidMixin):
                 else:
                     rfid = "0"
                 try:
+                    ocpp_client = optional.OCPPClient()
                     self.data.set.ocpp_transaction_id = asyncio.run(
-                        optional.OCPPClient._start_transaction(
+                        ocpp_client._start_transaction(
                             self.num, rfid, int(self.data.get.imported)))
                     Pub().pub("openWB/set/chargepoint/"+str(self.num) +
                               "/set/ocpp_transaction_id", self.data.set.ocpp_transaction_id)

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -714,9 +714,6 @@ class Chargepoint(ChargepointRfidMixin):
             else:
                 self._pub_configured_ev(ev_list)
             # OCPP Start Transaction nach Anstecken
-            # self.data.set.ocpp_transaction_active = False
-            # Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/ocpp_transaction_active",
-            #          self.data.set.ocpp_transaction_active)
             if (self.data.get.plug_state and
                     self.data.set.ocpp_transaction_active is False and
                     self.data.set.manual_lock is False):

--- a/packages/control/chargepoint/chargepoint_data.py
+++ b/packages/control/chargepoint/chargepoint_data.py
@@ -137,6 +137,7 @@ class Set:
     target_current: float = 0  # Sollstrom aus fest vorgegebener Stromstärke
     charging_ev_data: Ev = field(default_factory=ev_factory)
     ocpp_transaction_id: Optional[int] = None
+    ocpp_transaction_active: bool = False
 
 
 @dataclass

--- a/packages/control/chargepoint/chargepoint_data.py
+++ b/packages/control/chargepoint/chargepoint_data.py
@@ -136,6 +136,7 @@ class Set:
     rfid: Optional[str] = None
     target_current: float = 0  # Sollstrom aus fest vorgegebener Stromstärke
     charging_ev_data: Ev = field(default_factory=ev_factory)
+    ocpp_transaction_id: Optional[int] = None
 
 
 @dataclass

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -18,6 +18,7 @@ import threading
 from typing import Dict, List
 import re
 import copy
+from control import data
 
 
 log = logging.getLogger(__name__)
@@ -25,15 +26,6 @@ log = logging.getLogger(__name__)
 # timestamp hat spezielles Format!
 now = datetime.now()
 current_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-@dataclass
-class OcppGet:
-    url: str = ""
-
-
-def ocpp_factory() -> OcppGet:
-    return OcppGet()
 
 
 @dataclass
@@ -89,12 +81,21 @@ def rfid_factory() -> Rfid:
 
 
 @dataclass
+class Ocpp:
+    url: str = ""
+
+
+def ocpp_factory() -> Ocpp:
+    return Ocpp()
+
+
+@dataclass
 class OptionalData:
     et: Et = field(default_factory=et_factory)
     int_display: InternalDisplay = field(default_factory=int_display_factory)
     led: Led = field(default_factory=led_factory)
     rfid: Rfid = field(default_factory=rfid_factory)
-    ocpp: OcppGet = field(default_factory=ocpp_factory)
+    ocpp: Ocpp = field(default_factory=ocpp_factory)
 
 
 class Optional:
@@ -253,7 +254,10 @@ class OCPPClient(ChargePoint):
 
     async def _start_transaction(connector_id, id_tag, meter_value_charged):
         try:
-            url = OptionalData.ocpp.url
+            try:
+                url = data.data.optional_data.data.ocpp.url
+            except Exception as e:
+                print(e)
             if len(url) > 0:
                 async with websockets.connect(
                     url,
@@ -274,7 +278,7 @@ class OCPPClient(ChargePoint):
 
     async def _transfer_values(connector_id, meter_value_charged):
         try:
-            url = OptionalData.ocpp.url
+            url = data.data.optional_data.data.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,
@@ -288,7 +292,7 @@ class OCPPClient(ChargePoint):
 
     async def _stop_transaction(meter_value_charged, transaction_id, id_tag):
         try:
-            url = OptionalData.ocpp.url
+            url = data.data.optional_data.data.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -270,7 +270,7 @@ class OCPPClient(ChargePoint):
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
-                    cp = ChargePoint('openWB', ws, 0)
+                    cp = ChargePoint('openWB', ws, 1)
                 # Start Transaction
                     await cp.start_transaction(connector_id, id_tag, meter_value_charged)
                     # TransactionId extrahieren
@@ -292,7 +292,7 @@ class OCPPClient(ChargePoint):
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
-                    cp = ChargePoint('openWB', ws, 0)
+                    cp = ChargePoint('openWB', ws, 1)
                 # transfer meter values
                     await cp.get_meter(connector_id, meter_value_charged)
         except Exception:
@@ -307,7 +307,7 @@ class OCPPClient(ChargePoint):
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
-                    cp = ChargePoint('openWB', ws, 0)
+                    cp = ChargePoint('openWB', ws, 1)
                 # Stop transaction
                     await cp.stop_transaction(meter_value_charged, transaction_id, id_tag)
         except Exception:

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -208,12 +208,9 @@ class ChargePoint(cp):
 
 class OCPPClient():
 
-    # Test URL: ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1
-
     async def _start_transaction(connector_id, id_tag, meter_value_charged):
         try:
-            # url = data.data.optional_data.data.ocpp.url
-            url = "ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1"
+            url = data.data.optional_data.data.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,
@@ -243,8 +240,7 @@ class OCPPClient():
 
     async def _transfer_values(connector_id, meter_value_charged):
         try:
-            # url = data.data.optional_data.data.ocpp.url
-            url = "ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1"
+            url = data.data.optional_data.data.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,
@@ -275,8 +271,7 @@ class OCPPClient():
 
     async def _send_heart_beat():
         try:
-            # url = data.data.optional_data.data.ocpp.url
-            url = "ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1"
+            url = data.data.optional_data.data.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,
@@ -293,8 +288,7 @@ class OCPPClient():
 
     async def _stop_transaction(meter_value_charged, transaction_id, id_tag):
         try:
-            # url = data.data.optional_data.data.ocpp.url
-            url = "ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1"
+            url = data.data.optional_data.data.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -256,12 +256,6 @@ class OCPPClient(ChargePoint):
 
     # Test URL: ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1
 
-    def __init__() -> None:
-        try:
-            pass
-        except Exception:
-            log.exception("Fehler Initialisierung im OCPP-Modul")
-
     def get_ocpp_config():
         return {
             "data": {

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -229,7 +229,8 @@ class Optional:
                     except Exception as e:
                         print(e)
                     log.debug("Send Meter Values to OCPP")
-            if (chargepoint_ocpp.data.get.charge_state is False and chargepoint_ocpp.num in charging_chargepoints and chargepoint_ocpp.num in started_charging_chargepoints):
+            if (chargepoint_ocpp.data.get.charge_state is False and chargepoint_ocpp.num in charging_chargepoints
+                    and chargepoint_ocpp.num in started_charging_chargepoints):
                 charging_chargepoints.remove(chargepoint_ocpp.num)
                 started_charging_chargepoints.remove(chargepoint_ocpp.num)
                 transaction_list = OCPPClient.get_ocpp_transaction_list()

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -204,7 +204,8 @@ class ChargePoint(cp):
                 timestamp=current_time
             ))
         except asyncio.exceptions.TimeoutError:
-            log.exception("Erwarteter TimeOut Start Transaction")
+            # log.exception("Erwarteter TimeOut Start Transaction")
+            pass
 
     async def stop_transaction(self, meter_value_charged, transaction_id, id_tag):
         try:
@@ -215,7 +216,8 @@ class ChargePoint(cp):
                                                  id_tag=id_tag
                                                  ))
         except asyncio.exceptions.TimeoutError:
-            log.exception("Erwarteter TimeOut Stop Transaction")
+            # log.exception("Erwarteter TimeOut Stop Transaction")
+            pass
 
     async def get_meter(self, connector_id, meter_value_charged):
         try:
@@ -234,7 +236,8 @@ class ChargePoint(cp):
                               ]}],
             ))
         except asyncio.exceptions.TimeoutError:
-            log.exception("Erwarteter TimeOut Meter Values")
+            # log.exception("Erwarteter TimeOut Meter Values")
+            pass
 
 
 class OCPPClient(ChargePoint):
@@ -269,7 +272,7 @@ class OCPPClient(ChargePoint):
                 ) as ws:
                     cp = ChargePoint('openWB', ws)
                 # Start Transaction
-                    await asyncio.gather(cp.start_transaction(connector_id, id_tag, meter_value_charged))
+                    await cp.start_transaction(connector_id, id_tag, meter_value_charged)
                     # TransactionId extrahieren
                     transaction_str = str(ws.messages[0])[slice(str(ws.messages[0]).index(("idTag")))]
                     index1 = str(transaction_str).index(("transactionId"))
@@ -291,8 +294,7 @@ class OCPPClient(ChargePoint):
                 ) as ws:
                     cp = ChargePoint('openWB', ws)
                 # transfer meter values
-                    await asyncio.gather(
-                        cp.get_meter(connector_id, meter_value_charged))
+                    await cp.get_meter(connector_id, meter_value_charged)
         except Exception:
             log.exception("Fehler OCPP: _transfer_values")
 
@@ -307,6 +309,6 @@ class OCPPClient(ChargePoint):
                 ) as ws:
                     cp = ChargePoint('openWB', ws)
                 # Stop transaction
-                    await asyncio.gather(cp.stop_transaction(meter_value_charged, transaction_id, id_tag))
+                    await cp.stop_transaction(meter_value_charged, transaction_id, id_tag)
         except Exception:
             log.exception("Fehler OCPP: _stop_transaction")

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -218,7 +218,7 @@ class OCPPClient():
                 ) as ws:
                     # Start Transaction
                     try:
-                        cp = ChargePoint('openWB', ws, 1)
+                        cp = ChargePoint('openWB', ws, 2)
                         await cp.call(call.StartTransaction(
                             connector_id=connector_id,
                             id_tag=id_tag,

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -261,9 +261,9 @@ class ChargePoint(cp):
 
             ))
         except Exception as e:
-            print(e)
+            log.debug(e)
 
-    async def start_transaction(self, ws, connector_id, meter_value_charged):
+    async def start_transaction(self, connector_id, meter_value_charged):
         try:
             await self.call(call.StartTransaction(
                 connector_id=connector_id,
@@ -388,7 +388,7 @@ class OCPPClient(ChargePoint):
                     connector_list = OCPPClient.get_ocpp_connector_list()
                     connector_list.append(connector_id)
                     transaction_list = OCPPClient.get_ocpp_transaction_list()
-                    await asyncio.gather(cp.start_transaction(ws, connector_id, meter_value_charged))
+                    await asyncio.gather(cp.start_transaction(connector_id, meter_value_charged))
                     # TransactionId extrahieren
                     transaction_str = str(ws.messages[0])[slice(str(ws.messages[0]).index(("idTag")))]
                     index1 = str(transaction_str).index(("transactionId"))

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -270,7 +270,7 @@ class OCPPClient(ChargePoint):
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
-                    cp = ChargePoint('openWB', ws)
+                    cp = ChargePoint('openWB', ws, 0)
                 # Start Transaction
                     await cp.start_transaction(connector_id, id_tag, meter_value_charged)
                     # TransactionId extrahieren
@@ -292,7 +292,7 @@ class OCPPClient(ChargePoint):
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
-                    cp = ChargePoint('openWB', ws)
+                    cp = ChargePoint('openWB', ws, 0)
                 # transfer meter values
                     await cp.get_meter(connector_id, meter_value_charged)
         except Exception:
@@ -307,7 +307,7 @@ class OCPPClient(ChargePoint):
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
-                    cp = ChargePoint('openWB', ws)
+                    cp = ChargePoint('openWB', ws, 0)
                 # Stop transaction
                     await cp.stop_transaction(meter_value_charged, transaction_id, id_tag)
         except Exception:

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -254,6 +254,8 @@ class ChargePoint(cp):
 
 class OCPPClient(ChargePoint):
 
+    # Test URL: ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1
+
     def __init__() -> None:
         try:
             pass
@@ -278,7 +280,6 @@ class OCPPClient(ChargePoint):
             url = OCPPClient.get_url()
             if len(url) > 0:
                 async with websockets.connect(
-                    # 'ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1',
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
@@ -300,7 +301,6 @@ class OCPPClient(ChargePoint):
             url = OCPPClient.get_url()
             if len(url) > 0:
                 async with websockets.connect(
-                    # 'ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1',
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
@@ -315,7 +315,6 @@ class OCPPClient(ChargePoint):
             url = OCPPClient.get_url()
             if len(url) > 0:
                 async with websockets.connect(
-                    # 'ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1',
                     url,
                     subprotocols=['ocpp1.6']
                 ) as ws:

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -264,7 +264,7 @@ class ChargePoint(cp):
                 charge_point_model="openWB",
                 charge_point_vendor="openwb"
             ))
-        except TimeoutError:
+        except asyncio.exceptions.TimeoutError:
             log.exception("TimeOutError StartUp")
 
     async def send_heart_beat(self):
@@ -272,7 +272,7 @@ class ChargePoint(cp):
             await self.call(call.Heartbeat(
 
             ))
-        except TimeoutError:
+        except asyncio.exceptions.TimeoutError:
             log.exception("TimeOutError HeartBeat")
 
     async def start_transaction(self, connector_id, meter_value_charged):
@@ -283,7 +283,7 @@ class ChargePoint(cp):
                 meter_start=meter_value_charged,
                 timestamp=current_time
             ))
-        except TimeoutError:
+        except asyncio.exceptions.TimeoutError:
             log.exception("TimeOutError Start Transaction")
 
     async def stop_transaction(self, meter_value_charged, transaction_id):
@@ -294,7 +294,7 @@ class ChargePoint(cp):
                                                  reason="Local",
                                                  id_tag="user1"
                                                  ))
-        except TimeoutError:
+        except asyncio.exceptions.TimeoutError:
             log.exception("TimeOutError Stop Transaction")
 
     async def get_meter(self, connector_id, meter_value_charged):
@@ -313,7 +313,7 @@ class ChargePoint(cp):
                                   },
                               ]}],
             ))
-        except TimeoutError:
+        except asyncio.exceptions.TimeoutError:
             log.exception("TimeOutError Meter Values")
 
 

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -29,16 +29,11 @@ current_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 @dataclass
 class OcppGet:
-    url = ""
+    url: str = ""
 
 
 def ocpp_factory() -> OcppGet:
-    return OcppGet
-
-
-@dataclass
-class Ocpp:
-    get: OcppGet = field(default_factory=ocpp_factory)
+    return OcppGet()
 
 
 @dataclass
@@ -99,7 +94,7 @@ class OptionalData:
     int_display: InternalDisplay = field(default_factory=int_display_factory)
     led: Led = field(default_factory=led_factory)
     rfid: Rfid = field(default_factory=rfid_factory)
-    ocpp: Ocpp = field(default_factory=ocpp_factory)
+    ocpp: OcppGet = field(default_factory=ocpp_factory)
 
 
 class Optional:
@@ -256,22 +251,9 @@ class OCPPClient(ChargePoint):
 
     # Test URL: ws://128.140.100.76:8080/steve/websocket/CentralSystemService/simtest1
 
-    def get_ocpp_config():
-        return {
-            "data": {
-                "url": "",
-            },
-        }
-
-    def get_config(ocpp_config):
-        OcppGet.url = ocpp_config["data"]["url"]
-
-    def get_url():
-        return OcppGet.url
-
     async def _start_transaction(connector_id, id_tag, meter_value_charged):
         try:
-            url = OCPPClient.get_url()
+            url = OptionalData.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,
@@ -292,7 +274,7 @@ class OCPPClient(ChargePoint):
 
     async def _transfer_values(connector_id, meter_value_charged):
         try:
-            url = OCPPClient.get_url()
+            url = OptionalData.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,
@@ -306,7 +288,7 @@ class OCPPClient(ChargePoint):
 
     async def _stop_transaction(meter_value_charged, transaction_id, id_tag):
         try:
-            url = OCPPClient.get_url()
+            url = OptionalData.ocpp.url
             if len(url) > 0:
                 async with websockets.connect(
                     url,

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -193,10 +193,11 @@ class Optional:
                 meter_value_charged = int(meter_value_charged_copy)
                 connector_id = SubData.cp_data[chpnt].chargepoint.num
                 try:
+                    ocpp_client = OCPPClient()
                     asyncio.run(
-                        OCPPClient._send_heart_beat())
+                        ocpp_client._send_heart_beat())
                     asyncio.run(
-                        OCPPClient._transfer_values(
+                        ocpp_client._transfer_values(
                             connector_id, meter_value_charged))
                 except Exception:
                     log.exception("Fehler Trigger Meter Values")
@@ -208,12 +209,14 @@ class ChargePoint(cp):
 
 class OCPPClient():
 
-    async def _start_transaction(connector_id, id_tag, meter_value_charged):
+    def __init__(self):
+        self.url = data.data.optional_data.data.ocpp.url
+
+    async def _start_transaction(self, connector_id, id_tag, meter_value_charged):
         try:
-            url = data.data.optional_data.data.ocpp.url
-            if len(url) > 0:
+            if len(self.url) > 0:
                 async with websockets.connect(
-                    url,
+                    self.url,
                     subprotocols=['ocpp1.6']
                 ) as ws:
                     # Start Transaction
@@ -238,12 +241,11 @@ class OCPPClient():
         except Exception:
             log.exception("Fehler OCPP: _start_transaction")
 
-    async def _transfer_values(connector_id, meter_value_charged):
+    async def _transfer_values(self, connector_id, meter_value_charged):
         try:
-            url = data.data.optional_data.data.ocpp.url
-            if len(url) > 0:
+            if len(self.url) > 0:
                 async with websockets.connect(
-                    url,
+                    self.url,
                     subprotocols=['ocpp1.6']
                 )as ws:
                     cp = ChargePoint('openWB', ws, 1)
@@ -269,12 +271,11 @@ class OCPPClient():
         except Exception:
             log.exception("Fehler OCPP: _transfer_values")
 
-    async def _send_heart_beat():
+    async def _send_heart_beat(self):
         try:
-            url = data.data.optional_data.data.ocpp.url
-            if len(url) > 0:
+            if len(self.url) > 0:
                 async with websockets.connect(
-                    url,
+                    self.url,
                     subprotocols=['ocpp1.6']
                 )as ws:
                     cp = ChargePoint('openWB', ws, 1)
@@ -286,12 +287,11 @@ class OCPPClient():
         except Exception:
             log.exception("Fehler OCPP: _send_heart_beat")
 
-    async def _stop_transaction(meter_value_charged, transaction_id, id_tag):
+    async def _stop_transaction(self, meter_value_charged, transaction_id, id_tag):
         try:
-            url = data.data.optional_data.data.ocpp.url
-            if len(url) > 0:
+            if len(self.url) > 0:
                 async with websockets.connect(
-                    url,
+                    self.url,
                     subprotocols=['ocpp1.6']
                 )as ws:
                     cp = ChargePoint('openWB', ws, 1)

--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -17,7 +17,6 @@ from math import ceil  # Aufrunden
 import threading
 from typing import Dict, List
 from control import data
-import re
 
 
 log = logging.getLogger(__name__)

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -28,7 +28,7 @@ from helpermodules.create_debug import create_debug_log
 from helpermodules.pub import Pub, pub_single
 from helpermodules.subdata import SubData
 from helpermodules.utils.topic_parser import decode_payload
-from control import bat, bridge, data, ev, counter, counter_all, pv
+from control import bat, bridge, data, ev, counter, counter_all, pv, optional
 from modules.chargepoints.internal_openwb.chargepoint_module import ChargepointModule
 from modules.chargepoints.internal_openwb.config import InternalChargepointMode
 from modules.common.component_type import ComponentType, special_to_general_type_mapping, type_to_topic_mapping
@@ -559,6 +559,15 @@ class Command:
     def getYearlyLog(self, connection_id: str, payload: dict) -> None:
         Pub().pub(f'openWB/set/log/yearly/{payload["data"]["year"]}',
                   get_yearly_log(payload["data"]["year"]))
+
+    def connectOcpp(self, connection_id: str, payload: dict) -> None:
+        ocpp_config = optional.OCPPClient.get_ocpp_config()
+        ocpp_config["data"]["url"] = payload["data"]["url"]
+        optional.OCPPClient.get_config(ocpp_config)
+        optional.OCPPClient.start_ocpp()
+
+    def disconnectOcpp(self, connection_id: str, payload: dict) -> None:
+        optional.OCPPClient.stop_ocpp()
 
     def initCloud(self, connection_id: str, payload: dict) -> None:
         parent_file = Path(__file__).resolve().parents[2]

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -28,7 +28,7 @@ from helpermodules.create_debug import create_debug_log
 from helpermodules.pub import Pub, pub_single
 from helpermodules.subdata import SubData
 from helpermodules.utils.topic_parser import decode_payload
-from control import bat, bridge, data, ev, counter, counter_all, pv, optional
+from control import bat, bridge, data, ev, counter, counter_all, pv
 from modules.chargepoints.internal_openwb.chargepoint_module import ChargepointModule
 from modules.chargepoints.internal_openwb.config import InternalChargepointMode
 from modules.common.component_type import ComponentType, special_to_general_type_mapping, type_to_topic_mapping

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -560,11 +560,6 @@ class Command:
         Pub().pub(f'openWB/set/log/yearly/{payload["data"]["year"]}',
                   get_yearly_log(payload["data"]["year"]))
 
-    def connectOcpp(self, connection_id: str, payload: dict) -> None:
-        ocpp_config = optional.OCPPClient.get_ocpp_config()
-        ocpp_config["data"]["url"] = payload["data"]["url"]
-        optional.OCPPClient.get_config(ocpp_config)
-
     def initCloud(self, connection_id: str, payload: dict) -> None:
         parent_file = Path(__file__).resolve().parents[2]
         result = run_command(

--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -564,10 +564,6 @@ class Command:
         ocpp_config = optional.OCPPClient.get_ocpp_config()
         ocpp_config["data"]["url"] = payload["data"]["url"]
         optional.OCPPClient.get_config(ocpp_config)
-        optional.OCPPClient.start_ocpp()
-
-    def disconnectOcpp(self, connection_id: str, payload: dict) -> None:
-        optional.OCPPClient.stop_ocpp()
 
     def initCloud(self, connection_id: str, payload: dict) -> None:
         parent_file = Path(__file__).resolve().parents[2]

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -530,6 +530,7 @@ class SetData:
                 elif ("/set/manual_lock" in msg.topic or
                         "/set/perform_control_pilot_interruption" in msg.topic or
                         "/set/perform_phase_switch" in msg.topic or
+                        "/set/ocpp_transaction_active" in msg.topic or
                         "/set/plug_state_prev" in msg.topic):
                     self._validate_value(msg, bool)
                 elif "/set/autolock_state" in msg.topic:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -537,6 +537,8 @@ class SetData:
                 elif ("/set/rfid" in msg.topic or
                         "/set/plug_time" in msg.topic):
                     self._validate_value(msg, float)
+                elif "/set/ocpp_transaction_id" in msg.topic:
+                    self._validate_value(msg, int)
                 elif "/set/log" in msg.topic:
                     self._validate_value(msg, "json")
                 elif "/config/ev" in msg.topic:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -833,6 +833,8 @@ class SetData:
                 self._validate_value(msg, "json")
             elif "openWB/set/optional/rfid/active" in msg.topic:
                 self._validate_value(msg, bool)
+            elif "openWB/set/optional/ocpp/url" in msg.topic:
+                self._validate_value(msg, str)
             elif "openWB/set/optional/int_display/rotation" in msg.topic:
                 self._validate_value(msg, int, [(0, 0), (90, 90), (180, 180), (270, 270)])
             elif "openWB/set/optional/int_display/active" in msg.topic:

--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -648,6 +648,8 @@ class SubData:
                     self.set_json_payload_class(var.data.led, msg)
                 elif re.search("/optional/rfid/", msg.topic) is not None:
                     self.set_json_payload_class(var.data.rfid, msg)
+                elif re.search("/optional/ocpp/", msg.topic) is not None:
+                    self.set_json_payload_class(var.data.ocpp, msg)
                 elif re.search("/optional/int_display/", msg.topic) is not None:
                     self.set_json_payload_class(var.data.int_display, msg)
                     if re.search("/(standby|active|rotation)$", msg.topic) is not None:

--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -648,7 +648,7 @@ class SubData:
                     self.set_json_payload_class(var.data.led, msg)
                 elif re.search("/optional/rfid/", msg.topic) is not None:
                     self.set_json_payload_class(var.data.rfid, msg)
-                elif re.search("/optional/ocpp/", msg.topic) is not None:
+                elif re.search("/optional/ocpp/url", msg.topic) is not None:
                     self.set_json_payload_class(var.data.ocpp, msg)
                 elif re.search("/optional/int_display/", msg.topic) is not None:
                     self.set_json_payload_class(var.data.int_display, msg)

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -122,6 +122,7 @@ class UpdateConfig:
         "^openWB/chargepoint/[0-9]+/set/log$",
         "^openWB/chargepoint/[0-9]+/set/phases_to_use$",
         "^openWB/chargepoint/[0-9]+/set/charging_ev_prev$",
+        "^openWB/chargepoint/[0-9]+/set/ocpp_transaction_id$",
 
         "^openWB/command/max_id/autolock_plan$",
         "^openWB/command/max_id/charge_template$",

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -244,6 +244,7 @@ class UpdateConfig:
         "^openWB/optional/int_display/only_local_charge_points",
         "^openWB/optional/led/active$",
         "^openWB/optional/rfid/active$",
+        "^openWB/optional/ocpp/url$",
 
         "^openWB/pv/config/configured$",
         "^openWB/pv/get/exported$",

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -123,6 +123,7 @@ class UpdateConfig:
         "^openWB/chargepoint/[0-9]+/set/phases_to_use$",
         "^openWB/chargepoint/[0-9]+/set/charging_ev_prev$",
         "^openWB/chargepoint/[0-9]+/set/ocpp_transaction_id$",
+        "^openWB/chargepoint/[0-9]+/set/ocpp_transaction_active$",
 
         "^openWB/command/max_id/autolock_plan$",
         "^openWB/command/max_id/charge_template$",

--- a/packages/main.py
+++ b/packages/main.py
@@ -49,7 +49,7 @@ class HandlerAlgorithm:
         """ führt den Algorithmus durch.
         """
         try:
-           # @exit_after(data.data.general_data.data.control_interval)
+            @exit_after(data.data.general_data.data.control_interval)
             def handler_with_control_interval():
                 if (data.data.general_data.data.control_interval / 10) == self.interval_counter:
                     data.data.copy_data()
@@ -68,8 +68,8 @@ class HandlerAlgorithm:
                         prep.setup_algorithm()
                         control.calc_current()
                         proc.process_algorithm_results()
-                        # for testing purpose 10s handler ocpp
-                        data.data.optional_data.ocpp_get_state()
+                        # ocpp start/stop transaction
+                        data.data.optional_data.ocpp_set_state()
                         data.data.graph_data.pub_graph_data()
                     self.interval_counter = 1
                 else:
@@ -94,7 +94,8 @@ class HandlerAlgorithm:
                 update_pv_monthly_yearly_yields()
                 data.data.general_data.grid_protection()
                 data.data.optional_data.et_get_prices()
-                #data.data.optional_data.ocpp_get_state()
+                #ocpp send meter_values
+                data.data.optional_data.ocpp_transfer_meter_values()
                 data.data.counter_all_data.validate_hierarchy()
         except KeyboardInterrupt:
             log.critical("Ausführung durch exit_after gestoppt: "+traceback.format_exc())

--- a/packages/main.py
+++ b/packages/main.py
@@ -49,7 +49,7 @@ class HandlerAlgorithm:
         """ führt den Algorithmus durch.
         """
         try:
-            @exit_after(data.data.general_data.data.control_interval)
+           # @exit_after(data.data.general_data.data.control_interval)
             def handler_with_control_interval():
                 if (data.data.general_data.data.control_interval / 10) == self.interval_counter:
                     data.data.copy_data()
@@ -68,6 +68,8 @@ class HandlerAlgorithm:
                         prep.setup_algorithm()
                         control.calc_current()
                         proc.process_algorithm_results()
+                        # for testing purpose 10s handler ocpp
+                        data.data.optional_data.ocpp_get_state()
                         data.data.graph_data.pub_graph_data()
                     self.interval_counter = 1
                 else:
@@ -92,6 +94,7 @@ class HandlerAlgorithm:
                 update_pv_monthly_yearly_yields()
                 data.data.general_data.grid_protection()
                 data.data.optional_data.et_get_prices()
+                #data.data.optional_data.ocpp_get_state()
                 data.data.counter_all_data.validate_hierarchy()
         except KeyboardInterrupt:
             log.critical("Ausführung durch exit_after gestoppt: "+traceback.format_exc())

--- a/packages/main.py
+++ b/packages/main.py
@@ -32,6 +32,7 @@ from control import prepare
 from control import data
 from control import process
 from control.algorithm import algorithm
+from control import optional
 from helpermodules.utils import exit_after
 from modules import update_soc
 from modules.internal_chargepoint_handler.internal_chargepoint_handler import GeneralInternalChargepointHandler
@@ -68,8 +69,6 @@ class HandlerAlgorithm:
                         prep.setup_algorithm()
                         control.calc_current()
                         proc.process_algorithm_results()
-                        # ocpp start/stop transaction
-                        data.data.optional_data.ocpp_set_state()
                         data.data.graph_data.pub_graph_data()
                     self.interval_counter = 1
                 else:
@@ -94,8 +93,7 @@ class HandlerAlgorithm:
                 update_pv_monthly_yearly_yields()
                 data.data.general_data.grid_protection()
                 data.data.optional_data.et_get_prices()
-                #ocpp send meter_values
-                data.data.optional_data.ocpp_transfer_meter_values()
+                optional.Optional.ocpp_transfer_meter_values()
                 data.data.counter_all_data.validate_hierarchy()
         except KeyboardInterrupt:
             log.critical("Ausführung durch exit_after gestoppt: "+traceback.format_exc())

--- a/packages/main.py
+++ b/packages/main.py
@@ -93,7 +93,7 @@ class HandlerAlgorithm:
                 update_pv_monthly_yearly_yields()
                 data.data.general_data.grid_protection()
                 data.data.optional_data.et_get_prices()
-                optional.Optional.ocpp_transfer_meter_values()
+                optional.Optional.ocpp_get_meter_values()
                 data.data.counter_all_data.validate_hierarchy()
         except KeyboardInterrupt:
             log.critical("Ausführung durch exit_after gestoppt: "+traceback.format_exc())

--- a/packages/main.py
+++ b/packages/main.py
@@ -93,7 +93,7 @@ class HandlerAlgorithm:
                 update_pv_monthly_yearly_yields()
                 data.data.general_data.grid_protection()
                 data.data.optional_data.et_get_prices()
-                optional.Optional.ocpp_get_meter_values()
+                optional.Optional.ocpp_transaction()
                 data.data.counter_all_data.validate_hierarchy()
         except KeyboardInterrupt:
             log.critical("Ausführung durch exit_after gestoppt: "+traceback.format_exc())

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,10 @@ pytz==2023.3.post1
 grpcio==1.60.1
 protobuf==4.25.3
 bimmer_connected==0.15.1
+# ocpp
+jsonschema==4.22.0
+jsonschema-specifications==2023.12.1
+ocpp==1.0.0
+referencing==0.35.1
+rpds-py==0.18.1
+websockets==12.0


### PR DESCRIPTION
### Zweite Version Ocpp Backlog Kommunikation **ocpp V1.6**

Im Frontend wurde unter Übergreifendes eine neue Funktion hinzugefügt:
Zwei Buttons mit OCCP Ja/Nein, welche ein Feld URL eingeben ein/ausblendet. Wird eine gültige URL eingegeben, dann wird diese bei Drücken auf speichern ans backend übertragen.

Start/Stop-Transaction() werden über den Ladepunkt (chargepoint.py) aufgerufen. Mit Aufruf der start-transaction-Funktion wird die transaction_id ermittelt, welche beim Aufruf der stop-transaction() Funktion zwingend benötigt wird. Ist der Ladepunkt gesperrt, wird der start_transaction() erst aufgerufen, wenn entweder ein gültiger Id-tag vorliegt oder das manual_lock entfernt wurde.

Die meter_values werden über den 5 min Handler ans ocpp-backend übergeben, sobald ein Ladepunkt eine transaction_id zugewiesen bekommen hat (thread), genauso wie der heartbeat.

Getestet mit 3 MQTT Ladepunkte im 10s Handler + 5min handler

Stand: 29.Juli 2024