### PR TITLE
fix: read PV counter from Kostal device instead of calculation

### DIFF
--- a/packages/modules/devices/kostal/kostal_plenticore/counter.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/counter.py
@@ -26,6 +26,7 @@ class KostalPlenticoreCounter(AbstractCounter):
         powers = [reader(register, ModbusDataType.FLOAT_32) for register in [224, 234, 244]]
         power = reader(252, ModbusDataType.FLOAT_32)
         frequency = reader(220, ModbusDataType.FLOAT_32)
+        exported = reader(1056, ModbusDataType.FLOAT_32) 
 
         return CounterState(
             powers=powers,
@@ -33,15 +34,13 @@ class KostalPlenticoreCounter(AbstractCounter):
             voltages=voltages,
             power=power,
             power_factors=[power_factor]*3,
-            frequency=frequency
+            frequency=frequency,
+            exported=exported,
+            imported=0
         )
 
-    def update_imported_exported(self, state: CounterState) -> CounterState:
-        state.imported, state.exported = self.sim_counter.sim_count(state.power)
-        return state
-
     def update(self, reader: Callable[[int, ModbusDataType], Any]):
-        self.store.set(self.update_imported_exported(self.get_values(reader)))
+        self.store.set(self.get_values(reader))
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=KostalPlenticoreCounterSetup)


### PR DESCRIPTION
BA_KOSTAL-Interface-description-MODBUS-TCP_SunSpec_Hybrid-1.pdf (20) ->  0x420 1056 Total DC PV energy (sum of all PV inputs) Wh Float 2 RO 0x03