### PR TITLE
error timestamp for pro, external, satellit and smartwb

### DIFF
--- a/packages/control/chargepoint/chargepoint_data.py
+++ b/packages/control/chargepoint/chargepoint_data.py
@@ -97,6 +97,7 @@ class Get:
     currents: List[float] = field(default_factory=currents_list_factory)
     daily_imported: float = 0
     daily_exported: float = 0
+    error_timestamp: int = 0
     evse_current: Optional[float] = None
     exported: float = 0
     fault_str: str = NO_ERROR

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -618,8 +618,6 @@ class SetData:
             self._validate_value(msg, int, [(0, 2)])
         elif "/get/evse_current" in msg.topic:
             self._validate_value(msg, float, [(0, 0), (6, 32), (600, 3200)])
-        elif "/get/rfid_timestamp" in msg.topic:
-            self._validate_value(msg, float)
         elif ("/get/fault_str" in msg.topic or
                 "/get/state_str" in msg.topic or
                 "/get/heartbeat" in msg.topic or
@@ -627,6 +625,9 @@ class SetData:
                 "/get/vehicle_id" in msg.topic or
                 "/get/serial_number" in msg.topic):
             self._validate_value(msg, str)
+        elif ("/get/error_timestamp" in msg.topic or
+                "/get/rfid_timestamp" in msg.topic):
+            self._validate_value(msg, float)
         elif ("/get/soc" in msg.topic):
             self._validate_value(msg, float, [(0, 100)])
         elif "/get/rfid_timestamp" in msg.topic:

--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -425,24 +425,25 @@ class SubData:
                     elif re.search("/chargepoint/[0-9]+/get/", msg.topic) is not None:
                         if re.search("/chargepoint/[0-9]+/get/connected_vehicle/", msg.topic) is not None:
                             self.set_json_payload_class(var["cp"+index].chargepoint.data.get.connected_vehicle, msg)
-                        elif re.search("/chargepoint/[0-9]+/get/", msg.topic) is not None:
-                            if (re.search("/chargepoint/[0-9]+/get/soc$", msg.topic) is not None and
-                                    decode_payload(msg.payload) != var["cp"+index].chargepoint.data.get.soc):
-                                # Wenn das Auto noch nicht zugeordnet ist, wird der SoC nach der Zuordnung aktualisiert
-                                if var["cp"+index].chargepoint.data.set.charging_ev > -1:
-                                    Pub().pub(f'openWB/set/vehicle/{var["cp"+index].chargepoint.data.set.charging_ev}'
-                                              '/get/force_soc_update', True)
-                                self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
-                            elif re.search("/chargepoint/[0-9]+/get/error_timestamp$", msg.topic) is not None:
-                                var["cp" +
-                                    index].chargepoint.chargepoint_module.client_error_context.error_timestamp = (
-                                    decode_payload(msg.payload)
-                                )
-                                self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
-                            elif re.search("/chargepoint/[0-9]+/get/simulation$", msg.topic) is not None:
-                                var["cp"+index].chargepoint.chargepoint_module.sim_counter.data = dataclass_from_dict(
-                                    SimCounterState,
-                                    decode_payload(msg.payload))
+                        elif (re.search("/chargepoint/[0-9]+/get/soc$", msg.topic) is not None and
+                              decode_payload(msg.payload) != var["cp"+index].chargepoint.data.get.soc):
+                            # Wenn das Auto noch nicht zugeordnet ist, wird der SoC nach der Zuordnung aktualisiert
+                            if var["cp"+index].chargepoint.data.set.charging_ev > -1:
+                                Pub().pub(f'openWB/set/vehicle/{var["cp"+index].chargepoint.data.set.charging_ev}'
+                                          '/get/force_soc_update', True)
+                            self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
+                        elif re.search("/chargepoint/[0-9]+/get/error_timestamp$", msg.topic) is not None:
+                            var["cp" +
+                                index].chargepoint.chargepoint_module.client_error_context.error_timestamp = (
+                                decode_payload(msg.payload)
+                            )
+                            self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
+                        elif re.search("/chargepoint/[0-9]+/get/simulation$", msg.topic) is not None:
+                            var["cp"+index].chargepoint.chargepoint_module.sim_counter.data = dataclass_from_dict(
+                                SimCounterState,
+                                decode_payload(msg.payload))
+                        else:
+                            self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
                     elif re.search("/chargepoint/[0-9]+/config$", msg.topic) is not None:
                         self.process_chargepoint_config_topic(var, msg)
                     elif re.search("/chargepoint/[0-9]+/control_parameter/", msg.topic) is not None:

