### PR TITLE
soc_bmwbc: fix session_id, rename to BMW & Mini

### DIFF
--- a/packages/modules/vehicles/bmwbc/config.py
+++ b/packages/modules/vehicles/bmwbc/config.py
@@ -17,7 +17,7 @@ class BMWbcConfiguration:
 
 class BMWbc:
     def __init__(self,
-                 name: str = "BMW (Bimmer)",
+                 name: str = "BMW & Mini ",
                  type: str = "bmwbc",
                  configuration: BMWbcConfiguration = None) -> None:
         self.name = name


### PR DESCRIPTION
Show in Configuration module as  "BMW & Mini" instead "BMW (Bimmer)"
session_id and gcid are created at initial login via captcha and then reused in all requests.
This should help to avoid repeated new logins via captcha.   