### PR TITLE
update soc if new soc from cp is available

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -734,7 +734,8 @@ class Chargepoint(ChargepointRfidMixin):
                           "/set/ocpp_transaction_id", self.data.set.ocpp_transaction_id)
             # SoC nach Anstecken aktualisieren
             if ((self.data.get.plug_state and self.data.set.plug_state_prev is False) or
-                    (self.data.get.plug_state is False and self.data.set.plug_state_prev)):
+                    (self.data.get.plug_state is False and self.data.set.plug_state_prev) or
+                    (self.data.get.soc_timestamp > self.data.set.charging_ev_data.data.get.soc_timestamp)):
                 Pub().pub(f"openWB/set/vehicle/{self.data.config.ev}/get/force_soc_update", True)
                 log.debug("SoC nach Anstecken")
             self.set_state_and_log(message)

--- a/packages/modules/update_soc.py
+++ b/packages/modules/update_soc.py
@@ -103,12 +103,9 @@ class UpdateSoc:
                 if ev.soc_module.general_config.use_soc_from_cp:
                     soc_from_cp = cp.data.get.soc
                     timestamp_soc_from_cp = cp.data.get.soc_timestamp
-                    log.debug(f"cp.num {cp.num} cp.data.get {cp.data.get}")
-                    log.debug(f"1 soc_from_cp: {soc_from_cp}, timestamp_soc_from_cp: {timestamp_soc_from_cp}")
                 else:
                     soc_from_cp = None
                     timestamp_soc_from_cp = None
-                    log.debug(f"2 soc_from_cp: {soc_from_cp}, timestamp_soc_from_cp: {timestamp_soc_from_cp}")
                 break
         else:
             plug_state = False
@@ -118,7 +115,6 @@ class UpdateSoc:
             efficiency = ev_template.data.efficiency
             soc_from_cp = None
             timestamp_soc_from_cp = None
-            log.debug(f"3 soc_from_cp: {soc_from_cp}, timestamp_soc_from_cp: {timestamp_soc_from_cp}")
         return VehicleUpdateData(plug_state=plug_state,
                                  charge_state=charge_state,
                                  efficiency=efficiency,


### PR DESCRIPTION
In der aktuellen Umsetzung wird nach dem Anstecken der SoC abgefragt. Wenn das Auslesen des SoC aus dem Fahrzeug lange dauert, liefert die Pro bei manchen Fahrzeugen (zB Enyaq) erst im zweiten Zyklus nach dem Anstecken den SoC. Die Regelung aktualisiert aber nach dem Anstecken und dann im eingestellten Intervall den SoC und dann ist der Zeitstempel vom Pro-SoC schon abgelaufen.
Deshalb wird nun immer, wenn der Zeitstempel vom Pro-SoC neuer als die letzte Abfrage ist, der SoC aktualisiert. Bei DC-Ladern wird dann kontinuierlich während der Ladung der SoC aktualisiert.

https://forum.openwb.de/viewtopic.php?p=118561#p118561