### PR TITLE
rename Sdm630 to Sdm630_72

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -496,10 +496,6 @@ class Chargepoint(ChargepointRfidMixin):
                         # Wenn keine Phasenumschaltung durchgeführt wird, Status auf CHARGING_ALLOWED setzen, sonst
                         # bleibt PHASE_SWITCH_DELAY_EXPIRED stehen.
                         self.data.control_parameter.state = ChargepointState.CHARGING_ALLOWED
-                else:
-                    log.error(
-                        "Phasenumschaltung an Ladepunkt" + str(self.num) +
-                        " nicht möglich, da der Ladepunkt keine Phasenumschaltung unterstützt.")
         except Exception:
             log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num))
 

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -289,6 +289,8 @@ class Counter:
                     self.data.set.reserved_surplus += power_to_reserve
                     message = self.SWITCH_ON_WAITING.format(timecheck.convert_timestamp_delta_to_time_string(
                         timestamp_switch_on_off, pv_config.switch_on_delay))
+                    if feed_in_limit:
+                        message += "Die Einspeisegrenze wird berücksichtigt."
                     control_parameter.state = ChargepointState.SWITCH_ON_DELAY
                 else:
                     # Einschaltschwelle nicht erreicht

--- a/packages/modules/common/hardware_check_test.py
+++ b/packages/modules/common/hardware_check_test.py
@@ -47,9 +47,9 @@ def test_hardware_check_fails(evse_side_effect,
     mock_evse_facotry = Mock(spec=Evse, return_value=mock_evse_client)
     monkeypatch.setattr(ClientHandler, "_evse_factory", mock_evse_facotry)
 
-    mock_meter_client = Mock(spec=sdm.Sdm630, get_voltages=Mock(
+    mock_meter_client = Mock(spec=sdm.Sdm630_72, get_voltages=Mock(
         side_effect=meter_side_effect, return_value=meter_return_value))
-    mock_find_meter_client = Mock(spec=sdm.Sdm630, return_value=mock_meter_client)
+    mock_find_meter_client = Mock(spec=sdm.Sdm630_72, return_value=mock_meter_client)
     monkeypatch.setattr(ClientHandler, "find_meter_client", mock_find_meter_client)
 
     handle_exception_mock = Mock(side_effect=handle_exception_side_effect, return_value=handle_exception_return_value)
@@ -69,8 +69,8 @@ def test_hardware_check_succeeds(monkeypatch):
     mock_evse_facotry = Mock(spec=Evse, return_value=mock_evse_client)
     monkeypatch.setattr(ClientHandler, "_evse_factory", mock_evse_facotry)
 
-    mock_meter_client = Mock(spec=sdm.Sdm630, get_voltages=Mock(return_value=[230]*3))
-    mock_find_meter_client = Mock(spec=sdm.Sdm630, return_value=mock_meter_client)
+    mock_meter_client = Mock(spec=sdm.Sdm630_72, get_voltages=Mock(return_value=[230]*3))
+    mock_find_meter_client = Mock(spec=sdm.Sdm630_72, return_value=mock_meter_client)
     monkeypatch.setattr(ClientHandler, "find_meter_client", mock_find_meter_client)
 
     mock_modbus_client = MagicMock(spec=ModbusClient)

--- a/packages/modules/common/sdm.py
+++ b/packages/modules/common/sdm.py
@@ -27,7 +27,7 @@ class Sdm(AbstractCounter):
         return str(self.client.read_holding_registers(0xFC00, ModbusDataType.UINT_32, unit=self.id))
 
 
-class Sdm630(Sdm):
+class Sdm630_72(Sdm):
     def __init__(self, modbus_id: int, client: modbus.ModbusTcpClient_) -> None:
         super().__init__(modbus_id, client)
 

--- a/packages/modules/devices/openwb_flex/bat.py
+++ b/packages/modules/devices/openwb_flex/bat.py
@@ -7,7 +7,7 @@ from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.lovato import Lovato
-from modules.common.sdm import Sdm630
+from modules.common.sdm import Sdm630_72
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.openwb_flex.config import BatKitFlexSetup
@@ -34,7 +34,7 @@ class BatKitFlex:
         # TCP-Verbindung schließen möglichst bevor etwas anderes gemacht wird, um im Fehlerfall zu verhindern,
         # dass offene Verbindungen den Modbus-Adapter blockieren.
         with self.__tcp_client:
-            if isinstance(self.__client, Sdm630):
+            if isinstance(self.__client, Sdm630_72):
                 _, power = self.__client.get_power()
                 power = power * -1
             else:

--- a/packages/modules/devices/openwb_flex/versions.py
+++ b/packages/modules/devices/openwb_flex/versions.py
@@ -6,13 +6,13 @@ from modules.common import sdm
 
 
 def kit_counter_version_factory(
-        version: int) -> Type[Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm.Sdm630, b23.B23]]:
+        version: int) -> Type[Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm.Sdm630_72, b23.B23]]:
     if version == 0:
         return mpm3pm.Mpm3pm
     elif version == 1:
         return lovato.Lovato
     elif version == 2:
-        return sdm.Sdm630
+        return sdm.Sdm630_72
     elif version == 3:
         return b23.B23
     else:
