### PR TITLE
consider min current for calculation of scheduled charging duration

### DIFF
--- a/packages/control/ev_charge_template_test.py
+++ b/packages/control/ev_charge_template_test.py
@@ -172,7 +172,7 @@ def test_calculate_duration(selected: str, phases: int, expected_duration: float
     plan = ScheduledChargingPlan()
     plan.limit.selected = selected
     # execution
-    duration, missing_amount = ct.calculate_duration(plan, 60, 45000, 200, phases, ChargingType.AC.value)
+    duration, missing_amount = ct.calculate_duration(plan, 60, 45000, 200, phases, ChargingType.AC.value, EvTemplate())
 
     # evaluation
     assert duration == expected_duration


### PR DESCRIPTION
> Ich hatte im Zielladen einen Strom von 6A eingestellt.
Das Zielladen begann dann zum entsprechenden Zeitpunkt, der auf Basis der 6A berechnet wurde.
Das Fahrzeug lud dann aber mit 12A, da dies im Fahrzeugprofil als Mindeststrom eingestellt war.
Dann wurde wieder abgeschaltet, da genug Zeit bis zum Ziel durch das schnellere Laden zur Verfügung stand.

https://forum.openwb.de/viewtopic.php?p=116365#p116365