### PR TITLE
pv: fix submode change during switch on

### DIFF
--- a/packages/control/algorithm/surplus_controlled.py
+++ b/packages/control/algorithm/surplus_controlled.py
@@ -110,7 +110,7 @@ class SurplusControlled:
             MAX_CURRENT = 30
         msg = None
         nominal_difference = chargepoint.data.set.charging_ev_data.ev_template.data.nominal_difference
-        if chargepoint.data.set.charging_ev_data.chargemode_changed:
+        if chargepoint.data.set.charging_ev_data.chargemode_changed or chargepoint.data.get.charge_state is False:
             return new_current
         else:
             # Um max. +/- 5A pro Zyklus regeln

--- a/packages/control/algorithm/surplus_controlled_test.py
+++ b/packages/control/algorithm/surplus_controlled_test.py
@@ -63,7 +63,7 @@ def test_filter_by_feed_in_limit(feed_in_limit_1: bool,
 def test_limit_adjust_current(new_current: float, expected_current: float, monkeypatch):
     # setup
     cp = Chargepoint(0, None)
-    cp.data = ChargepointData(get=Get(currents=[15]*3))
+    cp.data = ChargepointData(get=Get(charge_state=True, currents=[15]*3))
     cp.template = CpTemplate()
     monkeypatch.setattr(Chargepoint, "set_state_and_log", Mock())
 

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -676,7 +676,7 @@ class Chargepoint(ChargepointRfidMixin):
                     self.set_timestamp_charge_start()
                     self.check_phase_switch_completed()
 
-                    if charging_ev.chargemode_changed:
+                    if charging_ev.chargemode_changed or charging_ev.submode_changed:
                         data.data.counter_all_data.get_evu_counter().reset_switch_on_off(
                             self, charging_ev)
                         charging_ev.reset_phase_switch(self.data.control_parameter)

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -492,6 +492,7 @@ class Counter:
                 else:
                     evu_counter.data.set.released_surplus -= (pv_config.switch_on_threshold
                                                               * chargepoint.data.control_parameter.phases)
+                chargepoint.data.control_parameter.state = ChargepointState.NO_CHARGING_ALLOWED
         except Exception:
             log.exception("Fehler im allgemeinen PV-Modul")
 

--- a/packages/control/ev.py
+++ b/packages/control/ev.py
@@ -573,6 +573,7 @@ class Ev:
                 log.debug(
                     "Zurücksetzen der reservierten Leistung für die Phasenumschaltung. reservierte Leistung: " +
                     str(data.data.counter_all_data.get_evu_counter().data.set.reserved_surplus))
+            control_parameter.state = ChargepointState.CHARGING_ALLOWED
 
     def load_default_profile(self):
         """ prüft, ob nach dem Abstecken das Standardprofil geladen werden soll und lädt dieses ggf..


### PR DESCRIPTION
Wenn während der Einschaltverzögerung der Dauerstrom aktiviert wird (= Änderung des Submodus), müssen die Parameter und der ChargepointState zurückgesetzt werden.
https://forum.openwb.de/viewtopic.php?p=120560#p120560