### PR TITLE
pv charging: range offset based on range mid point

### DIFF
--- a/packages/control/algorithm/integration_test/pv_charging_test.py
+++ b/packages/control/algorithm/integration_test/pv_charging_test.py
@@ -137,7 +137,7 @@ def test_start_pv_delay(all_cp_pv_charging_3p, all_cp_not_charging, monkeypatch)
     assert data.data.cp_data[
         "cp5"].data.control_parameter.timestamp_switch_on_off is None
     assert data.data.counter_data["counter0"].data.set.raw_power_left == 31775
-    assert data.data.counter_data["counter0"].data.set.surplus_power_left == 9660
+    assert data.data.counter_data["counter0"].data.set.surplus_power_left == 9890
     assert data.data.counter_data["counter0"].data.set.reserved_surplus == 9000
 
 
@@ -176,7 +176,7 @@ def test_pv_delay_expired(all_cp_pv_charging_3p, all_cp_not_charging, monkeypatc
     assert data.data.cp_data[
         "cp5"].data.control_parameter.timestamp_switch_on_off is None
     assert data.data.counter_data["counter0"].data.set.raw_power_left == 24300
-    assert data.data.counter_data["counter0"].data.set.surplus_power_left == 2185
+    assert data.data.counter_data["counter0"].data.set.surplus_power_left == 2415
     assert data.data.counter_data["counter0"].data.set.reserved_surplus == 0
 
 
@@ -214,7 +214,7 @@ cases_limit = [
                   expected_current_cp4=6,
                   expected_current_cp5=6,
                   expected_raw_power_left=5635,
-                  expected_surplus_power_left=-16480.0,
+                  expected_surplus_power_left=-16250.0,
                   expected_reserved_surplus=0,
                   expected_released_surplus=11040),
 ]
@@ -250,7 +250,7 @@ cases_phase_switch = [
                       expected_current_cp4=6,
                       expected_current_cp5=6,
                       expected_raw_power_left=17400,
-                      expected_surplus_power_left=-4715,
+                      expected_surplus_power_left=-4485,
                       expected_reserved_surplus=0,
                       expected_released_surplus=0),
     ParamsPhaseSwitch(name="phase switch 1p->3p",

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -243,13 +243,7 @@ class Counter:
         control_range_low = data.data.general_data.data.chargemode_config.pv_charging.control_range[0]
         control_range_high = data.data.general_data.data.chargemode_config.pv_charging.control_range[1]
         control_range_center = control_range_high - (control_range_high - control_range_low) / 2
-        control_range_state = self.get_control_range_state(0)
-        if control_range_state == ControlRangeState.BELOW:
-            range_offset = abs(control_range_center)
-        elif control_range_state == ControlRangeState.ABOVE:
-            range_offset = - abs(control_range_center)
-        else:
-            range_offset = 0
+        range_offset = control_range_center
         log.debug(f"Anpassen des Regelbereichs {range_offset}W")
         return range_offset
 

--- a/packages/control/counter_test.py
+++ b/packages/control/counter_test.py
@@ -156,12 +156,12 @@ def test_switch_on_threshold_reached(params: Params, caplog, general_data_fixtur
 
 
 @pytest.mark.parametrize("control_range, evu_power, expected_range_offset",
-                         [pytest.param([0, 230], 200, 0, id="Bezug, im Regelbereich"),
-                          pytest.param([0, 230], 290, -115, id="Bezug, über Regelbereich"),
+                         [pytest.param([0, 230], 200, 115, id="Bezug, im Regelbereich"),
+                          pytest.param([0, 230], 290, 115, id="Bezug, über Regelbereich"),
                           pytest.param([0, 230], -100, 115, id="Bezug, unter Regelbereich"),
-                          pytest.param([-230, 0], -104, 0, id="Einspeisung, im Regelbereich"),
+                          pytest.param([-230, 0], -104, -115, id="Einspeisung, im Regelbereich"),
                           pytest.param([-230, 0], 80, -115, id="Einspeisung, über Regelbereich"),
-                          pytest.param([-230, 0], -300, 115, id="Einspeisung, unter Regelbereich"),
+                          pytest.param([-230, 0], -300, -115, id="Einspeisung, unter Regelbereich"),
                           ],
                          )
 def test_control_range(control_range, evu_power, expected_range_offset, general_data_fixture, monkeypatch):


### PR DESCRIPTION
Beim PV-Laden muss der Regelmodus in jeden Regelzyklus beachtet werden.
Der Algorithmus will den gesamten verfügbaren Überschuss für das Laden benutzen. Um dem eingestellten Regelmodus einzuhalten, muss dann ein passender Ab- bzw. Zuschlag berücksichtigt werden.
Damit entfällt dann auch das Nachregeln, wenn die letzte Berechnung wegen geänderter Bedingungen nicht gepasst hat.