### PR TITLE
soc_bmwbc: add new captcha for initial login

### DIFF
--- a/packages/modules/vehicles/bmwbc/api.py
+++ b/packages/modules/vehicles/bmwbc/api.py
@@ -22,7 +22,7 @@ from modules.common.component_state import CarState
 from modules.common.store import RAMDISK_PATH
 from pathlib import Path
 
-dataPath = "/var/www/html/openWB/data/bmwbc"
+DATA_PATH = "data/bmwbc"
 
 log = logging.getLogger(__name__)
 
@@ -40,13 +40,6 @@ def init_store():
 # load store from file, if no store file exists initialize store structure
 def load_store():
     global storeFile
-    try:
-        Path(dataPath).mkdir(parents=True, exist_ok=True)
-    except Exception as e:
-        log.error("init: dataPath creation failed, dataPath: " +
-                  dataPath + ", error=" + str(e))
-        store = init_store()
-        return store
     try:
         with open(storeFile, 'r', encoding='utf-8') as tf:
             store = json.load(tf)
@@ -80,6 +73,16 @@ def dump_json(data: dict, fout: str):
 # ---------------fetch Function called by core ------------------------------------
 async def _fetch_soc(user_id: str, password: str, vin: str, captcha_token: str, vnum: int) -> Union[int, float]:
     global storeFile
+    try:
+        openwbpath = str(Path(__file__).resolve().parents[4])
+        dataPath = openwbpath + '/' + DATA_PATH
+        log.debug("dataPath=" + dataPath)
+        Path(dataPath).mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        log.error("init: dataPath creation failed, dataPath: " +
+                  dataPath + ", error=" + str(e))
+        store = init_store()
+        return store
     storeFile = str(dataPath) + '/soc_bmwbc_vh_' + str(vnum) + '.json'
 
     try:

--- a/packages/modules/vehicles/bmwbc/api.py
+++ b/packages/modules/vehicles/bmwbc/api.py
@@ -20,6 +20,9 @@ with ImportErrorContext():
 
 from modules.common.component_state import CarState
 from modules.common.store import RAMDISK_PATH
+from pathlib import Path
+
+dataPath = "/var/www/html/openWB/data/bmwbc"
 
 log = logging.getLogger(__name__)
 
@@ -36,6 +39,14 @@ def init_store():
 
 # load store from file, if no store file exists initialize store structure
 def load_store():
+    global storeFile
+    try:
+        Path(dataPath).mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        log.error("init: dataPath creation failed, dataPath: " +
+                  dataPath + ", error=" + str(e))
+        store = init_store()
+        return store
     try:
         with open(storeFile, 'r', encoding='utf-8') as tf:
             store = json.load(tf)
@@ -54,6 +65,7 @@ def load_store():
 
 # write store file
 def write_store(store: dict):
+    global storeFile
     with open(storeFile, 'w', encoding='utf-8') as tf:
         json.dump(store, tf, indent=4)
 
@@ -66,9 +78,9 @@ def dump_json(data: dict, fout: str):
 
 
 # ---------------fetch Function called by core ------------------------------------
-async def _fetch_soc(user_id: str, password: str, vin: str, vnum: int) -> Union[int, float]:
+async def _fetch_soc(user_id: str, password: str, vin: str, captcha_token: str, vnum: int) -> Union[int, float]:
     global storeFile
-    storeFile = str(RAMDISK_PATH) + '/soc_bmwbc_vh_' + str(vnum) + '.json'
+    storeFile = str(dataPath) + '/soc_bmwbc_vh_' + str(vnum) + '.json'
 
     try:
         # set loggin in httpx to WARNING to prevent unwanted messages
@@ -85,12 +97,15 @@ async def _fetch_soc(user_id: str, password: str, vin: str, vnum: int) -> Union[
                                        expires_at=expires_at)
         else:
             # no token, authenticate via user_id and password only
-            auth = MyBMWAuthentication(user_id, password, Regions.REST_OF_WORLD)
+            auth = MyBMWAuthentication(user_id,
+                                       password,
+                                       Regions.REST_OF_WORLD,
+                                       hcaptcha_token=captcha_token)
 
         clconf = MyBMWClientConfiguration(auth)
         # account = MyBMWAccount(user_id, password, Regions.REST_OF_WORLD, config=clconf)
         # user, password and region already set in BMWAuthentication/ClientConfiguration!
-        account = MyBMWAccount(None, None, None, config=clconf)
+        account = MyBMWAccount(None, None, None, config=clconf, hcaptcha_token=captcha_token)
 
         # get vehicle list - needs to be called async
         await account.get_vehicles()
