### PR TITLE
SOC-Module bmwbc: get km-Stand/mileage from server and show in log on level info

### DIFF
--- a/packages/modules/vehicles/bmwbc/api.py
+++ b/packages/modules/vehicles/bmwbc/api.py
@@ -105,12 +105,13 @@ async def _fetch_soc(user_id: str, password: str, vin: str, vnum: int) -> Union[
         # get soc, range, lastUpdated from vehicle data
         soc = int(state['electricChargingState']['chargingLevelPercent'])
         range = float(state['electricChargingState']['range'])
+        kms = int(state['currentMileage'])
         lastUpdatedAt = state['lastUpdatedAt']
 
         # save the vehicle data for further analysis if required
         dump_json(respd, '/soc_bmwbc_reply_vehicle_' + str(vnum))
 
-        log.info(" SOC/Range: " + str(soc) + '%/' + str(range) + 'KM@' + lastUpdatedAt)
+        log.info(" SOC/Range: " + str(soc) + '%/' + str(range) + 'KM@' + lastUpdatedAt + ", km-Stand: " + str(kms))
 
         # store token and expires_at if changed
         expires_at = datetime.datetime.isoformat(auth.expires_at)


### PR DESCRIPTION
small addition: 
Read mileage/km-Stand from server response and show in soc.log on level info.
In case km-Stand will be represented in a future extended CarState it is ready to be added.