### PR TITLE
Rvert: Bump cryptography from 42.0.4 to 43.0.1(#1867)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bs4==0.0.1
 pkce==1.0.3
 # skodaconnect==1.3.4
 evdev==1.5.0
-cryptography==43.0.1
+cryptography==42.0.4
 msal==1.27.0
 python-dateutil==2.8.2
 umodbus==1.0.4


### PR DESCRIPTION
Die neue Version des cryptography-Pakets stellt keine kompilierten Sourcen bereit. Die lokale Kompilierung nimmt mitunter sehr viel Zeit in Anspruch.