### PR TITLE
SMA - Fehlerbehandlung NAN 

### DIFF
--- a/packages/modules/devices/sma/sma_sunny_boy/bat.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat.py
@@ -12,6 +12,8 @@ from modules.devices.sma.sma_sunny_boy.config import SmaSunnyBoyBatSetup
 
 
 class SunnyBoyBat(AbstractBat):
+    SMA_UINT_64_NAN = 0xFFFFFFFFFFFFFFFF  # SMA uses this value to represent NaN
+
     def __init__(self,
                  device_id: int,
                  component_config: Union[Dict, SmaSunnyBoyBatSetup],
@@ -34,6 +36,11 @@ class SunnyBoyBat(AbstractBat):
 
         exported = self.__tcp_client.read_holding_registers(31401, ModbusDataType.UINT_64, unit=unit)
         imported = self.__tcp_client.read_holding_registers(31397, ModbusDataType.UINT_64, unit=unit)
+
+        if exported == self.SMA_UINT_64_NAN or imported == self.SMA_UINT_64_NAN:
+            raise ValueError(f'Batterie lieferte nicht plausible Werte. Export: {exported}, Import: {imported}. ',
+                             'Sobald die Batterie geladen/entladen wird sollte sich dieser Wert ändern, ',
+                             'andernfalls kann ein Defekt vorliegen.')
 
         return BatState(
             power=power,

--- a/packages/modules/devices/sma/sma_sunny_boy/inverter.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/inverter.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 class SmaSunnyBoyInverter(AbstractInverter):
 
     SMA_INT32_NAN = -0x80000000  # SMA uses this value to represent NaN
+    SMA_UINT32_NAN = 0xFFFFFFFF  # SMA uses this value to represent NaN
     SMA_NAN = -0xC000
 
     def __init__(self,
@@ -67,6 +68,13 @@ class SmaSunnyBoyInverter(AbstractInverter):
             raise ValueError("Unbekannte Version "+str(self.component_config.configuration.version))
         if power_total == self.SMA_INT32_NAN or power_total == self.SMA_NAN:
             power_total = 0
+
+        if energy == self.SMA_UINT32_NAN:
+            raise ValueError(
+                f'Wechselrichter lieferte nicht plausiblen Zählerstand: {energy}. '
+                'Sobald PV Ertrag vorhanden ist sollte sich dieser Wert ändern, '
+                'andernfalls kann ein Defekt vorliegen.'
+            )
 
         inverter_state = InverterState(
             power=power_total * -1,


### PR DESCRIPTION
Nach einem Factory-Reset liefert SMA keine Zählerstände sondern einen NAN Wert (0xFFFFFFFFFFFFFFFF bzw 0xFFFFFFFF). Dies wird abgefangen und die Verabeitung abgebrochen um falsche Zählerstände zu vermeiden.