### PR TITLE
SMA Speichersteuerung

### DIFF
--- a/packages/modules/devices/sma/sma_sunny_boy/bat.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat.py
@@ -51,7 +51,7 @@ class SunnyBoyBat(AbstractBat):
             imported=imported,
             exported=exported
         )
-        log.debug("Bat {}: {}".format(self.tcp_client.address, bat_state))
+        log.debug("Bat {}: {}".format(self.__tcp_client.address, bat_state))
         return bat_state
 
     def update(self) -> None:

--- a/packages/modules/devices/sma/sma_sunny_boy/bat.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Union
 
 from dataclass_utils import dataclass_from_dict
@@ -9,6 +10,8 @@ from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.store import get_bat_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaSunnyBoyBatSetup
+
+log = logging.getLogger(__name__)
 
 
 class SunnyBoyBat(AbstractBat):
@@ -42,12 +45,14 @@ class SunnyBoyBat(AbstractBat):
                              'Sobald die Batterie geladen/entladen wird sollte sich dieser Wert ändern, ',
                              'andernfalls kann ein Defekt vorliegen.')
 
-        return BatState(
+        bat_state = BatState(
             power=power,
             soc=soc,
             imported=imported,
             exported=exported
         )
+        log.debug("Bat {}: {}".format(self.tcp_client.address, bat_state))
+        return bat_state
 
     def update(self) -> None:
         self.store.set(self.read())

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -41,8 +41,8 @@ class SunnyBoySmartEnergyBat(AbstractBat):
             "Battery_SoC": (30845, ModbusDataType.UINT_32),
             "Battery_ChargePower": (31393, ModbusDataType.INT_32),
             "Battery_DischargePower": (31395, ModbusDataType.INT_32),
-            "Battery_ChargedEnergy": (31401, ModbusDataType.UINT_64),
-            "Battery_DischargedEnergy": (31397, ModbusDataType.UINT_64),
+            "Battery_ChargedEnergy": (31397, ModbusDataType.UINT_64),
+            "Battery_DischargedEnergy": (31401, ModbusDataType.UINT_64),
             "Inverter_Type": (30053, ModbusDataType.UINT_32)
         }
 
@@ -71,8 +71,8 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         bat_state = BatState(
             power=power,
             soc=values["Battery_SoC"],
-            exported=values["Battery_ChargedEnergy"],
-            imported=values["Battery_DischargedEnergy"]
+            exported=values["Battery_DischargedEnergy"],
+            imported=values["Battery_ChargedEnergy"]
         )
         log.debug("Bat {}: {}".format(self.__tcp_client.address, bat_state))
         return bat_state

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -98,7 +98,6 @@ class SunnyBoySmartEnergyBat(AbstractBat):
 
     def set_power_limit(self, power_limit: Optional[int]) -> None:
         unit = self.component_config.configuration.modbus_id
-        log.debug(f'last_mode: {self.last_mode}')
 
         if power_limit is None:
             if self.last_mode is not None:

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -60,7 +60,7 @@ class SunnyBoySmartEnergyBat(AbstractBat):
             "Battery_DischargedEnergy"
         ]
 
-        if self.Inverter_Type is None:  # Only read Inverter_Type if not already set
+        if self.inverter_type is None:  # Only read Inverter_Type if not already set
             registers_to_read.append("Inverter_Type")
 
         values = self._read_registers(registers_to_read, unit)

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -11,8 +11,8 @@ from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaSunnyBoySmartEnergyBatSetup
-from pymodbus.payload import BinaryPayloadBuilder
-from pymodbus.constants import Endian
+import pymodbus
+
 
 log = logging.getLogger(__name__)
 
@@ -130,8 +130,10 @@ class SunnyBoySmartEnergyBat(AbstractBat):
             log.debug(f"Neuer Wert {encoded_value} in Register {address} geschrieben.")
 
     def _encode_value(self, value: Union[int, float], data_type: ModbusDataType) -> list:
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Big)
-
+        builder = pymodbus.payload.BinaryPayloadBuilder(
+            byteorder=pymodbus.constants.Endian.Big,
+            wordorder=pymodbus.constants.Endian.Big
+            )
         if data_type == ModbusDataType.UINT_32:
             builder.add_32bit_uint(int(value))
         elif data_type == ModbusDataType.INT_32:

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -44,7 +44,7 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.last_mode = 'Undefined'
-        self.Inverter_Type = None
+        self.inverter_type = None
 
     def update(self) -> None:
         self.store.set(self.read())
