### PR TITLE
soc_bmwbc: update version of bimmer_connected from 0.15.1 to 0.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ pysmb==1.2.9.1
 pytz==2023.3.post1
 grpcio==1.60.1
 protobuf==4.25.3
-bimmer_connected==0.15.1
+bimmer_connected==0.16.1


### PR DESCRIPTION
version 0.16.1 tested successfully in my test instance.