### PR TITLE
Set imported and exported en energy values for EvuKitFlex with SDM meters

### DIFF
--- a/packages/modules/devices/openwb/openwb_flex/counter.py
+++ b/packages/modules/devices/openwb/openwb_flex/counter.py
@@ -9,6 +9,7 @@ from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.lovato import Lovato
 from modules.common.mpm3pm import Mpm3pm
 from modules.common.b23 import B23
+from modules.common.sdm import Sdm
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.openwb.openwb_flex.config import EvuKitFlexSetup
@@ -40,7 +41,11 @@ class EvuKitFlex:
             frequency = self.__client.get_frequency()
             power_factors = self.__client.get_power_factors()
 
-            if isinstance(self.__client, Mpm3pm or B23):
+            if isinstance(self.__client, Sdm):
+                imported = self.__client.get_imported()
+                exported = self.__client.get_exported()
+                currents = self.__client.get_currents()
+            elif isinstance(self.__client, Mpm3pm or B23):
                 imported = self.__client.get_imported()
                 exported = self.__client.get_exported()
             else:


### PR DESCRIPTION
Potentially adresses [Ticket #74832726]

The values for total imported and exported energy are not set at all when SDM meters (e.g. SDM630, SDM72 or SDM120) are being used as EvuKitFlex.

However I cannot test this as the above ticket is coming from one of our customers and I don't have a setup similar to customer available.

Please double-check carefully whether the fix is correct. I think SDMs do directly deliver the imported and exported energies so no special handling is required. Additionally I copied the current setting from the "else" path into the SDM path as currents have been working fine so far at customer's system.