### PR TITLE
[ADD] Integration Battery Index for SolarEdge Batteries

### DIFF
--- a/packages/modules/devices/solaredge/solaredge/bat.py
+++ b/packages/modules/devices/solaredge/solaredge/bat.py
@@ -47,12 +47,31 @@ class SolaredgeBat(AbstractBat):
 
     def get_values(self) -> Tuple[float, float]:
         unit = self.component_config.configuration.modbus_id
+        # Use 1 as fallback if battery_index is not set
+        battery_index = getattr(self.component_config.configuration, "battery_index", 1)
+
+        # Define registers based on battery_index
+        if battery_index == 1:
+            soc_reg = 62852  # Battery 1 SoC
+            power_reg = 62836  # Battery 1 Power
+        elif battery_index == 2:
+            soc_reg = 63108  # Battery 2 SoC
+            power_reg = 63092  # Battery 2 Power
+        else:
+            raise ValueError(f"Invalid battery_index: {battery_index}. Must be 1 or 2.")
+
+        # Read SoC and Power from the appropriate registers
         soc = self.__tcp_client.read_holding_registers(
-            62852, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit)
+            soc_reg, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit
+        )
         power = self.__tcp_client.read_holding_registers(
-            62836, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit)
+            power_reg, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit
+        )
+
+        # Handle unsupported FLOAT32 case
         if power == FLOAT32_UNSUPPORTED:
             power = 0
+
         return power, soc
 
     def get_imported_exported(self, power: float) -> Tuple[float, float]:

--- a/packages/modules/devices/solaredge/solaredge/config.py
+++ b/packages/modules/devices/solaredge/solaredge/config.py
@@ -24,8 +24,9 @@ class Solaredge:
 
 
 class SolaredgeBatConfiguration:
-    def __init__(self, modbus_id: int = 1):
+    def __init__(self, modbus_id: int = 1, battery_index: int = 1):
         self.modbus_id = modbus_id
+        self.battery_index = battery_index
 
 
 class SolaredgeBatSetup(ComponentSetup[SolaredgeBatConfiguration]):


### PR DESCRIPTION
https://github.com/openWB/openwb-ui-settings/pull/654

Details:
https://forum.openwb.de/viewtopic.php?t=9875

Uses new registers from solaredge specification.
https://forum.iobroker.net/assets/uploads/files/1709136209375-decimal-power-control-open-protocol-for-solaredge-inverters.pdf

Similar to the handling here:
https://github.com/WillCodeForCats/solaredge-modbus-multi/blob/main/custom_components/solaredge_modbus_multi/const.py#L159