@@ -130,13 +145,13 @@ async def _fetch_soc(user_id: str, password: str, vin: str, vnum: int) -> Union[
 
 
 # main entry - _fetch needs to be run async
-def fetch_soc(user_id: str, password: str, vin: str, vnum: int) -> CarState:
+def fetch_soc(user_id: str, password: str, vin: str, captcha_token: str, vnum: int) -> CarState:
 
     # prepare and call async method
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
     # get soc, range from server
-    soc, range = loop.run_until_complete(_fetch_soc(user_id, password, vin, vnum))
+    soc, range = loop.run_until_complete(_fetch_soc(user_id, password, vin, captcha_token, vnum))
 
     return CarState(soc, range)

--- a/packages/modules/vehicles/bmwbc/api.py
+++ b/packages/modules/vehicles/bmwbc/api.py
@@ -22,7 +22,7 @@ from modules.common.component_state import CarState
 from modules.common.store import RAMDISK_PATH
 from pathlib import Path
 
-DATA_PATH = "data/bmwbc"
+DATA_PATH = Path(__file__).resolve().parents[4] / "data" / "bmwbc"
 
 log = logging.getLogger(__name__)
 
@@ -74,16 +74,14 @@ def dump_json(data: dict, fout: str):
 async def _fetch_soc(user_id: str, password: str, vin: str, captcha_token: str, vnum: int) -> Union[int, float]:
     global storeFile
     try:
-        openwbpath = str(Path(__file__).resolve().parents[4])
-        dataPath = openwbpath + '/' + DATA_PATH
-        log.debug("dataPath=" + dataPath)
-        Path(dataPath).mkdir(parents=True, exist_ok=True)
+        log.debug("dataPath=" + str(DATA_PATH))
+        DATA_PATH.mkdir(parents=True, exist_ok=True)
     except Exception as e:
         log.error("init: dataPath creation failed, dataPath: " +
-                  dataPath + ", error=" + str(e))
+                  str(DATA_PATH) + ", error=" + str(e))
         store = init_store()
         return store
-    storeFile = str(dataPath) + '/soc_bmwbc_vh_' + str(vnum) + '.json'
+    storeFile = str(DATA_PATH) + '/soc_bmwbc_vh_' + str(vnum) + '.json'
 
     try:
         # set loggin in httpx to WARNING to prevent unwanted messages

--- a/packages/modules/vehicles/bmwbc/config.py
+++ b/packages/modules/vehicles/bmwbc/config.py
@@ -6,10 +6,12 @@ class BMWbcConfiguration:
                  user_id: Optional[str] = None,
                  password: Optional[str] = None,
                  vin: Optional[str] = None,
+                 captcha_token: Optional[str] = None,
                  calculate_soc: bool = False):
         self.user_id = user_id
         self.password = password
         self.vin = vin
+        self.captcha_token = captcha_token
         self.calculate_soc = calculate_soc
 
 

--- a/packages/modules/vehicles/bmwbc/soc.py
+++ b/packages/modules/vehicles/bmwbc/soc.py
@@ -21,6 +21,7 @@ def create_vehicle(vehicle_config: BMWbc, vehicle: int):
             vehicle_config.configuration.user_id,
             vehicle_config.configuration.password,
             vehicle_config.configuration.vin,
+            vehicle_config.configuration.captcha_token,
             vehicle)
     return ConfigurableVehicle(vehicle_config=vehicle_config,
                                component_updater=updater,
@@ -28,13 +29,19 @@ def create_vehicle(vehicle_config: BMWbc, vehicle: int):
                                calc_while_charging=vehicle_config.configuration.calculate_soc)
 
 
-def bmwbc_update(user_id: str, password: str, vin: str, charge_point: int):
+def bmwbc_update(user_id: str, password: str, vin: str, captcha_token: str, charge_point: int):
     log.debug("bmwbc: user_id="+user_id+"vin="+vin+"charge_point="+str(charge_point))
-    vehicle_config = BMWbc(configuration=BMWbcConfiguration(charge_point, user_id, password, vin))
+    log.debug("bmwbc: captcha_token="+captcha_token)
+    vehicle_config = BMWbc(configuration=BMWbcConfiguration(charge_point,
+                                                            user_id,
+                                                            password,
+                                                            vin,
+                                                            captcha_token))
     store.get_car_value_store(charge_point).store.set(api.fetch_soc(
         vehicle_config.configuration.user_id,
         vehicle_config.configuration.password,
         vehicle_config.configuration.vin,
+        vehicle_config.configuration.captcha_token,
         charge_point))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ pysmb==1.2.9.1
 pytz==2023.3.post1
 grpcio==1.60.1
 protobuf==4.25.3
-bimmer_connected==0.16.1
+bimmer_connected==0.17.0
 ocpp==1.0.0
 websockets==12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ pysmb==1.2.9.1
 pytz==2023.3.post1
 grpcio==1.60.1
 protobuf==4.25.3
-bimmer_connected==0.17.0
+bimmer_connected==0.17.2
 ocpp==1.0.0
 websockets==12.0


### PR DESCRIPTION
Support new captcha required by BMW server login
Store token file in folder data/bmwbc instead of ramdisk to avoid too frequent captcha process after reboot.
related UI PR: https://github.com/openWB/openwb-ui-settings/pull/589