### PR TITLE
wait for using phases after charge start

### DIFF
--- a/packages/control/algorithm/common_test.py
+++ b/packages/control/algorithm/common_test.py
@@ -49,6 +49,7 @@ def test_set_current_counterdiff(diff: float,
     cp.data.control_parameter.required_currents = required_currents
     cp.data.set.charging_ev_data = ev
     cp.data.set.current = 6
+    cp.data.get.currents = [10]*3
     get_counters_to_check_mock = Mock(return_value=["cp0", "cp6"])
     monkeypatch.setattr(CounterAll, "get_counters_to_check", get_counters_to_check_mock)
     data.data.counter_data = {"cp0": Mock(spec=Counter), "cp6": Mock(spec=Counter)}

--- a/packages/control/auto_phase_switch_test.py
+++ b/packages/control/auto_phase_switch_test.py
@@ -88,7 +88,7 @@ cases = [
            timestamp_auto_phase_switch=1652682772.0, phases_to_use=1, required_current=6,
            evu_surplus=1640, get_currents=[15.6, 0, 0], get_power=3450,
            state=ChargepointState.PHASE_SWITCH_DELAY,
-           expected_phases_to_use=3, expected_current=6, expected_state=ChargepointState.PHASE_SWITCH_DELAY_EXPIRED),
+           expected_phases_to_use=3, expected_current=6, expected_state=ChargepointState.PHASE_SWITCH_AWAITED),
 
     Params("3to1, not enough power, start timer", max_current_single_phase=16, timestamp_auto_phase_switch=None,
            phases_to_use=3, required_current=6, evu_surplus=0,
@@ -116,7 +116,7 @@ cases = [
            timestamp_auto_phase_switch=1652682592.0, phases_to_use=3, required_current=6,
            evu_surplus=-460, get_currents=[4.5, 4.4, 5.8],
            get_power=3381, state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=1, expected_current=16,
-           expected_state=ChargepointState.PHASE_SWITCH_DELAY_EXPIRED),
+           expected_state=ChargepointState.PHASE_SWITCH_AWAITED),
 ]
 
 

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -37,7 +37,7 @@ from helpermodules.pub import Pub
 from helpermodules import timecheck
 from helpermodules.utils import thread_handler
 from modules.common.abstract_chargepoint import AbstractChargepoint
-from helpermodules.timecheck import create_timestamp
+from helpermodules.timecheck import check_timestamp, create_timestamp
 
 
 def get_chargepoint_config_default() -> dict:
@@ -304,6 +304,7 @@ class Chargepoint(ChargepointRfidMixin):
 
     def remember_previous_values(self):
         self.data.set.plug_state_prev = self.data.get.plug_state
+        self.set_current_prev = self.data.set.current
         Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/plug_state_prev", self.data.set.plug_state_prev)
 
     def reset_log_data_chargemode_switch(self) -> None:
@@ -440,7 +441,9 @@ class Chargepoint(ChargepointRfidMixin):
                     self.set_state_and_log(message)
                 return
             if self.data.control_parameter.state == ChargepointState.WAIT_FOR_USING_PHASES:
-                if phase_switch.phase_switch_thread_alive(self.num) is False:
+                if (phase_switch.phase_switch_thread_alive(self.num) is False and
+                        check_timestamp(self.data.control_parameter.timestamp_charge_start,
+                                        charging_ev.ev_template.data.keep_charge_active_duration) is False):
                     self.data.control_parameter.state = ChargepointState.CHARGING_ALLOWED
         except Exception:
             log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num))
@@ -613,21 +616,15 @@ class Chargepoint(ChargepointRfidMixin):
                                    "was ggf eine unnötige Reduktion der Ladeleistung zur Folge hat.")
         self.data.set.required_power = sum(control_parameter.required_currents) * 230
 
