### PR TITLE
PSA Car Controller SoC

### DIFF
--- a/packages/modules/vehicles/psacc/config.py
+++ b/packages/modules/vehicles/psacc/config.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+
+class PSACCVehicleSocConfiguration:
+    def __init__(self,
+                 psacc_server_or_ip: Optional[str] = None,
+                 psacc_port: Optional[int] = None,
+                 vehicle_vin: Optional[str] = None) -> None:
+        self.psacc_server_or_ip = psacc_server_or_ip
+        self.psacc_port = psacc_port
+        self.vehicle_vin = vehicle_vin
+
+
+class PSACCVehicleSoc:
+    def __init__(self,
+                 name: str = "PSA Car Controller",
+                 type: str = "psacc",
+                 configuration: PSACCVehicleSocConfiguration = None) -> None:
+        self.name = name
+        self.type = type
+        self.configuration = configuration or PSACCVehicleSocConfiguration()

--- a/packages/modules/vehicles/psacc/config.py
+++ b/packages/modules/vehicles/psacc/config.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from modules.vehicles.json.config import JsonSocConfiguration
+from modules.vehicles.json.config import JsonSocConfiguration, JsonSocSetup
 
 
 class PSACCVehicleSocConfiguration(JsonSocConfiguration):
@@ -27,11 +27,10 @@ class PSACCVehicleSocConfiguration(JsonSocConfiguration):
         pass
 
 
-class PSACCVehicleSoc:
+class PSACCVehicleSoc(JsonSocSetup):
     def __init__(self,
                  name: str = "PSA Car Controller",
                  type: str = "psacc",
                  configuration: PSACCVehicleSocConfiguration = None) -> None:
-        self.name = name
-        self.type = type
-        self.configuration = configuration or PSACCVehicleSocConfiguration()
+        super().__init__(name=name, type=type,
+                         configuration=configuration or PSACCVehicleSocConfiguration())

--- a/packages/modules/vehicles/psacc/config.py
+++ b/packages/modules/vehicles/psacc/config.py
@@ -1,14 +1,30 @@
 from typing import Optional
 
+from modules.vehicles.json.config import JsonSocConfiguration
 
-class PSACCVehicleSocConfiguration:
+
+class PSACCVehicleSocConfiguration(JsonSocConfiguration):
     def __init__(self,
                  psacc_server_or_ip: Optional[str] = None,
                  psacc_port: Optional[int] = None,
                  vehicle_vin: Optional[str] = None) -> None:
+
+        super().__init__(soc_pattern=".energy[0].level",
+                         range_pattern=".energy[0].autonomy",
+                         timeout=10,
+                         calculate_soc=True)
+
         self.psacc_server_or_ip = psacc_server_or_ip
         self.psacc_port = psacc_port
         self.vehicle_vin = vehicle_vin
+
+    @property
+    def url(self):
+        return f'http://{self.psacc_server_or_ip}:{self.psacc_port}/get_vehicleinfo/{self.vehicle_vin}'
+
+    @url.setter
+    def url(self, value):
+        pass
 
 
 class PSACCVehicleSoc:

--- a/packages/modules/vehicles/psacc/soc.py
+++ b/packages/modules/vehicles/psacc/soc.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import logging
 
-from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
 from modules.vehicles.psacc.config import PSACCVehicleSoc
 from modules.vehicles.json.soc import create_vehicle as create_vehicle_json

--- a/packages/modules/vehicles/psacc/soc.py
+++ b/packages/modules/vehicles/psacc/soc.py
@@ -3,7 +3,6 @@ import logging
 
 
 from modules.common import req
-from modules.common.abstract_device import DeviceDescriptor
 from modules.common.abstract_vehicle import VehicleUpdateData
 from modules.common.component_state import CarState
 from modules.common.configurable_vehicle import ConfigurableVehicle

--- a/packages/modules/vehicles/psacc/soc.py
+++ b/packages/modules/vehicles/psacc/soc.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 def create_vehicle(vehicle_config: PSACCVehicleSoc, vehicle: int):
-    return create_vehicle_json(vehicle_config, int)
+    return create_vehicle_json(vehicle_config, vehicle)
 
 
 device_descriptor = DeviceDescriptor(configuration_factory=PSACCVehicleSoc)

--- a/packages/modules/vehicles/psacc/soc.py
+++ b/packages/modules/vehicles/psacc/soc.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 def fetch(vehicle_config: PSACCVehicleSoc, vehicle_update_data: VehicleUpdateData) -> CarState:
     c = vehicle_config.configuration
     url = f'http://{c.psacc_server_or_ip}:{c.psacc_port}/get_vehicleinfo/{c.vehicle_vin}'
