### PR TITLE
fix the deviation only for vehicles with a larger deviation

### DIFF
--- a/packages/control/algorithm/surplus_controlled.py
+++ b/packages/control/algorithm/surplus_controlled.py
@@ -139,15 +139,17 @@ class SurplusControlled:
         Wenn die Soll-Stromstärke nicht angepasst worden ist, nicht den ungenutzten EVSE-Strom aufschlagen. Wenn das
         Auto nur in 1A-Schritten regeln kann, rundet es und lädt immer etwas mehr oder weniger als Soll-Strom. Schlägt
         man den EVSE-Strom auf, pendelt die Regelung um diesen 1A-Schritt."""
+        MAX_DEVIATION = 1.1
         evse_current = chargepoint.data.get.evse_current
         if evse_current and chargepoint.data.set.current != chargepoint.set_current_prev:
             formatted_evse_current = evse_current if evse_current < 32 else evse_current / 100
-            current_with_offset = chargepoint.data.set.current + \
-                formatted_evse_current - max(chargepoint.data.get.currents)
-            current = min(current_with_offset, chargepoint.data.control_parameter.required_current)
-            if current != chargepoint.data.set.current:
-                log.debug(f"Ungenutzten Soll-Strom aufschlagen ergibt {current}A.")
-            chargepoint.data.set.current = current
+            offset = formatted_evse_current - max(chargepoint.data.get.currents)
+            if abs(offset) >= MAX_DEVIATION:
+                current_with_offset = chargepoint.data.set.current + offset
+                current = min(current_with_offset, chargepoint.data.control_parameter.required_current)
+                if current != chargepoint.data.set.current:
+                    log.debug(f"Ungenutzten Soll-Strom aufschlagen ergibt {current}A.")
+                chargepoint.data.set.current = current
 
     def check_submode_pv_charging(self) -> None:
         evu_counter = data.data.counter_all_data.get_evu_counter()

--- a/packages/control/algorithm/surplus_controlled_test.py
+++ b/packages/control/algorithm/surplus_controlled_test.py
@@ -101,24 +101,24 @@ def test_set_required_current_to_max(phases: int,
 
 
 @pytest.mark.parametrize(
-    "evse_current, limited_current, required_current, expected_current",
+    "evse_current, limited_current, expected_current",
     [
-        pytest.param(None, 6, 16, 6, id="Kein Soll-Strom aus der EVSE ausgelesen"),
-        pytest.param(15, 15, 16, 15, id="Auto lädt mit Soll-Stromstärke"),
-        pytest.param(14.5, 14.5, 14.5, 14, id="Auto lädt mit mehr als Soll-Stromstärke"),
-        pytest.param(15.5, 15.5, 16, 16, id="Auto lädt mit weniger als Soll-Stromstärke"),
-        pytest.param(16, 16, 16, 16,
+        pytest.param(None, 6, 6, id="Kein Soll-Strom aus der EVSE ausgelesen"),
+        pytest.param(13, 13, 13, id="Auto lädt mit Soll-Stromstärke"),
+        pytest.param(12.5, 12.5, 12.5, id="Auto lädt mit 0.5A Abweichung von der Soll-Stromstärke"),
+        pytest.param(11.8, 11.8, 10.600000000000001, id="Auto lädt mit mehr als Soll-Stromstärke"),
+        pytest.param(14.2, 14.2, 15.399999999999999, id="Auto lädt mit weniger als Soll-Stromstärke"),
+        pytest.param(15, 15, 16,
                      id="Auto lädt mit weniger als Soll-Stromstärke, aber EVSE-Begrenzung ist erreicht.")
     ])
 def test_add_unused_evse_current(evse_current: float,
                                  limited_current: float,
-                                 required_current: float,
                                  expected_current: float):
     # setup
     c = Chargepoint(0, None)
-    c.data.get.currents = [15]*3
+    c.data.get.currents = [13]*3
     c.data.get.evse_current = evse_current
-    c.data.control_parameter.required_current = required_current
+    c.data.control_parameter.required_current = 16
     c.data.set.current = limited_current
 
     # execution


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?p=118547#p118547

Bei Fahrzeugen, die nur in 1A-Schritten regeln können, hat das Aufschlagen der EVSE-Abweichung in ungünstigen Fällen dazu geführt, dass durch Auf- und Abrunden des Fahrzeugs und Aufschlagen der Differenz die Regelung gesprungen ist.