--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -425,19 +425,24 @@ class SubData:
                     elif re.search("/chargepoint/[0-9]+/get/", msg.topic) is not None:
                         if re.search("/chargepoint/[0-9]+/get/connected_vehicle/", msg.topic) is not None:
                             self.set_json_payload_class(var["cp"+index].chargepoint.data.get.connected_vehicle, msg)
-                        elif (re.search("/chargepoint/[0-9]+/get/soc$", msg.topic) is not None and
-                              decode_payload(msg.payload) != var["cp"+index].chargepoint.data.get.soc):
-                            # Wenn das Auto noch nicht zugeordnet ist, wird der SoC nach der Zuordnung aktualisiert
-                            if var["cp"+index].chargepoint.data.set.charging_ev > -1:
-                                Pub().pub(f'openWB/set/vehicle/{var["cp"+index].chargepoint.data.set.charging_ev}'
-                                          '/get/force_soc_update', True)
-                            self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
-                        elif re.search("/chargepoint/[0-9]+/get/simulation$", msg.topic) is not None:
-                            var["cp"+index].chargepoint.chargepoint_module.sim_counter.data = dataclass_from_dict(
-                                SimCounterState,
-                                decode_payload(msg.payload))
-                        else:
-                            self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
+                        elif re.search("/chargepoint/[0-9]+/get/", msg.topic) is not None:
+                            if (re.search("/chargepoint/[0-9]+/get/soc$", msg.topic) is not None and
+                                    decode_payload(msg.payload) != var["cp"+index].chargepoint.data.get.soc):
+                                # Wenn das Auto noch nicht zugeordnet ist, wird der SoC nach der Zuordnung aktualisiert
+                                if var["cp"+index].chargepoint.data.set.charging_ev > -1:
+                                    Pub().pub(f'openWB/set/vehicle/{var["cp"+index].chargepoint.data.set.charging_ev}'
+                                              '/get/force_soc_update', True)
+                                self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
+                            elif re.search("/chargepoint/[0-9]+/get/error_timestamp$", msg.topic) is not None:
+                                var["cp" +
+                                    index].chargepoint.chargepoint_module.client_error_context.error_timestamp = (
+                                    decode_payload(msg.payload)
+                                )
+                                self.set_json_payload_class(var["cp"+index].chargepoint.data.get, msg)
+                            elif re.search("/chargepoint/[0-9]+/get/simulation$", msg.topic) is not None:
+                                var["cp"+index].chargepoint.chargepoint_module.sim_counter.data = dataclass_from_dict(
+                                    SimCounterState,
+                                    decode_payload(msg.payload))
                     elif re.search("/chargepoint/[0-9]+/config$", msg.topic) is not None:
                         self.process_chargepoint_config_topic(var, msg)
                     elif re.search("/chargepoint/[0-9]+/control_parameter/", msg.topic) is not None:

--- a/packages/helpermodules/utils/error_counter.py
+++ b/packages/helpermodules/utils/error_counter.py
@@ -1,14 +1,21 @@
 import logging
 
+from helpermodules import timecheck
+from helpermodules.pub import Pub
+
 
 log = logging.getLogger(__name__)
 
+CP_ERROR = ("Anhaltender Fehler beim Auslesen des Ladepunkts. Sollstromstärke, Lade- und Stecker-Status wird "
+            "zurückgesetzt.")
 
-class ErrorCounterContext:
-    def __init__(self, exceeded_msg: str, max_errors: int = 2, hide_exception: bool = False):
-        self.max_errors = max_errors
+
+class ErrorTimerContext:
+    def __init__(self, topic: str, exceeded_msg: str, timeout: int = 60, hide_exception: bool = False):
+        self.topic = topic
+        self.timeout = timeout
         self.hide_exception = hide_exception
-        self.__error_counter = 0
+        self.error_timestamp = None
         self.__exceeded_msg = exceeded_msg
 
     def __enter__(self):
@@ -16,18 +23,21 @@ class ErrorCounterContext:
 
     def __exit__(self, exception_type, exception, exception_traceback) -> bool:
         if exception:
-            self.__error_counter += 1
+            if self.error_timestamp is None:
+                self.error_timestamp = timecheck.create_timestamp()
+                Pub().pub(self.topic, self.error_timestamp)
             log.error(exception)
-            if self.hide_exception is False or self.__error_counter >= self.max_errors:
+            if self.hide_exception is False or timecheck.check_timestamp(self.error_timestamp, self.timeout) is False:
                 raise exception
         return True
 
     def error_counter_exceeded(self) -> bool:
-        if self.__error_counter > self.max_errors:
+        if self.error_timestamp and timecheck.check_timestamp(self.error_timestamp, self.timeout):
             log.error(self.__exceeded_msg)
             return True
         else:
             return False
 
     def reset_error_counter(self):