@@ -60,7 +60,7 @@ class SunnyBoySmartEnergyBat(AbstractBat):
             "Battery_DischargedEnergy"
         ]
 
-        if self.inverter_type is None:  # Only read Inverter_Type if not already set
+        if self.Inverter_Type is None:  # Only read Inverter_Type if not already set
             registers_to_read.append("Inverter_Type")
 
         values = self._read_registers(registers_to_read, unit)
@@ -91,8 +91,8 @@ class SunnyBoySmartEnergyBat(AbstractBat):
             imported=values["Battery_ChargedEnergy"]
         )
         if self.inverter_type is None:
-            self.Inverter_Type = values["Inverter_Type"]
-        log.debug(f"Inverter Type: {self.Inverter_Type}")
+            self.inverter_type = values["Inverter_Type"]
+        log.debug(f"Inverter Type: {self.inverter_type}")
         log.debug(f"Bat {self.__tcp_client.address}: {bat_state}")
         return bat_state
 

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -43,6 +43,7 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
+        self.last_mode = None
 
     def update(self) -> None:
         self.store.set(self.read())
@@ -61,7 +62,7 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         ]
 
         # Read all values
-        values = self.read_registers(registers_to_read, unit)
+        values = self._read_registers(registers_to_read, unit)
 
         if values["Battery_SoC"] == self.SMA_UINT32_NAN:
             # If the storage is empty and nothing is produced on the DC side, the inverter does not supply any values.
@@ -94,22 +95,26 @@ class SunnyBoySmartEnergyBat(AbstractBat):
     def set_power_limit(self, power_limit: Optional[int]) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        if power_limit is None:
+        if power_limit is None and self.last_mode is not None:
+            # Kein Powerlimit gefordert, externe Steuerung war aktiv, externe Steuerung deaktivieren
             log.debug("Keine Batteriesteuerung gefordert, deaktiviere externe Steuerung.")
             values_to_write = {
                 "Externe_Steuerung": 803,
                 "Wirkleistungsvorgabe": 0,
             }
+            self._write_registers(values_to_write, unit)
+            self.last_mode = None
         else:
+            # Powerlimit gefordert, externe Steuerung aktivieren, Limit setzen
             log.debug("Aktive Batteriesteuerung vorhanden. Setze externe Steuerung.")
             values_to_write = {
                 "Externe_Steuerung": 802,
                 "Wirkleistungsvorgabe": power_limit
             }
+            self._write_registers(values_to_write, unit)
+            self.last_mode = 'limited'
 
-        self.write_registers(values_to_write, unit)
-
-    def read_registers(self, register_names: list, unit: int) -> Dict[str, Union[int, float]]:
+    def _read_registers(self, register_names: list, unit: int) -> Dict[str, Union[int, float]]:
         values = {}
         for key in register_names:
             address, data_type = self.REGISTERS[key]
@@ -117,24 +122,24 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         log.debug("Bat raw values {}: {}".format(self.__tcp_client.address, values))
         return values
 
-    def write_registers(self, values_to_write: Dict[str, Union[int, float]], unit: int) -> None:
+    def _write_registers(self, values_to_write: Dict[str, Union[int, float]], unit: int) -> None:
         for key, value in values_to_write.items():
             address, data_type = self.REGISTERS[key]
-            encoded_value = self.encode_value(value, data_type)
+            encoded_value = self._encode_value(value, data_type)
             self.__tcp_client.write_registers(address, encoded_value, unit=unit)
             log.debug(f"Neuer Wert {encoded_value} in Register {address} geschrieben.")
 
-    def encode_value(self, value: Union[int, float], data_type: ModbusDataType) -> list:
+    def _encode_value(self, value: Union[int, float], data_type: ModbusDataType) -> list:
         builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Big)
 
         if data_type == ModbusDataType.UINT_32:
-            builder.add_32bit_uint(value)
+            builder.add_32bit_uint(int(value))
         elif data_type == ModbusDataType.INT_32:
-            builder.add_32bit_int(value)
+            builder.add_32bit_int(int(value))
         elif data_type == ModbusDataType.UINT_16:
-            builder.add_16bit_uint(value)
+            builder.add_16bit_uint(int(value))
         elif data_type == ModbusDataType.INT_16:
-            builder.add_16bit_int(value)
+            builder.add_16bit_int(int(value))
         else:
             raise ValueError(f"Unsupported data type: {data_type}")
 

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 from typing import Dict, Union
 
 from dataclass_utils import dataclass_from_dict
