### PR TITLE
steuerung über mqtt...

### DIFF
--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -1118,7 +1118,7 @@ class SetData:
                         with open(self._get_ramdisk_path()/f"smarthome_device_manual_control_{index}", 'w') as f:
                             f.write(str(decode_payload(msg.payload)))
                     if f"openWB/set/LegacySmartHome/config/set/Devices/{index}/manueb" in msg.topic:
-                        manueb = int(msg.payload)                            
+                        manueb = int(msg.payload)
                         with open(self._get_ramdisk_path()/f"smarthome_device_manual_ueb_{index}", 'w') as f:
                             f.write(str(manueb))
                 elif (f"openWB/set/LegacySmartHome/Devices/{index}/Ueberschuss" in msg.topic or

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -1117,6 +1117,10 @@ class SetData:
                     if f"openWB/set/LegacySmartHome/config/set/Devices/{index}/device_manual_control" in msg.topic:
                         with open(self._get_ramdisk_path()/f"smarthome_device_manual_control_{index}", 'w') as f:
                             f.write(str(decode_payload(msg.payload)))
+                    if f"openWB/set/LegacySmartHome/config/set/Devices/{index}/manueb" in msg.topic:
+                        manueb = int(msg.payload)                            
+                        with open(self._get_ramdisk_path()/f"smarthome_device_manual_ueb_{index}", 'w') as f:
+                            f.write(str(manueb))
                 elif (f"openWB/set/LegacySmartHome/Devices/{index}/Ueberschuss" in msg.topic or
                         f"openWB/set/LegacySmartHome/Devices/{index}/ReqRelay" in msg.topic or
                         f"openWB/set/LegacySmartHome/Devices/{index}/Aktpower" in msg.topic or

--- a/packages/smarthome/smartbase.py
+++ b/packages/smarthome/smartbase.py
@@ -449,8 +449,10 @@ class Sbase(Sbase0):
         #    (1 = mit Speicher, 2 = mit offset , 0 = manual eingeschaltet)
         if (self.ueberschussberechnung == 2):
             self.devuberschuss = self._uberschussoffset
-        else:
+        elif (self.ueberschussberechnung == 1):
             self.devuberschuss = self._uberschuss
+        else:
+            self.devuberschuss = self.device_manual_ueb
 
     def preturn(self, zustand: int, ueberschussberechnung: int, updatecnt: int) -> None:
         self.ueberschussberechnung = ueberschussberechnung
@@ -483,6 +485,8 @@ class Sbase(Sbase0):
     def conditions(self, speichersoc: int) -> None:
         # do not do anything in case none type or can switch = no
         # or device manuam mode
+        if (self.device_manual == 1):
+            self.ueberschussberechnung = 0
         if ((self.device_canswitch == 0) or
            (self.device_manual == 1)):
             return

--- a/packages/smarthome/smartbase0.py
+++ b/packages/smarthome/smartbase0.py
@@ -102,6 +102,7 @@ class Sbase0:
         self._wpos = 0
         self._deviceconfigured = '1'
         self._deviceconfiguredold = '9'
+        self.device_manual_ueb = 0
         # not none !
         self._oldmeasuretype1 = 'empty'
         self.c_oldstampeinschaltdauer = 0

--- a/packages/smarthome/smartcommon.py
+++ b/packages/smarthome/smartcommon.py
@@ -446,6 +446,14 @@ def loadregelvars(wattbezug: int, speicherleistung: int, speichersoc: int,
                             mydevice.device_manual_control = int(value.read())
             except Exception:
                 pass
+            try:
+                with open(bp+'/ramdisk/smarthome_device_manual_ueb_'
+                          + str(i), 'r') as value:
+                    for mydevice in mydevices:
+                        if (str(i) == str(mydevice.device_nummer)):
+                            mydevice.device_manual_ueb = int(value.read())
+            except Exception:
+                pass
     return uberschuss, uberschussoffset
 
 
@@ -488,6 +496,12 @@ def mainloop(wattbezug: int, speicherleistung: int, speichersoc: int, pvwatt: in
                         with open(fname,  'w') as f:
                             f.write(str(mydevice.device_manual_control))
                     log.info("File: " + str(fname) + " created. Content: " + str(mydevice.device_manual_control))
+                    os.chmod(fname, 0o777)
+                    fname = bp+'/ramdisk/smarthome_device_manual_ueb_'+str(i)
+                    if not os.path.isfile(fname):
+                        with open(fname,  'w') as f:
+                            f.write(str(mydevice.device_manual_ueb))
+                    log.info("File: " + str(fname) + " created. Content: " + str(mydevice.device_manual_ueb))
                     os.chmod(fname, 0o777)
     mqtt_man = {}
     sendmess = 0


### PR DESCRIPTION
Neu kann auch für Acthor und andere der Zu meldende Überschuss im Manuellen  Modus übergeben werden. Alle möglichen MQTT Topics sind im mqtt modul besschrieben: Generisches MQTT modul
Wenn Einschaltbedingung erreicht (Beispiel hier mit Device 2) openWB/LegacySmartHome/Devices/2/ReqRelay = 1
openWB/LegacySmartHome/Devices/2/Ueberschuss = in Watt Wenn Ausschaltbedingung erreicht
openWB/LegacySmartHome/Devices/2/ReqRelay = 0
openWB/LegacySmartHome/Devices/2/Ueberschuss = in Watt ReqRelay gibt den Status vom Gerät aus Sicht openWb an (1 = eingeschaltet, 0 = ausgeschaltet) Bei der periodischen Abfrage wird die aktuelle Leistung openWB/set/LegacySmartHome/Devices/2/Aktpower = in Watt erwartet openWB/set/LegacySmartHome/Devices/2/Tempa = Temperatur in C mit max 2 Nachkommastellen openWB/set/LegacySmartHome/Devices/2/Tempb = Temperatur in C mit max 2 Nachkommastellen openWB/set/LegacySmartHome/Devices/2/Tempc = Temperatur in C mit max 2 Nachkommastellen und der aktuelle Zähler in Wattstunden wird hier erwartet openWB/set/LegacySmartHome/Devices/2/Powerc
wenn kein Zähler übergeben oder 0 übergeben wird, wird der Zähler selber gerechnet openWB/set/LegacySmartHome/Devices/2/Ueberschuss = in Watt alle Geräte (nicht nur MQTT) können bezüglich manuell / automatisch von extern gesteuert werden. openWB/set/LegacySmartHome/config/set/Devices/2/mode Mode steuert das Gerät (1 = manueller Modus, 0 = automatischer Modus) openWB/set/LegacySmartHome/config/set/Devices/2/device_manual_control device_manual_control steuert das Ferät im manuellen Modus (1 = ein, 0 = aus) openWB/set/LegacySmartHome/config/set/Devices/2/manueb = vorgebener Überschuss in Watt ohne Nachkommastellen Dieser Wert wird wenn das Gerät auf Manueller Modus und ein geschaltet ist, als Überschuss an das jeweilige Gerät übergeben. (nur relevant für Acthor, Elwa, IDM, Lambda die mit überschuss gesteuert werden)