### PR TITLE
Io actions

### DIFF
--- a/docs/IO-Geräte & -Aktionen.md
+++ b/docs/IO-Geräte & -Aktionen.md
@@ -25,6 +25,6 @@ Die AddOn-Platine stellt 7 Eingänge und 3 Ausgänge zur Verfügung. WICHTIG: In
 
 ## IO-Aktionen
 
-### Steuerbare Verbrauchseinrichtungen: Dimmen per HEMS, Dimmung per Direkt-Steuerung, RSE
+### Steuerbare Verbrauchseinrichtungen: Dimmen per EMS, Dimmung per Direkt-Steuerung, RSE
 
 Ausführliche Informationen findest Du im gesonderten Wiki-Beitrag [Steuerbare Verbrauchseinrichtungen](https://github.com/openWB/core/wiki/Steuerbare-Verbrauchseinrichtungen)

--- a/docs/Steuerbare Verbrauchseinrichtungen nach § 14a.md
+++ b/docs/Steuerbare Verbrauchseinrichtungen nach § 14a.md
@@ -1,6 +1,6 @@
 Der Gesetzgeber sieht verschiedene Möglichkeiten für steuerbare Verbrauchseinrichtungen vor. Für jede steuerbare Verbrauchseinrichtung kann eine andere Option angemeldet werden. Bei der Konfiguration muss deshalb auch immer der/die Ladepunkte angegeben werden, für die die IO-Aktion angewendet werden soll.
 
-### Dimmen per HEMS
+### Dimmen per EMS
 
 Beim Dimmen wird eine maximale Bezugsleistung für alle steuerbaren Verbrauchseinrichtungen nach einer vorgegebene Formel ermittelt. Das Ergebnis dieser Formel muss bei der IO-Aktion `Dimmen` in der Einstellung `maximale Bezugsleistung` eingetragen werden. ACHTUNG: Die openWB kann aktuell nur die Ladepunkte berücksichtigen. Sind noch weitere steuerbare Verbraucher angemeldet, können diese über einen digitalen Ausgang angebunden werden. Da openWB die Leistung dieser Geräte nicht kennt, werden 4,2kW angenommen. Muss der Verbraucher seine Leistung begrenzen, wird der Ausgang auf 0V gesetzt. Für die korrekte Ermittlung der maximalen Bezugsleistung ist der Betreiber, nicht openWB oder die software2 verantwortlich.
 Vorhandener Überschuss kann zusätzlich zur maximalen Bezugsleistung verwendet werden.

--- a/packages/control/process.py
+++ b/packages/control/process.py
@@ -75,13 +75,13 @@ class Process:
                     for d in action.config.configuration.devices:
                         if d["type"] == "io":
                             data.data.io_states[f"io_states{d['id']}"].data.set.digital_output[d["digital_output"]] = (
-                                action.dimming_via_direct_control() is not None
+                                action.dimming_via_direct_control() is None  # active output (True) if no dimming
                             )
                 if isinstance(action, Dimming):
                     for d in action.config.configuration.devices:
                         if d["type"] == "io":
                             data.data.io_states[f"io_states{d['id']}"].data.set.digital_output[d["digital_output"]] = (
-                                action.dimming_active()
+                                not action.dimming_active()  # active output (True) if no dimming
                             )
             for io in data.data.system_data.values():
                 if isinstance(io, AbstractIoDevice):

--- a/packages/modules/io_actions/controllable_consumers/dimming/api.py
+++ b/packages/modules/io_actions/controllable_consumers/dimming/api.py
@@ -21,17 +21,17 @@ class Dimming(AbstractIoAction):
             if len(input_matrix_list):
                 if pattern["value"]:
                     self.dimming_input, self.dimming_value = input_matrix_list[0]
-                    control_command_log.info(f"Dimmen per HEMS: Eingang {self.dimming_input} wird überwacht.")
+                    control_command_log.info(f"Dimmen per EMS: Eingang {self.dimming_input} wird überwacht.")
                 if pattern["value"] is False:
                     self.no_dimming_input, self.no_dimming_value = input_matrix_list[0]
             else:
-                control_command_log.warning("Dimmen per HEMS: Kein Eingang zum Überwachen konfiguriert.")
+                control_command_log.warning("Dimmen per EMS: Kein Eingang zum Überwachen konfiguriert.")
 
         fixed_import_power = 0
         for device in self.config.configuration.devices:
             if device["type"] != "cp":
                 fixed_import_power += 4200
-        log.debug(f"Dimmen per HEMS: Fest vergebene Mindestleistung: {fixed_import_power}W")
+        log.debug(f"Dimmen per EMS: Fest vergebene Mindestleistung: {fixed_import_power}W")
         if fixed_import_power != self.config.configuration.fixed_import_power:
             self.config.configuration.fixed_import_power = fixed_import_power
             Pub().pub(f"openWB/set/io/action/{self.config.id}/config", asdict(self.config))

--- a/packages/modules/io_actions/controllable_consumers/dimming/config.py
+++ b/packages/modules/io_actions/controllable_consumers/dimming/config.py
@@ -17,7 +17,7 @@ class DimmingConfig:
 
 class DimmingSetup:
     def __init__(self,
-                 name: str = "Dimmen per HEMS",
+                 name: str = "Dimmen per EMS",
                  type: str = "dimming",
                  id: int = 0,
                  configuration: DimmingConfig = None):


### PR DESCRIPTION
- Umbenennung "HEMS" -> "EMS"
- Den Aktionen "Dimmen" und "Dimmen per Direktsteuerung" zugeordnete Ausgänge werden invertiert gesetzt; "ungedimmt" entspricht jetzt einem aktiven/geschalteten, "gedimmt" einem nicht aktiven/nicht geschalteten Ausgangszustand