### PR TITLE
Redact credentials in logging

### DIFF
--- a/packages/helpermodules/logger.py
+++ b/packages/helpermodules/logger.py
@@ -17,8 +17,9 @@ KNOWN_SENSITIVE_FIELDS = [
     'refresh_token', 'accesstoken', 'refreshtoken'
 ]
 REDACTION_PATTERNS = [
-    (r'({field})[=:]([^\s&]+)', r'\1=***REDACTED***'),  # Matches field=value, i.e. for URL query parameters
-    (r'"{field}":\s*"(.*?)"', r'"{field}": "***REDACTED***"')  # Matches "field": "value", JSON formatted data
+    (r'({field})[=:]([^\s&]+)', r'\1=***REDACTED***'),  # field=value, i.e. for URL query parameters
+    (r'"{field}":\s*"(.*?)"', r'"{field}": "***REDACTED***"'),  # "field": "value", JSON formatted data
+    (r'\'{field}\':\s*\'(.*?)\'', r"'{field}': '***REDACTED***'")  # 'field': 'value', JSON formatted data
 ]
 
 


### PR DESCRIPTION
Introduce functionality to redact sensitive information from log messages. This enhances security by preventing sensitive data from being logged.

validated with these SoC modules:

- [x] OVMS
- [x] SmartHello

validated with these meter modules:
- [x] Discovergy