-    def handle_less_power(self):
-        if self.data.set.current != 0 and self.data.control_parameter.state == ChargepointState.CHARGING_ALLOWED:
-            nominal_difference = self.data.set.charging_ev_data.ev_template.data.nominal_difference
-            if self.data.set.current - nominal_difference > max(self.data.get.currents):
-                if self.data.control_parameter.timestamp_charge_start is None:
-                    self.data.control_parameter.timestamp_charge_start = create_timestamp()
-            else:
-                self.data.control_parameter.timestamp_charge_start = None
-        else:
-            # Beim Ladestart Timer laufen lassen, manche Fahrzeuge brauchen sehr lange.
+    def set_timestamp_charge_start(self):
+        # Beim Ladestart Timer laufen lassen, manche Fahrzeuge brauchen sehr lange.
+        if self.data.control_parameter.timestamp_charge_start is None:
+            if self.set_current_prev == 0 and self.data.set.current != 0:
+                self.data.control_parameter.timestamp_charge_start = create_timestamp()
+        elif self.data.set.current == 0:
             self.data.control_parameter.timestamp_charge_start = None
 
     def update_ev(self, ev_list: Dict[str, Ev]) -> None:
-        # Für Control-Pilot-Unterbrechung set current merken.
-        self.set_current_prev = self.data.set.current
         self._validate_rfid()
         charging_possible = self.is_charging_possible()[0]
         if charging_possible:
@@ -642,8 +639,6 @@ class Chargepoint(ChargepointRfidMixin):
 
     def update(self, ev_list: Dict[str, Ev]) -> None:
         try:
-            # Für Control-Pilot-Unterbrechung set current merken.
-            self.set_current_prev = self.data.set.current
             self._validate_rfid()
             charging_possible, message = self.is_charging_possible()
             if self.data.get.rfid is not None and self.data.get.plug_state:
@@ -677,7 +672,7 @@ class Chargepoint(ChargepointRfidMixin):
                     charging_ev.set_submode_changed(self.data.control_parameter, submode)
                     self.set_control_parameter(submode, required_current)
                     self.set_required_currents(required_current)
-                    self.handle_less_power()
+                    self.set_timestamp_charge_start()
                     self.check_phase_switch_completed()
 
                     if charging_ev.chargemode_changed:

--- a/packages/control/chargepoint/chargepoint_state.py
+++ b/packages/control/chargepoint/chargepoint_state.py
@@ -9,14 +9,14 @@ class ChargepointState(IntEnum):
     CHARGING_ALLOWED = 4
     SWITCH_OFF_DELAY = 5
     SWITCH_ON_DELAY = 6
-    PHASE_SWITCH_DELAY_EXPIRED = 7
+    PHASE_SWITCH_AWAITED = 7
 
 
 CHARGING_STATES = (ChargepointState.PHASE_SWITCH_DELAY,
                    ChargepointState.WAIT_FOR_USING_PHASES,
                    ChargepointState.CHARGING_ALLOWED,
                    ChargepointState.SWITCH_OFF_DELAY,
-                   ChargepointState.PHASE_SWITCH_DELAY_EXPIRED)
+                   ChargepointState.PHASE_SWITCH_AWAITED)
 
 PHASE_SWITCH_STATES = (ChargepointState.PHASE_SWITCH_DELAY,
                        ChargepointState.PERFORMING_PHASE_SWITCH,

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -535,7 +535,7 @@ class Ev:
                         phases_to_use = new_phase
                         current = new_current
                         log.debug("Phasenumschaltung kann nun durchgeführt werden.")
-                        control_parameter.state = ChargepointState.PHASE_SWITCH_DELAY_EXPIRED
+                        control_parameter.state = ChargepointState.PHASE_SWITCH_AWAITED
                 else:
                     timestamp_auto_phase_switch = None
                     data.data.counter_all_data.get_evu_counter(

--- a/packages/control/process.py
+++ b/packages/control/process.py
@@ -35,7 +35,7 @@ class Process:
                         cp.initiate_control_pilot_interruption()
                         cp.initiate_phase_switch()
                         if control_parameter.state == ChargepointState.NO_CHARGING_ALLOWED and cp.data.set.current != 0:
-                            control_parameter.state = ChargepointState.CHARGING_ALLOWED
+                            control_parameter.state = ChargepointState.WAIT_FOR_USING_PHASES
                         self._update_state(cp)
                     else:
                         # LP, an denen nicht geladen werden darf


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?p=118475#p118475

Manche Autos brauchen nach Ladestart sehr lange, bis sie mit 3 Phasen laden, dann darf nicht vorher nochmal umgeschaltet werden. Es wird nun nach Ladestart in den Zustand WAIT_FOR_USING_PHASES gegangen und die Mindestzeit zwischen Umschaltungen abgewartet.

Außerdem wurde der Timestamp_charge_start von dem Zeitpuffer für mit geringer Leistung ladende Fahrzeuge entkoppelt.