### PR TITLE
SMA Hybrid Bat: read bat power from modbus, remove calculation from voltage and current

### DIFF
--- a/packages/modules/devices/sma/sma_sunny_boy/bat.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Union
 
 from dataclass_utils import dataclass_from_dict
@@ -9,6 +10,8 @@ from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.store import get_bat_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaSunnyBoyBatSetup
+
+log = logging.getLogger(__name__)
 
 
 class SunnyBoyBat(AbstractBat):
@@ -42,12 +45,14 @@ class SunnyBoyBat(AbstractBat):
                              'Sobald die Batterie geladen/entladen wird sollte sich dieser Wert ändern, ',
                              'andernfalls kann ein Defekt vorliegen.')
 
-        return BatState(
+        bat_state = BatState(
             power=power,
             soc=soc,
             imported=imported,
             exported=exported
         )
+        log.debug("Bat {}: {}".format(self.tcp_client.address, bat_state))
+        return bat_state
 
     def update(self) -> None:
         self.store.set(self.read())

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -41,8 +41,8 @@ class SunnyBoySmartEnergyBat(AbstractBat):
             "Battery_SoC": (30845, ModbusDataType.UINT_32),
             "Battery_ChargePower": (31393, ModbusDataType.INT_32),
             "Battery_DischargePower": (31395, ModbusDataType.INT_32),
-            "Battery_ChargedEnergy": (31401, ModbusDataType.UINT_64),
-            "Battery_DischargedEnergy": (31397, ModbusDataType.UINT_64),
+            "Battery_ChargedEnergy": (31397, ModbusDataType.UINT_64),
+            "Battery_DischargedEnergy": (31401, ModbusDataType.UINT_64),
             "Inverter_Type": (30053, ModbusDataType.UINT_32)
         }
 
@@ -71,8 +71,8 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         bat_state = BatState(
             power=power,
             soc=values["Battery_SoC"],
-            exported=values["Battery_ChargedEnergy"],
-            imported=values["Battery_DischargedEnergy"]
+            exported=values["Battery_DischargedEnergy"],
+            imported=values["Battery_ChargedEnergy"]
         )
         log.debug("Bat {}: {}".format(self.__tcp_client.address, bat_state))
         return bat_state

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Union
 
 from dataclass_utils import dataclass_from_dict
@@ -10,6 +11,8 @@ from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaSunnyBoySmartEnergyBatSetup
+
+log = logging.getLogger(__name__)
 
 
 class SunnyBoySmartEnergyBat(AbstractBat):
@@ -54,12 +57,14 @@ class SunnyBoySmartEnergyBat(AbstractBat):
                              'Sobald die Batterie geladen/entladen wird sollte sich dieser Wert ändern, ',
                              'andernfalls kann ein Defekt vorliegen.')
 
-        return BatState(
+        bat_state = BatState(
             power=power,
             soc=soc,
             imported=imported,
             exported=exported
         )
+        log.debug("Bat {}: {}".format(self.tcp_client.address, bat_state))
+        return bat_state
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SmaSunnyBoySmartEnergyBatSetup)

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -34,15 +34,18 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         unit = self.component_config.configuration.modbus_id
 
         soc = self.__tcp_client.read_holding_registers(30845, ModbusDataType.UINT_32, unit=unit)
-        current = self.__tcp_client.read_holding_registers(30843, ModbusDataType.INT_32, unit=unit)/-1000
-        voltage = self.__tcp_client.read_holding_registers(30851, ModbusDataType.INT_32, unit=unit)/100
+        imp = self.__tcp_client.read_holding_registers(31393, ModbusDataType.INT_32, unit=unit)
+        exp = self.__tcp_client.read_holding_registers(31395, ModbusDataType.INT_32, unit=unit)
 
         if soc == self.SMA_UINT32_NAN:
             # If the storage is empty and nothing is produced on the DC side, the inverter does not supply any values.
             soc = 0
             power = 0
         else:
-            power = current*voltage
+            if imp > 5:
+                power = imp
+            else:
+                power = exp * -1
         exported = self.__tcp_client.read_holding_registers(31401, ModbusDataType.UINT_64, unit=3)
         imported = self.__tcp_client.read_holding_registers(31397, ModbusDataType.UINT_64, unit=3)
 

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_tesvolt.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_tesvolt.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 
 from modules.common.abstract_device import AbstractBat
 from modules.common.component_state import BatState
@@ -8,6 +9,8 @@ from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.simcount._simcounter import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaTesvoltBatSetup
+
+log = logging.getLogger(__name__)
 
 
 class TesvoltBat(AbstractBat):
@@ -32,7 +35,7 @@ class TesvoltBat(AbstractBat):
             imported=imported,
             exported=exported
         )
-
+        log.debug("Bat {}: {}".format(self.tcp_client.address, bat_state))
         self.store.set(bat_state)
 
 


### PR DESCRIPTION
Liest die Lade/Entladeleistung aus den Modbusregistern aus anstelle diese durch Batteriespannung und -strom zu berechnen.

https://forum.openwb.de/viewtopic.php?p=122770#p122770