### PR TITLE
add import counter to InverterState required for some hybrid systems

### DIFF
--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -109,7 +109,9 @@ class InverterState:
         exported: float,
         power: float,
         currents: Optional[List[Optional[float]]] = None,
-        dc_power: Optional[float] = None
+        dc_power: Optional[float] = None,
+        is_discrete_energy_and_combined_power: bool = False  # energy counters pv/bat are discrete, power is combined
+
     ):
         """Args:
             exported: total energy in Wh
@@ -126,6 +128,7 @@ class InverterState:
         self.power = power
         self.exported = exported
         self.dc_power = dc_power
+        self.is_discrete_energy_and_combined_power = is_discrete_energy_and_combined_power
 
 
 @auto_str

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -108,6 +108,7 @@ class InverterState:
         self,
         exported: float,
         power: float,
+        imported: float = 0,  # simulated import counter to properly calculate PV energy when bat is charged from AC
         currents: Optional[List[Optional[float]]] = None,
         dc_power: Optional[float] = None,
         is_discrete_energy_and_combined_power: bool = False  # energy counters pv/bat are discrete, power is combined
@@ -115,6 +116,7 @@ class InverterState:
     ):
         """Args:
             exported: total energy in Wh
+            imported: total energy in Wh
             power: actual power in W
             currents: actual currents for 3 phases in A
             dc_power: dc power in W
@@ -127,6 +129,7 @@ class InverterState:
         self.currents = currents
         self.power = power
         self.exported = exported
+        self.imported = imported
         self.dc_power = dc_power
         self.is_discrete_energy_and_combined_power = is_discrete_energy_and_combined_power
 

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -110,9 +110,7 @@ class InverterState:
         power: float,
         imported: float = 0,  # simulated import counter to properly calculate PV energy when bat is charged from AC
         currents: Optional[List[Optional[float]]] = None,
-        dc_power: Optional[float] = None,
-        is_discrete_energy_and_combined_power: bool = False  # energy counters pv/bat are discrete, power is combined
-
+        dc_power: Optional[float] = None
     ):
         """Args:
             exported: total energy in Wh
@@ -131,7 +129,6 @@ class InverterState:
         self.exported = exported
         self.imported = imported
         self.dc_power = dc_power
-        self.is_discrete_energy_and_combined_power = is_discrete_energy_and_combined_power
 
 
 @auto_str

--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -70,7 +70,10 @@ class PurgeInverterState:
                 for bat in hybrid:
                     bat_get = data.data.bat_data[bat].data.get
                     power -= bat_get.power
-                    exported += bat_get.imported - bat_get.exported
+                    
+                    if not state.is_discrete_energy_and_combined_power:
+                        exported += bat_get.imported - bat_get.exported
+
             if state.dc_power is not None:
                 # Manche Systeme werden auch aus dem Netz geladen, um einen Mindest-SoC zu halten.
                 if state.dc_power == 0:

--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -60,6 +60,7 @@ class PurgeInverterState:
         children = data.data.counter_all_data.get_entry_of_element(self.delegate.delegate.num)["children"]
         power = state.power
         exported = state.exported
+        imported = state.imported
         if len(children):
             hybrid = []
             for c in children:
@@ -70,9 +71,8 @@ class PurgeInverterState:
                 for bat in hybrid:
                     bat_get = data.data.bat_data[bat].data.get
                     power -= bat_get.power
-                    
-                    if not state.is_discrete_energy_and_combined_power:
-                        exported += bat_get.imported - bat_get.exported
+
+                    exported += bat_get.imported - bat_get.exported - imported
 
             if state.dc_power is not None:
                 # Manche Systeme werden auch aus dem Netz geladen, um einen Mindest-SoC zu halten.

--- a/packages/modules/devices/sma/sma_sunny_boy/inverter.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/inverter.py
@@ -79,7 +79,8 @@ class SmaSunnyBoyInverter(AbstractInverter):
         inverter_state = InverterState(
             power=power_total * -1,
             dc_power=dc_power * -1,
-            exported=energy
+            exported=energy,
+            is_discrete_energy_and_combined_power=True
         )
         log.debug("WR {}: {}".format(self.tcp_client.address, inverter_state))
         return inverter_state

--- a/packages/modules/devices/sma/sma_sunny_boy/inverter.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/inverter.py
@@ -78,7 +78,7 @@ class SmaSunnyBoyInverter(AbstractInverter):
                 'andernfalls kann ein Defekt vorliegen.'
             )
 
-        imported, not_needed_exported = self.sim_counter.sim_count(power_total * -1)
+        imported, _ = self.sim_counter.sim_count(power_total * -1)
 
         inverter_state = InverterState(
             power=power_total * -1,

--- a/packages/modules/devices/sma/sma_sunny_boy/inverter.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/inverter.py
@@ -12,6 +12,7 @@ from modules.common.modbus import ModbusDataType
 from modules.common.store import get_inverter_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaSunnyBoyInverterSetup
 from modules.devices.sma.sma_sunny_boy.inv_version import SmaInverterVersion
+from modules.common.simcount import SimCounter
 
 log = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ class SmaSunnyBoyInverter(AbstractInverter):
         self.tcp_client = tcp_client
         self.store = get_inverter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
+        self.sim_counter = SimCounter(device_id, self.component_config.id, prefix="Wechselrichter")
 
     def update(self) -> None:
         self.store.set(self.read())
@@ -76,11 +78,13 @@ class SmaSunnyBoyInverter(AbstractInverter):
                 'andernfalls kann ein Defekt vorliegen.'
             )
 
+        imported, not_needed_exported = self.sim_counter.sim_count(power_total * -1)
+
         inverter_state = InverterState(
             power=power_total * -1,
             dc_power=dc_power * -1,
             exported=energy,
-            is_discrete_energy_and_combined_power=True
+            imported=imported
         )
         log.debug("WR {}: {}".format(self.tcp_client.address, inverter_state))
         return inverter_state


### PR DESCRIPTION
Fügt import counter zum InverterState hinzu. 

Beim Laden des Speichers mit AC-seitiger Stromaufnahme wurde die bisher die gesamte geladene Energiemenge als PV-Ertrag gewertet sofern es sich um ein hybrid WR handelt und dieser nur die WR Leistung liefert (z.b. SMA). Dies ist u.a. in folgenden Szenarien inkorrekt und führt zu zu hohen PV Erträgen:
* Notladung aus dem Netz bei zu geringem SoC der Batterie
* zeitgesteuerte Ladung des Speichers Nachts, z.b. bei  zeitabhängigen Stromtarifen
* PV Systeme mit mehreren Wechselrichtern in einer gemeinsamen Anlage bei Ausregelegung des Netzanschlusses auf 0.

Mit dieser Änderung kann die vom hybrid-WR aufgenommene Energie übergeben werden. Ggf. kann diese über einen Simcount aus der Leistung berechnet werden.