### PR TITLE
remember timestamp of last phase switch instead of waiting the whole delay

### DIFF
--- a/packages/control/algorithm/integration_test/pv_charging_test.py
+++ b/packages/control/algorithm/integration_test/pv_charging_test.py
@@ -101,9 +101,9 @@ class ParamsPhaseSwitch(ParamsExpectedSetCurrent, ParamsExpectedCounterSet):
     raw_power_left: float = 0
     raw_currents_left_counter0: List[float] = field(default_factory=currents_list_factory)
     raw_currents_left_counter6: List[float] = field(default_factory=currents_list_factory)
-    expected_timestamp_auto_phase_switch_cp3: Optional[str] = None
-    expected_timestamp_auto_phase_switch_cp4: Optional[str] = None
-    expected_timestamp_auto_phase_switch_cp5: Optional[str] = None
+    expected_timestamp_last_phase_switch_cp3: Optional[str] = None
+    expected_timestamp_last_phase_switch_cp4: Optional[str] = None
+    expected_timestamp_last_phase_switch_cp5: Optional[str] = None
 
 
 def assert_counter_set(params: ParamsExpectedCounterSet):
@@ -243,9 +243,9 @@ cases_phase_switch = [
                       raw_power_left=32580,
                       raw_currents_left_counter0=[40]*3,
                       raw_currents_left_counter6=[16]*3,
-                      expected_timestamp_auto_phase_switch_cp3=1652683252.0,
-                      expected_timestamp_auto_phase_switch_cp4=None,
-                      expected_timestamp_auto_phase_switch_cp5=None,
+                      expected_timestamp_last_phase_switch_cp3=1652683252.0,
+                      expected_timestamp_last_phase_switch_cp4=None,
+                      expected_timestamp_last_phase_switch_cp5=None,
                       expected_current_cp3=10,
                       expected_current_cp4=6,
                       expected_current_cp5=6,
@@ -257,9 +257,9 @@ cases_phase_switch = [
                       raw_power_left=42580,
                       raw_currents_left_counter0=[40]*3,
                       raw_currents_left_counter6=[16]*3,
-                      expected_timestamp_auto_phase_switch_cp3=1652683252.0,
-                      expected_timestamp_auto_phase_switch_cp4=None,
-                      expected_timestamp_auto_phase_switch_cp5=None,
+                      expected_timestamp_last_phase_switch_cp3=1652683252.0,
+                      expected_timestamp_last_phase_switch_cp4=None,
+                      expected_timestamp_last_phase_switch_cp5=None,
                       expected_current_cp3=32,
                       expected_current_cp4=6,
                       expected_current_cp5=6,
@@ -281,6 +281,8 @@ def test_phase_switch(all_cp_pv_charging_3p, all_cp_charging_3p, monkeypatch):
     monkeypatch.setattr(algorithm_data.data.general_data, "get_phases_chargemode", mockget_get_phases_chargemode)
     data.data.cp_data[
         "cp3"].data.control_parameter.state = ChargepointState.CHARGING_ALLOWED
+    data.data.cp_data[
+        "cp3"].data.control_parameter.timestamp_last_phase_switch = 1652682252
 
     # execution
     Algorithm().calc_current()
@@ -288,14 +290,7 @@ def test_phase_switch(all_cp_pv_charging_3p, all_cp_charging_3p, monkeypatch):
     # evaluation
     assert_expected_current(cases_phase_switch[0])
     assert data.data.cp_data[
-        "cp3"].data.control_parameter.timestamp_auto_phase_switch == cases_phase_switch[
-            0].expected_timestamp_auto_phase_switch_cp3
-    assert data.data.cp_data[
-        "cp4"].data.control_parameter.timestamp_auto_phase_switch == cases_phase_switch[
-            0].expected_timestamp_auto_phase_switch_cp4
-    assert data.data.cp_data[
-        "cp5"].data.control_parameter.timestamp_auto_phase_switch == cases_phase_switch[
-            0].expected_timestamp_auto_phase_switch_cp5
+        "cp3"].data.control_parameter.state == ChargepointState.PHASE_SWITCH_DELAY
     assert_counter_set(cases_phase_switch[0])
 
 
@@ -311,6 +306,7 @@ def test_phase_switch_1p_3p(all_cp_pv_charging_1p, monkeypatch):
     monkeypatch.setattr(algorithm_data.data.general_data, "get_phases_chargemode", mockget_get_phases_chargemode)
     data.data.cp_data["cp3"].data.get.currents = [32, 0, 0]
     data.data.cp_data["cp3"].data.get.power = 7360
+    data.data.cp_data["cp3"].data.control_parameter.timestamp_last_phase_switch = 1652682252
     data.data.cp_data["cp4"].data.get.currents = [0, 0, 0]
     data.data.cp_data["cp5"].data.get.currents = [0, 0, 0]
 
@@ -320,11 +316,4 @@ def test_phase_switch_1p_3p(all_cp_pv_charging_1p, monkeypatch):
     # evaluation
     assert_counter_set(cases_phase_switch[1])
     assert data.data.cp_data[
-        "cp3"].data.control_parameter.timestamp_auto_phase_switch == cases_phase_switch[
-            1].expected_timestamp_auto_phase_switch_cp3
-    assert data.data.cp_data[
-        "cp4"].data.control_parameter.timestamp_auto_phase_switch == cases_phase_switch[
-            1].expected_timestamp_auto_phase_switch_cp4
-    assert data.data.cp_data[
-        "cp5"].data.control_parameter.timestamp_auto_phase_switch == cases_phase_switch[
-            1].expected_timestamp_auto_phase_switch_cp5
+        "cp3"].data.control_parameter.state == ChargepointState.PHASE_SWITCH_DELAY

