### PR TITLE
dailylog electricity_tariff price

### DIFF
--- a/packages/helpermodules/measurement_logging/write_log.py
+++ b/packages/helpermodules/measurement_logging/write_log.py
@@ -82,7 +82,7 @@ log = logging.getLogger(__name__)
 #             },
 #             "hc": {"all": {"imported": Wh # Hausverbrauch}}
 #
-#             "prices": {grid: 0.3, grid: (electriciy_tariff, fault_state, None), pv: 0.1, bat: 0,2}
+#             "prices": {grid: 0.3, grid: (electricity_tariff, static if not configured), pv: 0.1, bat: 0,2}
 #         }],
 #      "names": "names": {"sh1": "", "cp1": "", "counter2": "", "pv3": ""}
 #      }
@@ -247,17 +247,13 @@ def create_entry(log_type: LogType, sh_log_data: LegacySmartHomeLogData, previou
     hc_dict = {"all": {"imported": data.data.counter_all_data.data.set.imported_home_consumption}}
 
     try:
-        if data.data.optional_data.et_module is None:
-            prices_dict = {"grid": None,
+        if data.data.optional_data.et_module is None or data.data.optional_data.et_module.fault_state.fault_state == 2:
+            prices_dict = {"grid": data.data.general_data.data.prices.grid*1000,
                            "pv": data.data.general_data.data.prices.pv*1000,
                            "bat": data.data.general_data.data.prices.bat*1000}
         if (data.data.optional_data.et_module is not None and
                 data.data.optional_data.et_module.fault_state.fault_state == 0):
             prices_dict = {"grid": list(data.data.optional_data.data.et.get.prices.values())[0]*1000,
-                           "pv": data.data.general_data.data.prices.pv*1000,
-                           "bat": data.data.general_data.data.prices.bat*1000}
-        if data.data.optional_data.et_module.fault_state.fault_state == 2:
-            prices_dict = {"grid": "Fehler im dynamischen Strompreistarif",
                            "pv": data.data.general_data.data.prices.pv*1000,
                            "bat": data.data.general_data.data.prices.bat*1000}
     except Exception:


### PR DESCRIPTION
Der dynamische Strompreis soll im Tageslog aufgezeichnet werden. Ist keiner konfiguriert, wird der statische Strompreis stattdessen geloggt.