### PR TITLE
Programmierbarer Zustand des potentialfreien Kontakts für Ladefreigabe dimm_kit

### DIFF
--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -49,7 +49,7 @@ NO_MODULE = {"type": None, "configuration": {}}
 
 
 class UpdateConfig:
-    DATASTORE_VERSION = 65
+    DATASTORE_VERSION = 66
     valid_topic = [
         "^openWB/bat/config/configured$",
         "^openWB/bat/config/power_limit_mode$",
@@ -1839,3 +1839,16 @@ class UpdateConfig:
             '<a href="https://wb-solution.de/shop/">https://wb-solution.de/shop/</a>',
             MessageType.INFO)
         self.__update_topic("openWB/system/datastore_version", 65)
+
+    def upgrade_datastore_65(self) -> None:
+        def upgrade(topic: str, payload) -> Optional[dict]:
+            if "openWB/general/ripple_control_receiver/module" == topic:
+                configuration_payload = decode_payload(payload)
+                if configuration_payload.get("type") == "dimm_kit":
+                    if configuration_payload["configuration"].get("sw_ok") is None:
+                        configuration_payload["configuration"].update({
+                            "sw_ok": "CLOSED",
+                        })
+                    return {topic: configuration_payload}
+        self._loop_all_received_topics(upgrade)
+        self.__update_topic("openWB/system/datastore_version", 66)

--- a/packages/modules/ripple_control_receivers/dimm_kit/config.py
+++ b/packages/modules/ripple_control_receivers/dimm_kit/config.py
@@ -2,10 +2,12 @@ from typing import Optional
 
 
 class IoLanRcrConfiguration:
-    def __init__(self, ip_address: Optional[str] = None, port: int = 8899, modbus_id: int = 1):
+    def __init__(self, ip_address: Optional[str] = None, port: int = 8899, modbus_id: int = 1,
+                 sw_ok: str = "CLOSED"):
         self.ip_address = ip_address
         self.port = port
         self.modbus_id = modbus_id
+        self.sw_ok = sw_ok
 
 
 class IoLanRcr:

--- a/packages/modules/ripple_control_receivers/dimm_kit/ripple_control_receiver.py
+++ b/packages/modules/ripple_control_receivers/dimm_kit/ripple_control_receiver.py
@@ -25,7 +25,8 @@ def create_ripple_control_receiver(config: IoLanRcr):
         r1 = State(client.read_coils(0x0000, 1, unit=config.configuration.modbus_id))
         r2 = State(client.read_coils(0x0001, 1, unit=config.configuration.modbus_id))
         log.debug(f"RSE-Kontakt 1: {r1}, RSE-Kontakt 2: {r2}")
-        if r1 == State.OPENED or r2 == State.OPENED:
+        state_ok = State[config.configuration.sw_ok]
+        if r1 is not state_ok or r2 is not state_ok:
             override_value = 0
         else:
             override_value = 100


### PR DESCRIPTION
Unter Netzbetreibern gibt es kein einheitliches Vorgehen zu der Frage, ob der potentialfreie Kontakt für Ladefreigabe geschlossen oder geöffnet sein muss. Wallboxen von Konkurrenten haben deshalb eine Konfigurationsmöglichkeit hierfür. Dieser Pull-Request fügt die Konfigurationsmöglichkeit hinzu. Der Default-Zustand ist weiterhin "CLOSED" für Ladefreigabe. Datastore wird über Upgrade-Mechanismus aktualisiert. Die Versionsnummern hierbei müssen ggf. hochgesetzt werden, je nachdem wann dieser Pull-Request gemergt wird.
Der zugehörige Pull-Request für die GUI folgt.