@@ -20,35 +20,35 @@ def kit_counter_version_factory(
 
 
 def kit_inverter_version_factory(
-        version: int) -> Type[Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm.Sdm630, sdm.Sdm120]]:
+        version: int) -> Type[Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm.Sdm630_72, sdm.Sdm120]]:
     if version == 0:
         return mpm3pm.Mpm3pm
     elif version == 1:
         return lovato.Lovato
     elif version == 2:
-        return sdm.Sdm630
+        return sdm.Sdm630_72
     elif version == 3:
         return sdm.Sdm120
     else:
         raise ValueError("Version "+str(version) + " unbekannt.")
 
 
-def kit_bat_version_factory(version: int) -> Type[Union[mpm3pm.Mpm3pm, sdm.Sdm630, sdm.Sdm120]]:
+def kit_bat_version_factory(version: int) -> Type[Union[mpm3pm.Mpm3pm, sdm.Sdm630_72, sdm.Sdm120]]:
     if version == 0:
         return mpm3pm.Mpm3pm
     elif version == 1:
         return sdm.Sdm120
     elif version == 2:
-        return sdm.Sdm630
+        return sdm.Sdm630_72
     else:
         raise ValueError("Version "+str(version) + " unbekannt.")
 
 
-def consumption_counter_factory(type: str) -> Type[Union[sdm.Sdm120, sdm.Sdm630, b23.B23]]:
+def consumption_counter_factory(type: str) -> Type[Union[sdm.Sdm120, sdm.Sdm630_72, b23.B23]]:
     if type == "sdm120":
         return sdm.Sdm120
     elif type == "sdm630":
-        return sdm.Sdm630
+        return sdm.Sdm630_72
     elif type == "b23":
         return b23.B23
     else:

--- a/packages/modules/internal_chargepoint_handler/clients.py
+++ b/packages/modules/internal_chargepoint_handler/clients.py
@@ -15,13 +15,13 @@ log = logging.getLogger(__name__)
 
 BUS_SOURCES = ("/dev/ttyUSB0", "/dev/ttyUSB1", "/dev/ttyACM0", "/dev/serial0")
 
-METERS = Union[mpm3pm.Mpm3pm, sdm.Sdm630, b23.B23]
+METERS = Union[mpm3pm.Mpm3pm, sdm.Sdm630_72, b23.B23]
 meter_config = NamedTuple("meter_config", [('type', METERS), ('modbus_id', int)])
 CP0_METERS = [meter_config(mpm3pm.Mpm3pm, modbus_id=5),
-              meter_config(sdm.Sdm630, modbus_id=105),
+              meter_config(sdm.Sdm630_72, modbus_id=105),
               meter_config(b23.B23, modbus_id=201)]
 
-CP1_METERS = [meter_config(mpm3pm.Mpm3pm, modbus_id=6), meter_config(sdm.Sdm630, modbus_id=106)]
+CP1_METERS = [meter_config(mpm3pm.Mpm3pm, modbus_id=6), meter_config(sdm.Sdm630_72, modbus_id=106)]
 
 EVSE_ID_CP0 = [1]
 EVSE_ID_TWO_BUSSES_CP1 = [1, 2]

--- a/packages/modules/web_themes/standard_legacy/web/index.html
+++ b/packages/modules/web_themes/standard_legacy/web/index.html
@@ -660,7 +660,7 @@
 										<div
 											class="form-row form-group mb-1 vaRow regularTextSize chargemode-limit-option chargemode-limit-option-soc">
 											<div class="col">
-												Maximaler SoC
+												SoC-Limit für das Fahrzeug
 											</div>
 											<div class="col-md-8">
 												<div class="form-row form-group mb-1 vaRow">
@@ -679,7 +679,7 @@
 										<div
 											class="form-row form-group mb-1 vaRow regularTextSize chargemode-limit-option chargemode-limit-option-amount">
 											<div class="col">
-												Zu ladende Energie
+												Energie-Limit
 											</div>
 											<div class="col-md-8">
 												<div class="form-row form-group mb-1 vaRow">
@@ -722,7 +722,7 @@
 									</div>
 									<div class="form-row vaRow mb-0">
 										<div class="col">
-											Mindest-SoC
+											Mindest-SoC für das Fahrzeug
 										</div>
 										<div class="col-md-8">
 											<div class="form-row form-group mb-1 vaRow">
@@ -761,7 +761,7 @@
 									</div>
 									<div class="form-row vaRow mb-0">
 										<div class="col">
-											SoC-Limit
+											SoC-Limit für das Fahrzeug
 										</div>
 										<div class="col-md-8">
 											<div class="form-row form-group mb-1 vaRow">

--- a/packages/smarthome/smartmeas.py
+++ b/packages/smarthome/smartmeas.py
@@ -512,7 +512,7 @@ class Slsdm630(Slbase):
         try:
             # neu aus openwb 2.0
             with modbus.ModbusTcpClient_(self._device_measureip, self._device_measureportsdm) as tcp_client:
-                sdm630 = sdm.Sdm630(self._device_measureid, tcp_client)
+                sdm630 = sdm.Sdm630_72(self._device_measureid, tcp_client)
                 # log.warning(" sdm630 id %s " % ( str(id(sdm630))))
                 _, newwatt = sdm630.get_power()
                 self.newwatt = int(newwatt)


### PR DESCRIPTION
Führt sonst zu falschen Rückschlüssen, welcher Zähler verbaut ist.
Leider bietet der Zähler kein Register, aus dem man das Modell ablesen kann.