-        self.__error_counter = 0
+        Pub().pub(self.topic, self.error_timestamp)
+        self.error_timestamp = None

--- a/packages/modules/chargepoints/external_openwb/chargepoint_module.py
+++ b/packages/modules/chargepoints/external_openwb/chargepoint_module.py
@@ -2,7 +2,7 @@ import time
 
 from control import data
 from helpermodules import pub, timecheck
-from helpermodules.utils.error_counter import ErrorCounterContext
+from helpermodules.utils.error_counter import CP_ERROR, ErrorTimerContext
 from modules.chargepoints.external_openwb.config import OpenWBSeries
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.abstract_device import DeviceDescriptor
@@ -16,14 +16,14 @@ class ChargepointModule(AbstractChargepoint):
         self.fault_state = FaultState(ComponentInfo(
             self.config.id,
             "Ladepunkt", "chargepoint"))
-        self.__client_error_context = ErrorCounterContext(
-            "Anhaltender Fehler beim Auslesen des Ladepunkts. Soll-Stromstärke wird zurückgesetzt.")
+        self.client_error_context = ErrorTimerContext(
+            f"openWB/set/chargepoint/{self.config.id}/get/error_timestamp", CP_ERROR, hide_exception=True)
 
     def set_current(self, current: float) -> None:
