### PR TITLE
improve deviating evse current

### DIFF
--- a/packages/control/algorithm/surplus_controlled.py
+++ b/packages/control/algorithm/surplus_controlled.py
@@ -134,9 +134,12 @@ class SurplusControlled:
         """Wenn Autos nicht die volle Ladeleistung nutzen, wird unnötig eingespeist. Dann kann um den noch nicht
         genutzten Soll-Strom hochgeregelt werden. Wenn Fahrzeuge entgegen der Norm mehr Ladeleistung beziehen, als
         freigegeben, wird entsprechend weniger freigegeben, da sonst uU die untere Grenze für die Abschaltschwelle
-        nicht erreicht wird."""
+        nicht erreicht wird.
+        Wenn die Soll-Stromstärke nicht angepasst worden ist, nicht den ungenutzten EVSE-Strom aufschlagen. Wenn das
+        Auto nur in 1A-Schritten regeln kann, rundet es und lädt immer etwas mehr oder weniger als Soll-Strom. Schlägt
+        man den EVSE-Strom auf, pendelt die Regelung um diesen 1A-Schritt."""
         evse_current = chargepoint.data.get.evse_current
-        if evse_current:
+        if evse_current and chargepoint.data.set.current != chargepoint.set_current_prev:
             formatted_evse_current = evse_current if evse_current < 32 else evse_current / 100
             current_with_offset = chargepoint.data.set.current + \
                 formatted_evse_current - max(chargepoint.data.get.currents)

--- a/packages/control/algorithm/surplus_controlled_test.py
+++ b/packages/control/algorithm/surplus_controlled_test.py
@@ -119,15 +119,13 @@ def test_add_unused_evse_current(evse_current: float,
     c.data.get.currents = [15]*3
     c.data.get.evse_current = evse_current
     c.data.control_parameter.required_current = required_current
+    c.data.set.current = limited_current
 
     # execution
-    current = SurplusControlled()._fix_deviating_evse_current(limited_current, c)
-
-    # assertion
-    assert current == expected_current
+    SurplusControlled()._fix_deviating_evse_current(c)
 
     # evaluation
-    assert current == expected_current
+    assert c.data.set.current == expected_current
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Die Methode zum Aufschlagen des Überschuss wird für jeden Zähler aufgerufen. Bisher wurde bei jedem Zähler die Abweichung vom Soll-Strom aufgeschlagen, nun wird dies erst am Ende vorgenommen. Außerdem erfolgt das Aufschlagen erst nach dem Berechnen des Lastmanagements, da das Auto dadurch ja mit der eigentlichen Soll-Stromstärke laden soll, die auch im LM berücksichtigt worden ist. Das Aufschlagen ergibt einen angepassten Sollstrom, um das Auto dazu zu bringen, mit der gewünschten Stromstärke zu laden.

Wenn die Soll-Stromstärke nicht angepasst worden ist, nicht den ungenutzten EVSE-Strom aufschlagen. Wenn das
Auto nur in 1A-Schritten regeln kann, rundet es und lädt immer etwas mehr oder weniger als Soll-Strom. Schlägt
man den EVSE-Strom auf, pendelt die Regelung um diesen 1A-Schritt.

https://forum.openwb.de/viewtopic.php?p=118001#p118001
https://forum.openwb.de/viewtopic.php?p=118169#p118169