### PR TITLE
Use --connect-timeout 3 in setup_network.sh : check_internet_connection

### DIFF
--- a/runs/setup_network.sh
+++ b/runs/setup_network.sh
@@ -63,7 +63,7 @@ function setup_pnp_network() {
 }
 
 function check_internet_connection() {
-	if curl -s --head  --request GET "https://www.github.com" >/dev/null; then
+	if curl -s --head --connect-timeout 3 --request GET "https://www.github.com" >/dev/null; then
 		echo "Internet connection is up"
 	else
 		echo "ERROR: no internet connection!"


### PR DESCRIPTION
Fixing https://github.com/openWB/core/issues/2226 by using `--connect-timeout 3` option with `curl`.

This will result in detecting "no internet" after at most 3 seconds.

If Internet is available, it should really be possible to contact GitHub within 3 seconds. Else Internet seems so bad that it should probably be considered "inavailable".

Ideally, also the call to `runs/setup_network.sh` should not be made at all from within the message processing code of `subdata.py`. At least not as long as the script can block multiple seconds or minutes.