### PR TITLE
Added Server config value for passive checks

### DIFF
--- a/packages/modules/monitoring/zabbix/api.py
+++ b/packages/modules/monitoring/zabbix/api.py
@@ -26,6 +26,7 @@ def create_config(config: Zabbix):
         key_file.write(config.configuration.psk_key)
     with open(CONFIG_PATH, "r+") as config_file:
         lines = config_file.readlines()
+        set_value(lines, "Server", config.configuration.destination_host)
         set_value(lines, "ServerActive", config.configuration.destination_host)
         set_value(lines, "Hostname", config.configuration.hostname)
         set_value(lines, "TLSConnect", "psk")


### PR DESCRIPTION
Right now, it's only possible to use Active checks in Zabbix, so this PR adds the same server to the passive Server list.