### PR TITLE
Fix soc_timestamp handling for milliseconds

### DIFF
--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -142,6 +142,7 @@ class CarState:
             self.soc_timestamp = timecheck.create_timestamp()
         else:
             if soc_timestamp > 1e10:  # Convert soc_timestamp to seconds if it is in milliseconds
+                log.debug(f'Zeitstempel {soc_timestamp} ist in ms, wird in s gewandelt. Modul sollte angepasst werden.')
                 soc_timestamp /= 1000
             self.soc_timestamp = soc_timestamp
 

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -141,6 +141,8 @@ class CarState:
         if soc_timestamp is None:
             self.soc_timestamp = timecheck.create_timestamp()
         else:
+            if soc_timestamp > 1e10:  # Convert soc_timestamp to seconds if it is in milliseconds
+                soc_timestamp /= 1000
             self.soc_timestamp = soc_timestamp
 
 

--- a/packages/modules/common/configurable_vehicle.py
+++ b/packages/modules/common/configurable_vehicle.py
@@ -76,7 +76,8 @@ class ConfigurableVehicle(Generic[T_VEHICLE_CONFIG]):
             if vehicle_update_data.soc_timestamp is None or vehicle_update_data.soc_timestamp < car_state.soc_timestamp:
                 # Nur wenn der SoC neuer ist als der bisherige, diesen setzen.
                 self.store.set(car_state)
-            elif car_state.soc_timestamp > 1e10:  # car_state ist in ms geschrieben, dieser kann überschrieben werden
+            elif vehicle_update_data.soc_timestamp > 1e10:
+                # car_state ist in ms geschrieben, dieser kann überschrieben werden
                 self.store.set(car_state)
             else:
                 log.debug("Not updating SoC, because timestamp is older.")

--- a/packages/modules/common/configurable_vehicle.py
+++ b/packages/modules/common/configurable_vehicle.py
@@ -76,6 +76,8 @@ class ConfigurableVehicle(Generic[T_VEHICLE_CONFIG]):
             if vehicle_update_data.soc_timestamp is None or vehicle_update_data.soc_timestamp < car_state.soc_timestamp:
                 # Nur wenn der SoC neuer ist als der bisherige, diesen setzen.
                 self.store.set(car_state)
+            elif car_state.soc_timestamp > 1e10:  # car_state ist in ms geschrieben, dieser kann überschrieben werden
+                self.store.set(car_state)
             else:
                 log.debug("Not updating SoC, because timestamp is older.")
 


### PR DESCRIPTION
Adjust the handling of `soc_timestamp` to convert values from milliseconds to seconds, some SoC modules might return ms.