-    response = req.get_http_session().get(url, timeout=5).json()
+    response = req.get_http_session().get(url, timeout=10).json()
     energy = response['energy'][0]
     return CarState(soc=energy['level'], range=energy['autonomy'])
 

--- a/packages/modules/vehicles/psacc/soc.py
+++ b/packages/modules/vehicles/psacc/soc.py
@@ -1,33 +1,16 @@
 #!/usr/bin/env python3
 import logging
 
-
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
-from modules.common.abstract_vehicle import VehicleUpdateData
-from modules.common.component_state import CarState
-from modules.common.configurable_vehicle import ConfigurableVehicle
 from modules.vehicles.psacc.config import PSACCVehicleSoc
-
+from modules.vehicles.json.soc import create_vehicle as create_vehicle_json
 
 log = logging.getLogger(__name__)
 
 
-def fetch(vehicle_config: PSACCVehicleSoc, vehicle_update_data: VehicleUpdateData) -> CarState:
-    c = vehicle_config.configuration
-    url = f'http://{c.psacc_server_or_ip}:{c.psacc_port}/get_vehicleinfo/{c.vehicle_vin}'
-    response = req.get_http_session().get(url, timeout=10).json()
-    energy = response['energy'][0]
-    return CarState(soc=energy['level'], range=energy['autonomy'])
-
-
 def create_vehicle(vehicle_config: PSACCVehicleSoc, vehicle: int):
-    def updater(vehicle_update_data: VehicleUpdateData) -> CarState:
-        return fetch(vehicle_config, vehicle_update_data)
-    return ConfigurableVehicle(vehicle_config=vehicle_config,
-                               component_updater=updater,
-                               vehicle=vehicle,
-                               calc_while_charging=True)
+    return create_vehicle_json(vehicle_config, int)
 
 
 device_descriptor = DeviceDescriptor(configuration_factory=PSACCVehicleSoc)

--- a/packages/modules/vehicles/psacc/soc.py
+++ b/packages/modules/vehicles/psacc/soc.py
@@ -3,6 +3,7 @@ import logging
 
 
 from modules.common import req
+from modules.common.abstract_device import DeviceDescriptor
 from modules.common.abstract_vehicle import VehicleUpdateData
 from modules.common.component_state import CarState
 from modules.common.configurable_vehicle import ConfigurableVehicle
@@ -27,3 +28,6 @@ def create_vehicle(vehicle_config: PSACCVehicleSoc, vehicle: int):
                                component_updater=updater,
                                vehicle=vehicle,
                                calc_while_charging=True)
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=PSACCVehicleSoc)

--- a/packages/modules/vehicles/psacc/soc.py
+++ b/packages/modules/vehicles/psacc/soc.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import logging
+
+
+from modules.common import req
+from modules.common.abstract_device import DeviceDescriptor
+from modules.common.abstract_vehicle import VehicleUpdateData
+from modules.common.component_state import CarState
+from modules.common.configurable_vehicle import ConfigurableVehicle
+from modules.vehicles.psacc.config import PSACCVehicleSoc
+
+
+log = logging.getLogger(__name__)
+
+
+def fetch(vehicle_config: PSACCVehicleSoc, vehicle_update_data: VehicleUpdateData) -> CarState:
+    c = vehicle_config.configuration
+    url = f'http://{c.psacc_server_or_ip}:{c.psacc_port}/get_vehicleinfo/{c.vehicle_vin}'
+    response = req.get_http_session().get(url, timeout=5).json()
+    energy = response['energy'][0]
+    return CarState(soc=energy['level'], range=energy['autonomy'])
+
+
+def create_vehicle(vehicle_config: PSACCVehicleSoc, vehicle: int):
+    def updater(vehicle_update_data: VehicleUpdateData) -> CarState:
+        return fetch(vehicle_config, vehicle_update_data)
+    return ConfigurableVehicle(vehicle_config=vehicle_config,
+                               component_updater=updater,
+                               vehicle=vehicle,
+                               calc_while_charging=True)


### PR DESCRIPTION
Requests SoC from PSA Car Controller via http, SoC is calculated while charging. This approaches reduces the number of PSA API calls compared to MQTT as PSA API is only called when openWB requests SoC values rather than generating a stream of samples pushed to openWB by MQTT.

Matching .vue file PR will follow.