@@ -10,6 +11,8 @@ from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaSunnyBoySmartEnergyBatSetup
+
+log = logging.getLogger(__name__)
 
 
 class SunnyBoySmartEnergyBat(AbstractBat):
@@ -54,12 +57,14 @@ class SunnyBoySmartEnergyBat(AbstractBat):
                              'Sobald die Batterie geladen/entladen wird sollte sich dieser Wert ändern, ',
                              'andernfalls kann ein Defekt vorliegen.')
 
-        return BatState(
+        bat_state = BatState(
             power=power,
             soc=soc,
             imported=imported,
             exported=exported
         )
+        log.debug("Bat {}: {}".format(self.tcp_client.address, bat_state))
+        return bat_state
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SmaSunnyBoySmartEnergyBatSetup)

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import logging
-from typing import Dict, Union, Tuple
+from typing import Dict, Union, Optional
 
 from dataclass_utils import dataclass_from_dict
 from modules.common.abstract_device import AbstractBat
@@ -11,6 +11,8 @@ from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaSunnyBoySmartEnergyBatSetup
+from pymodbus.payload import BinaryPayloadBuilder
+from pymodbus.constants import Endian
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +20,18 @@ log = logging.getLogger(__name__)
 class SunnyBoySmartEnergyBat(AbstractBat):
     SMA_UINT32_NAN = 0xFFFFFFFF  # SMA uses this value to represent NaN
     SMA_UINT_64_NAN = 0xFFFFFFFFFFFFFFFF  # SMA uses this value to represent NaN
+
+    # Define all possible registers with their data types
+    REGISTERS = {
+        "Battery_SoC": (30845, ModbusDataType.UINT_32),
+        "Battery_ChargePower": (31393, ModbusDataType.INT_32),
+        "Battery_DischargePower": (31395, ModbusDataType.INT_32),
+        "Battery_ChargedEnergy": (31397, ModbusDataType.UINT_64),
+        "Battery_DischargedEnergy": (31401, ModbusDataType.UINT_64),
+        "Inverter_Type": (30053, ModbusDataType.UINT_32),
+        "Externe_Steuerung": (40151, ModbusDataType.UINT_32),
+        "Wirkleistungsvorgabe": (40149, ModbusDataType.UINT_32),
+    }
 
     def __init__(self,
                  device_id: int,
@@ -36,18 +50,18 @@ class SunnyBoySmartEnergyBat(AbstractBat):
     def read(self) -> BatState:
         unit = self.component_config.configuration.modbus_id
 
-        # Define the required registers
-        registers = {
-            "Battery_SoC": (30845, ModbusDataType.UINT_32),
-            "Battery_ChargePower": (31393, ModbusDataType.INT_32),
-            "Battery_DischargePower": (31395, ModbusDataType.INT_32),
-            "Battery_ChargedEnergy": (31397, ModbusDataType.UINT_64),
-            "Battery_DischargedEnergy": (31401, ModbusDataType.UINT_64),
-            "Inverter_Type": (30053, ModbusDataType.UINT_32)
-        }
+        # List the required registers to read
+        registers_to_read = [
+            "Battery_SoC",
+            "Battery_ChargePower",
+            "Battery_DischargePower",
+            "Battery_ChargedEnergy",
+            "Battery_DischargedEnergy",
+            "Inverter_Type"
+        ]
 
         # Read all values
-        values = self.read_registers(registers, unit)
+        values = self.read_registers(registers_to_read, unit)
 
         if values["Battery_SoC"] == self.SMA_UINT32_NAN:
             # If the storage is empty and nothing is produced on the DC side, the inverter does not supply any values.
@@ -77,14 +91,54 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         log.debug("Bat {}: {}".format(self.__tcp_client.address, bat_state))
         return bat_state
 
-    def read_registers(
-        self, registers: Dict[str, Tuple[int, ModbusDataType]], unit: int
-    ) -> Dict[str, Union[int, float]]:
+    def set_power_limit(self, power_limit: Optional[int]) -> None:
+        unit = self.component_config.configuration.modbus_id
+
+        if power_limit is None:
+            log.debug("Keine Batteriesteuerung gefordert, deaktiviere externe Steuerung.")
+            values_to_write = {
+                "Externe_Steuerung": 803,
+                "Wirkleistungsvorgabe": 0,
+            }
+        else:
+            log.debug("Aktive Batteriesteuerung vorhanden. Setze externe Steuerung.")
+            values_to_write = {
+                "Externe_Steuerung": 802,
+                "Wirkleistungsvorgabe": power_limit
+            }
+
+        self.write_registers(values_to_write, unit)
+
+    def read_registers(self, register_names: list, unit: int) -> Dict[str, Union[int, float]]:
         values = {}
-        for key, (address, data_type) in registers.items():
+        for key in register_names:
+            address, data_type = self.REGISTERS[key]
             values[key] = self.__tcp_client.read_holding_registers(address, data_type, unit=unit)
         log.debug("Bat raw values {}: {}".format(self.__tcp_client.address, values))
         return values
+
+    def write_registers(self, values_to_write: Dict[str, Union[int, float]], unit: int) -> None:
+        for key, value in values_to_write.items():
+            address, data_type = self.REGISTERS[key]
+            encoded_value = self.encode_value(value, data_type)
+            self.__tcp_client.write_registers(address, encoded_value, unit=unit)
+            log.debug(f"Neuer Wert {encoded_value} in Register {address} geschrieben.")
+
+    def encode_value(self, value: Union[int, float], data_type: ModbusDataType) -> list:
+        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Big)
+
+        if data_type == ModbusDataType.UINT_32:
+            builder.add_32bit_uint(value)
+        elif data_type == ModbusDataType.INT_32:
+            builder.add_32bit_int(value)
+        elif data_type == ModbusDataType.UINT_16:
+            builder.add_16bit_uint(value)
+        elif data_type == ModbusDataType.INT_16:
+            builder.add_16bit_int(value)
+        else:
+            raise ValueError(f"Unsupported data type: {data_type}")
+
+        return builder.to_registers()
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SmaSunnyBoySmartEnergyBatSetup)

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -34,15 +34,18 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         unit = self.component_config.configuration.modbus_id
 
         soc = self.__tcp_client.read_holding_registers(30845, ModbusDataType.UINT_32, unit=unit)