-        if self.__client_error_context.error_counter_exceeded():
+        if self.client_error_context.error_counter_exceeded():
             current = 0
         with SingleComponentUpdateContext(self.fault_state, False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 if self.config.configuration.duo_num == 0:
                     pub.pub_single("openWB/set/internal_chargepoint/0/data/set_current", current,
                                    hostname=self.config.configuration.ip_address)
@@ -37,7 +37,7 @@ class ChargepointModule(AbstractChargepoint):
 
     def get_values(self) -> None:
         with SingleComponentUpdateContext(self.fault_state, update_always=False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 num = self.config.id
                 if ip_address == "localhost":
@@ -56,11 +56,11 @@ class ChargepointModule(AbstractChargepoint):
                 else:
                     pub.pub_single("openWB/set/internal_chargepoint/0/data/parent_cp", str(num), hostname=ip_address)
                     pub.pub_single("openWB/set/isss/parentCPlp1", str(num), hostname=ip_address)
-                self.__client_error_context.reset_error_counter()
+                self.client_error_context.reset_error_counter()
 
     def switch_phases(self, phases_to_use: int, duration: int) -> None:
         with SingleComponentUpdateContext(self.fault_state, False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 pub.pub_single(
                     f"openWB/set/internal_chargepoint/{self.config.configuration.duo_num}/data/phases_to_use",
                     phases_to_use,
@@ -75,7 +75,7 @@ class ChargepointModule(AbstractChargepoint):
 
     def interrupt_cp(self, duration: int) -> None:
         with SingleComponentUpdateContext(self.fault_state, False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 if (self.config.configuration.duo_num == 1):
                     pub.pub_single("openWB/set/internal_chargepoint/1/data/cp_interruption_duration",
@@ -89,7 +89,7 @@ class ChargepointModule(AbstractChargepoint):
 
     def clear_rfid(self) -> None:
         with SingleComponentUpdateContext(self.fault_state):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 pub.pub_single("openWB/set/isss/ClearRfid", 1, hostname=ip_address)
                 pub.pub_single("openWB/set/internal_chargepoint/last_tag", None, hostname=ip_address)

--- a/packages/modules/chargepoints/openwb_pro/chargepoint_module.py
+++ b/packages/modules/chargepoints/openwb_pro/chargepoint_module.py
@@ -2,7 +2,7 @@
 import logging
 import time
 
-from helpermodules.utils.error_counter import ErrorCounterContext
+from helpermodules.utils.error_counter import CP_ERROR, ErrorTimerContext
 from modules.chargepoints.openwb_pro.config import OpenWBPro
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.abstract_device import DeviceDescriptor
@@ -27,26 +27,27 @@ class ChargepointModule(AbstractChargepoint):
             self.config.id,
             "Ladepunkt", "chargepoint"))
         self.__session = req.get_http_session()
-        self.__client_error_context = ErrorCounterContext(
-            "Anhaltender Fehler beim Auslesen des Ladepunkts. Sollstromstärke wird zurückgesetzt.")
+        self.client_error_context = ErrorTimerContext(
+            f"openWB/set/chargepoint/{self.config.id}/get/error_timestamp", CP_ERROR, hide_exception=True)
+        self.old_chargepoint_state = ChargepointState()
 
         with SingleComponentUpdateContext(self.fault_state, False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 self.__session.post(
                     'http://' + self.config.configuration.ip_address + '/connect.php',
                     data={'heartbeatenabled': '1'})
 
     def set_current(self, current: float) -> None:
-        if self.__client_error_context.error_counter_exceeded():
+        if self.client_error_context.error_counter_exceeded():
             current = 0
         with SingleComponentUpdateContext(self.fault_state, False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 self.__session.post('http://'+ip_address+'/connect.php', data={'ampere': current})
 
     def get_values(self) -> None:
         with SingleComponentUpdateContext(self.fault_state):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 json_rsp = self.__session.get('http://'+ip_address+'/connect.php').json()
 
@@ -82,7 +83,15 @@ class ChargepointModule(AbstractChargepoint):
 
                 self.validate_values(chargepoint_state)
                 self.store.set(chargepoint_state)
-                self.__client_error_context.reset_error_counter()
+                self.old_chargepoint_state = chargepoint_state
+                self.client_error_context.reset_error_counter()
+            if self.client_error_context.error_counter_exceeded():
+                chargepoint_state = ChargepointState()
+                chargepoint_state.plug_state = False
+                chargepoint_state.charge_state = False
+                chargepoint_state.imported = self.old_chargepoint_state.imported
+                chargepoint_state.exported = self.old_chargepoint_state.exported
+                self.store.set(chargepoint_state)
 
     def validate_values(self, chargepoint_state: ChargepointState) -> None:
         if chargepoint_state.charge_state is False and max(chargepoint_state.currents) > 1:
@@ -92,7 +101,7 @@ class ChargepointModule(AbstractChargepoint):
 
     def switch_phases(self, phases_to_use: int, duration: int) -> None:
         with SingleComponentUpdateContext(self.fault_state, False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 response = self.__session.get('http://'+ip_address+'/connect.php')
                 if response.json()["phases_target"] != phases_to_use:

--- a/packages/modules/chargepoints/smartwb/chargepoint_module.py
+++ b/packages/modules/chargepoints/smartwb/chargepoint_module.py
@@ -1,6 +1,6 @@
 
 import time
-from helpermodules.utils.error_counter import ErrorCounterContext
+from helpermodules.utils.error_counter import CP_ERROR, ErrorTimerContext
 from modules.chargepoints.smartwb.config import SmartWB
 from modules.common.abstract_chargepoint import AbstractChargepoint
 from modules.common.abstract_device import DeviceDescriptor
@@ -18,16 +18,16 @@ class ChargepointModule(AbstractChargepoint):
         self.fault_state = FaultState(ComponentInfo(
             self.config.id,
             "Ladepunkt", "chargepoint"))
-        self.__client_error_context = ErrorCounterContext(
-            "Anhaltender Fehler beim Auslesen des Ladepunkts. Soll-Stromstärke wird zurückgesetzt.")
+        self.client_error_context = ErrorTimerContext(
+            f"openWB/set/chargepoint/{self.config.id}/get/error_timestamp", CP_ERROR, hide_exception=True)
         self.phases_in_use = 1
         self.session = req.get_http_session()
 
     def set_current(self, current: float) -> None:
-        if self.__client_error_context.error_counter_exceeded():
+        if self.client_error_context.error_counter_exceeded():
             current = 0
         with SingleComponentUpdateContext(self.fault_state, False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 timeout = self.config.configuration.timeout
                 # Stromvorgabe in Hundertstel Ampere
@@ -36,7 +36,7 @@ class ChargepointModule(AbstractChargepoint):
 
     def get_values(self) -> None:
         with SingleComponentUpdateContext(self.fault_state):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 timeout = self.config.configuration.timeout
                 response = self.session.get('http://'+ip_address+'/getParameters', timeout=timeout)
@@ -91,18 +91,18 @@ class ChargepointModule(AbstractChargepoint):
                 )
 
                 self.store.set(chargepoint_state)
-                self.__client_error_context.reset_error_counter()
+                self.client_error_context.reset_error_counter()
 
     def clear_rfid(self) -> None:
         with SingleComponentUpdateContext(self.fault_state):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 timeout = self.config.configuration.timeout
                 req.get_http_session().get('http://'+ip_address+'/clearRfid', timeout=(timeout, None))
 
     def interrupt_cp(self, duration: int) -> None:
         with SingleComponentUpdateContext(self.fault_state, False):
-            with self.__client_error_context:
+            with self.client_error_context:
                 ip_address = self.config.configuration.ip_address
                 timeout = self.config.configuration.timeout
                 req.get_http_session().get(


### PR DESCRIPTION
Die Fehlermeldung wird erst nach 60s im Frontend angezeigt, vorher wird sie nur ins Log geschreiben.

Zeitstempel statt Fehlerzähler, damit es unabhängig vom Regelintervall ist