### PR TITLE
Mosquitto init

### DIFF
--- a/data/config/mosquitto/mosquitto_local_init
+++ b/data/config/mosquitto/mosquitto_local_init
@@ -1,12 +1,14 @@
 #! /bin/sh
 
+# openwb-version:1
+
 # JFL 20190529: patched startup script for multiple mosquitto instances. Rename 
 # to an instance name, e.g. mosquitto_dev to initiate an instance expecting its
 # config in /etc/mosquitto/mosquitto_dev (i.e. based on this script's name)
 
 ### BEGIN INIT INFO
-# Provides:		mosquitto
-# Required-Start:	$remote_fs $syslog
+# Provides:		mosquitto_local
+# Required-Start:	$remote_fs $syslog mosquitto
 # Required-Stop:	$remote_fs $syslog
 # Default-Start:	2 3 4 5
 # Default-Stop:		0 1 6

--- a/data/config/openwb2.service
+++ b/data/config/openwb2.service
@@ -13,3 +13,4 @@ TimeoutStartSec=900
 
 [Install]
 WantedBy=multi-user.target
+After=mosquitto_local.service

--- a/data/config/openwb2.service
+++ b/data/config/openwb2.service
@@ -1,4 +1,4 @@
-# openwb-version:2
+# openwb-version:3
 [Unit]
 Description="Regelung openWB 2.0"
 

--- a/data/config/openwbRemoteSupport.service
+++ b/data/config/openwbRemoteSupport.service
@@ -1,4 +1,4 @@
-# openwb-version:1
+# openwb-version:2
 [Unit]
 Description="Remote Support Handler openWB 2.0"
 

--- a/data/config/openwbRemoteSupport.service
+++ b/data/config/openwbRemoteSupport.service
@@ -10,3 +10,4 @@ Restart=always
 
 [Install]
 WantedBy=multi-user.target
+After=mosquitto_local.service

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -306,7 +306,18 @@ chmod 666 "$LOGFILE"
 	fi
 
 	#check for mosquitto_local instance
-	restartService=0
+	# restartService=0  # if we restart mosquitto, we need to restart mosquitto_local as well
+	if versionMatch "${OPENWBBASEDIR}/data/config/mosquitto/mosquitto_local_init" "/etc/init.d/mosquitto_local"; then
+		echo "mosquitto_local service definition already up to date"
+	else
+		echo "updating mosquitto_local service definition"
+		sudo cp "${OPENWBBASEDIR}/data/config/mosquitto/mosquitto_local_init" /etc/init.d/mosquitto_local
+		sudo chown root:root /etc/init.d/mosquitto_local
+		sudo chmod 755 /etc/init.d/mosquitto_local
+		sudo systemctl daemon-reload
+		sudo systemctl enable mosquitto_local
+		restartService=1
+	fi
 	if versionMatch "${OPENWBBASEDIR}/data/config/mosquitto/mosquitto_local.conf" "/etc/mosquitto/mosquitto_local.conf"; then
 		echo "mosquitto_local.conf already up to date"
 	else


### PR DESCRIPTION
fixes a startup race condition
- make service `mosquitto_local` start after `mosquitto`
- make openwb2 and remote service start after `mosquitto_local`