### PR TITLE
soc timestamp resturn changed from string to float

### DIFF
--- a/packages/modules/vehicles/polestar/api.py
+++ b/packages/modules/vehicles/polestar/api.py
@@ -86,4 +86,4 @@ def fetch_soc(user_id: str, password: str, vin: str, vehicle: int) -> CarState:
     soc = bat_data['batteryChargeLevelPercentage']
     est_range = bat_data['estimatedDistanceToEmptyKm']
 
-    return CarState(soc, est_range, time.strftime("%m/%d/%Y, %H:%M:%S"))
+    return CarState(soc, est_range, time.time())


### PR DESCRIPTION
Hallo,
mir ist bei der 2.1.7-RC.1 aufgefallen, dass der return Wert des SOC timestamp float sein muss statt ein String.
Das scheint bis jetzt nicht aufgefallen zu sein, weil wahrscheinlich noch kein Vergleich implementiert war.