### PR TITLE
run handler10sec first

### DIFF
--- a/packages/main.py
+++ b/packages/main.py
@@ -254,6 +254,9 @@ try:
     Pub().pub("openWB/set/system/boot_done", True)
     Path(Path(__file__).resolve().parents[1]/"ramdisk"/"bootdone").touch()
     schedule_jobs()
+    if event_jobs_running.is_set():
+        # Nach dem Starten als erstes den 10Sek-Handler aufrufen, damit die Werte der data.data initialisiert werden.
+        handler.handler10Sec()
 except Exception:
     log.exception("Fehler im Main-Modul")
 


### PR DESCRIPTION
Wenn genau zum 5 Minuten-Wechsel gestartet wird, läuft als erster Job der 5 Minuten Handler und löscht die Struktur.