--- a/packages/control/auto_phase_switch_test.py
+++ b/packages/control/auto_phase_switch_test.py
@@ -31,7 +31,7 @@ class Params:
     def __init__(self,
                  name: str,
                  max_current_single_phase: int,
-                 timestamp_auto_phase_switch: Optional[float],
+                 timestamp_last_phase_switch: Optional[float],
                  phases_to_use: int,
                  required_current: float,
                  evu_surplus: int,
@@ -41,11 +41,10 @@ class Params:
                  expected_phases_to_use: int,
                  expected_current: float,
                  expected_state: ChargepointState,
-                 expected_message: Optional[str] = None,
-                 expected_timestamp_auto_phase_switch: Optional[float] = None) -> None:
+                 expected_message: Optional[str] = None) -> None:
         self.name = name
         self.max_current_single_phase = max_current_single_phase
-        self.timestamp_auto_phase_switch = timestamp_auto_phase_switch
+        self.timestamp_last_phase_switch = timestamp_last_phase_switch
         self.phases_to_use = phases_to_use
         self.required_current = required_current
         self.available_power = evu_surplus
@@ -56,64 +55,57 @@ class Params:
         self.expected_current = expected_current
         self.expected_state = expected_state
         self.expected_message = expected_message
-        self.expected_timestamp_auto_phase_switch = expected_timestamp_auto_phase_switch
 
 
 cases = [
-    Params("1to3, enough power, start timer", max_current_single_phase=16, timestamp_auto_phase_switch=None,
+    Params("1to3, enough power, start timer", max_current_single_phase=16, timestamp_last_phase_switch=1652683202,
            phases_to_use=1, required_current=6, evu_surplus=800, get_currents=[15.6, 0, 0],
            get_power=3450, state=ChargepointState.CHARGING_ALLOWED, expected_phases_to_use=1, expected_current=6,
-           expected_message=Ev.PHASE_SWITCH_DELAY_TEXT.format("Umschaltung von 1 auf 3", "7 Min."),
-           expected_timestamp_auto_phase_switch=1652683252.0,
+           expected_message=Ev.PHASE_SWITCH_DELAY_TEXT.format("Umschaltung von 1 auf 3", "4 Min. 10 Sek."),
            expected_state=ChargepointState.PHASE_SWITCH_DELAY),
-    Params("1to3, not enough power, start timer", max_current_single_phase=16, timestamp_auto_phase_switch=None,
+    Params("1to3, not enough power, start timer", max_current_single_phase=16, timestamp_last_phase_switch=1652683202,
            phases_to_use=1, required_current=6, evu_surplus=300, get_currents=[15.6, 0, 0],
            get_power=3450, state=ChargepointState.CHARGING_ALLOWED, expected_phases_to_use=1, expected_current=6,
            expected_state=ChargepointState.CHARGING_ALLOWED),
     Params("1to3, enough power, timer not expired", max_current_single_phase=16,
-           timestamp_auto_phase_switch=1652682952.0, phases_to_use=1, required_current=6,
+           timestamp_last_phase_switch=1652683202.0, phases_to_use=1, required_current=6,
            evu_surplus=1460, get_currents=[15.6, 0, 0], get_power=3450,
            state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=1, expected_current=6,
-           expected_message=Ev.PHASE_SWITCH_DELAY_TEXT.format("Umschaltung von 1 auf 3", "2 Min."),
-           expected_timestamp_auto_phase_switch=1652683252.0,
+           expected_message=Ev.PHASE_SWITCH_DELAY_TEXT.format("Umschaltung von 1 auf 3", "4 Min. 10 Sek."),
            expected_state=ChargepointState.PHASE_SWITCH_DELAY),
     Params("1to3, not enough power, timer not expired", max_current_single_phase=16,
-           timestamp_auto_phase_switch=1652682952.0, phases_to_use=1, required_current=6,
+           timestamp_last_phase_switch=1652683202.0, phases_to_use=1, required_current=6,
            evu_surplus=460, get_currents=[15.6, 0, 0], get_power=3450,
            state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=1, expected_current=6,
            expected_message=f"Verzögerung für die Umschaltung von 1 auf 3 Phasen abgebrochen{Ev.NOT_ENOUGH_POWER}",
-           expected_timestamp_auto_phase_switch=1652683252.0,
            expected_state=ChargepointState.CHARGING_ALLOWED),
     Params("1to3, enough power, timer expired", max_current_single_phase=16,
-           timestamp_auto_phase_switch=1652682772.0, phases_to_use=1, required_current=6,
+           timestamp_last_phase_switch=1652682802.0, phases_to_use=1, required_current=6,
            evu_surplus=1640, get_currents=[15.6, 0, 0], get_power=3450,
            state=ChargepointState.PHASE_SWITCH_DELAY,
            expected_phases_to_use=3, expected_current=6, expected_state=ChargepointState.PHASE_SWITCH_AWAITED),
 
-    Params("3to1, not enough power, start timer", max_current_single_phase=16, timestamp_auto_phase_switch=None,
+    Params("3to1, not enough power, start timer", max_current_single_phase=16, timestamp_last_phase_switch=1652683202,
            phases_to_use=3, required_current=6, evu_surplus=0,
            get_currents=[4.5, 4.4, 5.8], get_power=3381, state=ChargepointState.CHARGING_ALLOWED,
            expected_phases_to_use=3, expected_current=6,
-           expected_message="Umschaltung von 3 auf 1 Phasen in 9 Min..",
-           expected_timestamp_auto_phase_switch=1652683252.0,
+           expected_message="Umschaltung von 3 auf 1 Phasen in 4 Min. 10 Sek..",
            expected_state=ChargepointState.PHASE_SWITCH_DELAY),
     Params("3to1, not enough power, timer not expired", max_current_single_phase=16,
-           timestamp_auto_phase_switch=1652682952.0,
+           timestamp_last_phase_switch=1652683202.0,
            phases_to_use=3, required_current=6, evu_surplus=-460,
            get_currents=[4.5, 4.4, 5.8], get_power=3381, state=ChargepointState.PHASE_SWITCH_DELAY,
            expected_phases_to_use=3, expected_current=6,
-           expected_message="Umschaltung von 3 auf 1 Phasen in 4 Min..",
-           expected_timestamp_auto_phase_switch=1652683252.0,
+           expected_message="Umschaltung von 3 auf 1 Phasen in 4 Min. 10 Sek..",
            expected_state=ChargepointState.PHASE_SWITCH_DELAY),
     Params("3to1, enough power, timer not expired", max_current_single_phase=16,
-           timestamp_auto_phase_switch=1652682952.0, phases_to_use=3, required_current=6,
+           timestamp_last_phase_switch=1652683202.0, phases_to_use=3, required_current=6,
            evu_surplus=860, get_currents=[4.5, 4.4, 5.8],
            get_power=3381, state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=3, expected_current=6,
            expected_message=f"Verzögerung für die Umschaltung von 3 auf 1 Phasen abgebrochen{Ev.ENOUGH_POWER}",
-           expected_timestamp_auto_phase_switch=1652683252.0,
            expected_state=ChargepointState.CHARGING_ALLOWED),
     Params("3to1, not enough power, timer expired", max_current_single_phase=16,
-           timestamp_auto_phase_switch=1652682592.0, phases_to_use=3, required_current=6,
+           timestamp_last_phase_switch=1652682802.0, phases_to_use=3, required_current=6,
            evu_surplus=-460, get_currents=[4.5, 4.4, 5.8],
            get_power=3381, state=ChargepointState.PHASE_SWITCH_DELAY, expected_phases_to_use=1, expected_current=16,
            expected_state=ChargepointState.PHASE_SWITCH_AWAITED),
@@ -133,7 +125,7 @@ def test_auto_phase_switch(monkeypatch, vehicle: Ev, params: Params):
 
     vehicle.ev_template.data.max_current_single_phase = params.max_current_single_phase
     control_parameter = ControlParameter()
-    control_parameter.timestamp_auto_phase_switch = params.timestamp_auto_phase_switch
+    control_parameter.timestamp_last_phase_switch = params.timestamp_last_phase_switch
     control_parameter.phases = params.phases_to_use
     control_parameter.required_current = params.required_current
     control_parameter.state = params.state

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -412,17 +412,16 @@ class Chargepoint(ChargepointRfidMixin):
                 # Umschaltung abgeschlossen
                 try:
                     timestamp_not_expired = timecheck.check_timestamp(
-                        self.data.control_parameter.timestamp_perform_phase_switch,
+                        self.data.control_parameter.timestamp_last_phase_switch,
                         6 + phase_switch_pause - 1)
                 except TypeError:
                     # so wird in jedem Fall die erforderliche Zeit abgewartet
-                    self.data.control_parameter.timestamp_perform_phase_switch = create_timestamp()
+                    self.data.control_parameter.timestamp_last_phase_switch = create_timestamp()
                     timestamp_not_expired = timecheck.check_timestamp(
-                        self.data.control_parameter.timestamp_perform_phase_switch,
+                        self.data.control_parameter.timestamp_last_phase_switch,
                         6 + phase_switch_pause - 1)
                 if not timestamp_not_expired:
                     log.debug("phase switch running")
-                    self.data.control_parameter.timestamp_perform_phase_switch = None
                     # Aktuelle Ladeleistung und Differenz wieder freigeben.
                     if self.data.set.phases_to_use == 1:
                         evu_counter.data.set.reserved_surplus -= charging_ev.ev_template. \
@@ -488,7 +487,7 @@ class Chargepoint(ChargepointRfidMixin):
                                 evu_counter.data.set.reserved_surplus += charging_ev. \
                                     ev_template.data.max_current_single_phase * 3 * 230
                             # Timestamp für die Durchführungsdauer
-                            self.data.control_parameter.timestamp_perform_phase_switch = create_timestamp()
+                            self.data.control_parameter.timestamp_last_phase_switch = create_timestamp()
                             self.set_state_and_log(message)
                             if self.data.set.phases_to_use != self.data.control_parameter.phases:
                                 Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/phases_to_use",

--- a/packages/control/chargepoint/control_parameter.py
+++ b/packages/control/chargepoint/control_parameter.py
@@ -26,12 +26,10 @@ class ControlParameter:
     state: ChargepointState = field(default=ChargepointState.NO_CHARGING_ALLOWED,
                                     metadata={"topic": "control_parameter/state"})
     submode: Chargemode_enum = field(default=Chargemode_enum.STOP, metadata={"topic": "control_parameter/submode"})
-    timestamp_auto_phase_switch: Optional[float] = field(
-        default=None, metadata={"topic": "control_parameter/timestamp_auto_phase_switch"})
     timestamp_charge_start: Optional[float] = field(
         default=None, metadata={"topic": "control_parameter/timestamp_charge_start"})
-    timestamp_perform_phase_switch: Optional[float] = field(
-        default=None, metadata={"topic": "control_parameter/timestamp_perform_phase_switch"})
+    timestamp_last_phase_switch: float = field(
+        default=0, metadata={"topic": "control_parameter/timestamp_last_phase_switch"})
     timestamp_switch_on_off: Optional[float] = field(
         default=None, metadata={"topic": "control_parameter/timestamp_switch_on_off"})
 

--- a/packages/control/chargepoint/get_phases_test.py
+++ b/packages/control/chargepoint/get_phases_test.py
@@ -35,7 +35,7 @@ class Params:
                  phases_in_use: int,
                  imported_since_plugged: float,
                  expected_phases: int,
-                 timestamp_perform_phase_switch: Optional[str] = None,
+                 timestamp_last_phase_switch: Optional[str] = None,
                  charge_state: bool = False) -> None:
         self.name = name
         self.connected_phases = connected_phases
@@ -45,7 +45,7 @@ class Params:
         self.phases_in_use = phases_in_use
         self.imported_since_plugged = imported_since_plugged
         self.expected_phases = expected_phases
-        self.timestamp_perform_phase_switch = timestamp_perform_phase_switch
+        self.timestamp_last_phase_switch = timestamp_last_phase_switch
         self.charge_state = charge_state
 
 
@@ -61,7 +61,7 @@ cases = [
            expected_phases=1, charge_state=True),
     Params("don't change during phase switch", connected_phases=3, auto_phase_switch_hw=True,
            prevent_phase_switch=False, chargemode_phases=0, phases_in_use=1, imported_since_plugged=0,
-           expected_phases=1, timestamp_perform_phase_switch="2022/05/11, 15:00:02"),
+           expected_phases=1, timestamp_last_phase_switch="2022/05/11, 15:00:02"),
     Params("auto phase during charge 3", connected_phases=3, auto_phase_switch_hw=True,
            prevent_phase_switch=False, chargemode_phases=0, phases_in_use=1, imported_since_plugged=0,
            expected_phases=1, charge_state=True),
@@ -94,7 +94,7 @@ def test_get_phases_by_selected_chargemode(monkeypatch, cp: Chargepoint, params:
     cp.data.set.log.imported_since_plugged = params.imported_since_plugged
     charging_ev_data = cp.data.set.charging_ev_data
     charging_ev_data.ev_template.data.prevent_phase_switch = params.prevent_phase_switch
-    cp.data.control_parameter.timestamp_perform_phase_switch = params.timestamp_perform_phase_switch
+    cp.data.control_parameter.timestamp_last_phase_switch = params.timestamp_last_phase_switch
     cp.data.control_parameter.phases = params.phases_in_use
 
     # execution

--- a/packages/control/ev/ev.py
+++ b/packages/control/ev/ev.py
@@ -348,7 +348,6 @@ class Ev:
         delay = cm_config.phase_switch_delay * 60
         if phases_in_use == 1:
             direction_str = f"Umschaltung von 1 auf {max_phases}"
-
             required_reserved_power = (control_parameter.min_current * max_phases * 230 -
                                        self.ev_template.data.max_current_single_phase * 230)
 

--- a/packages/control/general.py
+++ b/packages/control/general.py
@@ -93,7 +93,7 @@ def time_charging_factory() -> TimeCharging:
 @dataclass
 class ChargemodeConfig:
     instant_charging: InstantCharging = field(default_factory=instant_charging_factory)
-    phase_switch_delay: int = field(default=7, metadata={
+    phase_switch_delay: int = field(default=5, metadata={
         "topic": "chargemode_config/phase_switch_delay"})
     pv_charging: PvCharging = field(default_factory=pv_charging_factory)
     retry_failed_phase_switches: bool = field(

--- a/packages/control/process.py
+++ b/packages/control/process.py
@@ -27,7 +27,6 @@ class Process:
             for cp in data.data.cp_data.values():
                 try:
                     control_parameter = cp.data.control_parameter
-                    cp.remember_previous_values()
                     if cp.data.set.charging_ev != -1:
                         # Ladelog-Daten müssen vor dem Setzen des Stroms gesammelt werden,
                         # damit bei Phasenumschaltungs-empfindlichen EV sicher noch nicht geladen wurde.
@@ -58,6 +57,7 @@ class Process:
                     if cp.chargepoint_module.fault_state.fault_state != FaultStateLevel.NO_ERROR:
                         cp.chargepoint_module.fault_state.store_error()
                     modules_threads.append(self._start_charging(cp))
+                    cp.remember_previous_values()
                 except Exception:
                     log.exception("Fehler im Process-Modul für Ladepunkt "+str(cp))
             for bat_component in get_controllable_bat_components():
@@ -100,8 +100,7 @@ class Process:
                 "LP"+str(chargepoint.num)+": Ladung wurde trotz verhinderter Unterbrechung gestoppt.")
 
         # Wenn ein EV zugeordnet ist und die Phasenumschaltung aktiv ist, darf kein Strom gesetzt werden.
-        if (chargepoint.data.control_parameter.timestamp_perform_phase_switch is not None or
-                chargepoint.data.control_parameter.state == ChargepointState.PERFORMING_PHASE_SWITCH):
+        if chargepoint.data.control_parameter.state == ChargepointState.PERFORMING_PHASE_SWITCH:
             current = 0
 
         chargepoint.data.set.current = current

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -580,9 +580,8 @@ class SetData:
                         "/control_parameter/imported_at_plan_start" in msg.topic or
                         "/control_parameter/min_current" in msg.topic or
                         "/control_parameter/timestamp_switch_on_off" in msg.topic or
-                        "/control_parameter/timestamp_auto_phase_switch" in msg.topic or
                         "/control_parameter/timestamp_charge_start" in msg.topic or
-                        "/control_parameter/timestamp_perform_phase_switch" in msg.topic):
+                        "/control_parameter/timestamp_last_phase_switch" in msg.topic):
                     self._validate_value(msg, float, [(0, float("inf"))])
                 elif "/control_parameter/state" in msg.topic:
                     self._validate_value(msg, int, [(0, 7)])
@@ -784,7 +783,7 @@ class SetData:
             elif "openWB/set/general/chargemode_config/pv_charging/switch_off_threshold" in msg.topic:
                 self._validate_value(msg, float)
             elif "openWB/set/general/chargemode_config/phase_switch_delay" in msg.topic:
-                self._validate_value(msg, int, [(1, 15)])
+                self._validate_value(msg, int, [(5, 20)])
             elif "openWB/set/general/chargemode_config/pv_charging/control_range" in msg.topic:
                 self._validate_value(msg, int, collection=list)
             elif (("openWB/set/general/chargemode_config/pv_charging/phases_to_use" in msg.topic or

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -51,7 +51,7 @@ NO_MODULE = {"type": None, "configuration": {}}
 
 
 class UpdateConfig:
-    DATASTORE_VERSION = 67
+    DATASTORE_VERSION = 68
     valid_topic = [
         "^openWB/bat/config/configured$",
         "^openWB/bat/config/power_limit_mode$",
@@ -93,8 +93,7 @@ class UpdateConfig:
         "^openWB/chargepoint/[0-9]+/control_parameter/limit$",
         "^openWB/chargepoint/[0-9]+/control_parameter/prio$",
         "^openWB/chargepoint/[0-9]+/control_parameter/required_current$",
-        "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_auto_phase_switch$",
-        "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_perform_phase_switch$",
+        "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_last_phase_switch$",
         "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_switch_on_off$",
         "^openWB/chargepoint/[0-9]+/control_parameter/used_amount_instant_charging$",
         "^openWB/chargepoint/[0-9]+/control_parameter/phases$",
@@ -1867,3 +1866,11 @@ class UpdateConfig:
                 Pub().pub(topic, payload)
         self._loop_all_received_topics(upgrade)
         self.__update_topic("openWB/system/datastore_version", 67)
+
+    def upgrade_datastore_67(self) -> None:
+        def upgrade(topic: str, payload) -> Optional[dict]:
+            if "openWB/general/chargemode_config/phase_switch_delay" == topic:
+                if decode_payload(payload) < 5:
+                    return {"openWB/general/chargemode_config/phase_switch_delay": 5}
+        self._loop_all_received_topics(upgrade)
+        self.__update_topic("openWB/system/datastore_version", 68)


### PR DESCRIPTION
Es wird sich der Zeitpunkt der letzen Umschaltung gemerkt. Wenn diese das eingestellte Zeitintervall zurückliegt, wird direkt umgeschaltet, statt in jedem Fall die Umschaltverzögerung abzuwarten.

UI: https://github.com/openWB/openwb-ui-settings/pull/578