### PR TITLE
use imported and exported from broker if simcount is used for configu…

### DIFF
--- a/packages/modules/common/simcount/_simcounter_store.py
+++ b/packages/modules/common/simcount/_simcounter_store.py
@@ -174,7 +174,8 @@ class SimCounterStoreRamdisk(SimCounterStore):
 
 class SimCounterStoreBroker(SimCounterStore):
     def initialize(self, prefix: str, topic: str, power: float, timestamp: float) -> SimCounterState:
-        state = SimCounterState(timestamp, power, imported=0, exported=0)
+        state = SimCounterState(timestamp, power, imported=restore_last_energy(
+            topic, "imported"), exported=restore_last_energy(topic, "exported"))
         self.save(prefix, topic, state)
         return state
 


### PR DESCRIPTION
…red module

Betrifft den PR #1961 dort wird vom Auslesen der Zählerstände auf simcount umgestellt. Dann sollte nicht wieder bei 0kWh angefangen werden, sondern vom ausgelesenen Wert weitergerechnet werden.