### PR TITLE
voltage check for 1phase Zoe

### DIFF
--- a/packages/modules/common/hardware_check.py
+++ b/packages/modules/common/hardware_check.py
@@ -26,6 +26,8 @@ def check_meter_values(voltages: List[float]) -> Optional[str]:
     def valid_voltage(voltage) -> bool:
         return 200 < voltage < 260
     if ((valid_voltage(voltages[0]) and voltages[1] == 0 and voltages[2] == 0) or
+            # Zoe lädt einphasig an einphasiger Wallbox und erzeugt Spannung auf L2 (ca 126V)
+            (valid_voltage(voltages[0]) and 115 < voltages[1] < 135 and voltages[2] == 0) or
             (valid_voltage(voltages[0]) and valid_voltage(voltages[1]) and voltages[2] == 0) or
             (valid_voltage(voltages[0]) and valid_voltage(voltages[1]) and valid_voltage((voltages[2])))):
         return None


### PR DESCRIPTION
Zoe lädt einphasig an einphasiger Wallbox und erzeugt Spannung auf L2 (ca 126V)
#34171322