-        current = self.__tcp_client.read_holding_registers(30843, ModbusDataType.INT_32, unit=unit)/-1000
-        voltage = self.__tcp_client.read_holding_registers(30851, ModbusDataType.INT_32, unit=unit)/100
+        imp = self.__tcp_client.read_holding_registers(31393, ModbusDataType.INT_32, unit=unit)
+        exp = self.__tcp_client.read_holding_registers(31395, ModbusDataType.INT_32, unit=unit)
 
         if soc == self.SMA_UINT32_NAN:
             # If the storage is empty and nothing is produced on the DC side, the inverter does not supply any values.
             soc = 0
             power = 0
         else:
-            power = current*voltage
+            if imp > 5:
+                power = imp
+            else:
+                power = exp * -1
         exported = self.__tcp_client.read_holding_registers(31401, ModbusDataType.UINT_64, unit=3)
         imported = self.__tcp_client.read_holding_registers(31397, ModbusDataType.UINT_64, unit=3)
 

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_tesvolt.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_tesvolt.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 
 from modules.common.abstract_device import AbstractBat
 from modules.common.component_state import BatState
@@ -8,6 +9,8 @@ from modules.common.modbus import ModbusTcpClient_, ModbusDataType
 from modules.common.simcount._simcounter import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sma.sma_sunny_boy.config import SmaTesvoltBatSetup
+
+log = logging.getLogger(__name__)
 
 
 class TesvoltBat(AbstractBat):
@@ -32,7 +35,7 @@ class TesvoltBat(AbstractBat):
             imported=imported,
             exported=exported
         )
-
+        log.debug("Bat {}: {}".format(self.tcp_client.address, bat_state))
         self.store.set(bat_state)
 
 

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_tesvolt.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_tesvolt.py
@@ -35,7 +35,7 @@ class TesvoltBat(AbstractBat):
             imported=imported,
             exported=exported
         )
-        log.debug("Bat {}: {}".format(self.tcp_client.address, bat_state))
+        log.debug("Bat {}: {}".format(self.__tcp_client.address, bat_state))
         self.store.set(bat_state)
 
 


### PR DESCRIPTION
Liest die Lade/Entladeleistung aus den Modbusregistern aus anstelle diese durch Batteriespannung und -strom zu berechnen.
* adressiert u.a. negative PV Erträge in den Momentanwerten bei geringer PV Leistung
* exaktere Energiemengen in den Tages- und Wochenzählern welche nun auch mit den SMA Portalen übereinstimmen
https://forum.openwb.de/viewtopic.php?p=122770#p122770

Fügt aktive Speichersteuerung für SMA Hybrid-WR hinzu.
Fügt Logging für gelesene Werte für alle SMA Batterietypen hinzu.

Ersetzt https://github.com/openWB/core/pull/2163