### PR TITLE
Force SoC-Update after chargestop

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -282,10 +282,10 @@ class Chargepoint(ChargepointRfidMixin):
                       self.data.set.plug_time)
 
     def remember_previous_values(self):
-        self.data.get.charge_state_prev = self.data.get.charge_state
+        self.data.set.charge_state_prev = self.data.get.charge_state
         self.data.set.plug_state_prev = self.data.get.plug_state
         self.data.set.current_prev = self.data.set.current
-        Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/get/charge_state_prev", self.data.get.charge_state_prev)
+        Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/charge_state_prev", self.data.set.charge_state_prev)
         Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/plug_state_prev", self.data.set.plug_state_prev)
         Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/current_prev", self.data.set.current_prev)
 
@@ -427,8 +427,8 @@ class Chargepoint(ChargepointRfidMixin):
                     self.data.control_parameter.state = ChargepointState.PHASE_SWITCH_AWAITED
                     if self._is_phase_switch_required() is False:
                         self.data.control_parameter.state = ChargepointState.CHARGING_ALLOWED
-        except Exception as e:
-            log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num) + ", error=" + str(e))
+        except Exception:
+            log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num))
 
     def initiate_phase_switch(self):
         """prüft, ob eine Phasenumschaltung erforderlich ist und führt diese durch.
@@ -707,11 +707,11 @@ class Chargepoint(ChargepointRfidMixin):
                     self._pub_configured_ev(ev_list)
             try:
                 # check für charging stop or charging interruption, if so force a soc query for the ev
-                if self.data.get.charge_state_prev and self.data.get.charge_state is False:
+                if self.data.set.charge_state_prev and self.data.get.charge_state is False:
                     Pub().pub(f"openWB/set/vehicle/{self.data.config.ev}/get/force_soc_update", True)
-                    log.debug(f"SoC-Abfrage nach Ladeunterbrechung, cp{self.num}, ev{self.data.config.ev}")
-            except Exception as e:
-                log.exception(f"Fehler bei Ladestop,cp{self.num}, err={e}")
+                    log.info(f"SoC-Abfrage nach Ladeunterbrechung, cp{self.num}, ev{self.data.config.ev}")
+            except Exception:
+                log.exception(f"Fehler bei Ladestop,cp{self.num}")
 
             # OCPP Start Transaction nach Anstecken
             if ((self.data.get.plug_state and self.data.set.plug_state_prev is False) or

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -282,8 +282,10 @@ class Chargepoint(ChargepointRfidMixin):
                       self.data.set.plug_time)
 
     def remember_previous_values(self):
+        self.data.get.charge_state_prev = self.data.get.charge_state
         self.data.set.plug_state_prev = self.data.get.plug_state
         self.data.set.current_prev = self.data.set.current
+        Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/get/charge_state_prev", self.data.get.charge_state_prev)
         Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/plug_state_prev", self.data.set.plug_state_prev)
         Pub().pub("openWB/set/chargepoint/"+str(self.num)+"/set/current_prev", self.data.set.current_prev)
 
@@ -425,8 +427,8 @@ class Chargepoint(ChargepointRfidMixin):
                     self.data.control_parameter.state = ChargepointState.PHASE_SWITCH_AWAITED
                     if self._is_phase_switch_required() is False:
                         self.data.control_parameter.state = ChargepointState.CHARGING_ALLOWED
-        except Exception:
-            log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num))
+        except Exception as e:
+            log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num) + ", error=" + str(e))
 
     def initiate_phase_switch(self):
         """prüft, ob eine Phasenumschaltung erforderlich ist und führt diese durch.
@@ -703,6 +705,14 @@ class Chargepoint(ChargepointRfidMixin):
                     self._pub_connected_vehicle(ev_list[f"ev{vehicle}"])
                 else:
                     self._pub_configured_ev(ev_list)
+            try:
+                # check für charging stop or charging interruption, if so force a soc query for the ev
+                if self.data.get.charge_state_prev and self.data.get.charge_state is False:
+                    Pub().pub(f"openWB/set/vehicle/{self.data.config.ev}/get/force_soc_update", True)
+                    log.debug(f"SoC-Abfrage nach Ladeunterbrechung, cp{self.num}, ev{self.data.config.ev}")
+            except Exception as e:
+                log.exception(f"Fehler bei Ladestop,cp{self.num}, err={e}")
+
             # OCPP Start Transaction nach Anstecken
             if ((self.data.get.plug_state and self.data.set.plug_state_prev is False) or
                     (self.data.set.ocpp_transaction_id is None and self.data.get.charge_state)):

--- a/packages/control/chargepoint/chargepoint_data.py
+++ b/packages/control/chargepoint/chargepoint_data.py
@@ -90,7 +90,6 @@ def connected_vehicle_factory() -> ConnectedVehicle:
 @dataclass
 class Get:
     charge_state: bool = False
-    charge_state_prev: bool = False
     charging_current: Optional[float] = 0
     charging_power: Optional[float] = 0
     charging_voltage: Optional[float] = 0
@@ -147,6 +146,7 @@ class Set:
     target_current: float = 0  # Soll-Strom aus fest vorgegebener Stromstärke
     charging_ev_data: Ev = field(default_factory=ev_factory)
     ocpp_transaction_id: Optional[int] = None
+    charge_state_prev: bool = False
 
 
 @dataclass

--- a/packages/control/chargepoint/chargepoint_data.py
+++ b/packages/control/chargepoint/chargepoint_data.py
@@ -90,6 +90,7 @@ def connected_vehicle_factory() -> ConnectedVehicle:
 @dataclass
 class Get:
     charge_state: bool = False
+    charge_state_prev: bool = False
     charging_current: Optional[float] = 0
     charging_power: Optional[float] = 0
     charging_voltage: Optional[float] = 0

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -546,6 +546,7 @@ class SetData:
                         "/set/perform_control_pilot_interruption" in msg.topic or
                         "/set/perform_phase_switch" in msg.topic or
                         "/set/ocpp_transaction_active" in msg.topic or
+                        "/get/charge_state_prev" in msg.topic or
                         "/set/plug_state_prev" in msg.topic):
                     self._validate_value(msg, bool)
                 elif "/set/autolock_state" in msg.topic:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -546,7 +546,7 @@ class SetData:
                         "/set/perform_control_pilot_interruption" in msg.topic or
                         "/set/perform_phase_switch" in msg.topic or
                         "/set/ocpp_transaction_active" in msg.topic or
-                        "/get/charge_state_prev" in msg.topic or
+                        "/set/charge_state_prev" in msg.topic or
                         "/set/plug_state_prev" in msg.topic):
                     self._validate_value(msg, bool)
                 elif "/set/autolock_state" in msg.topic:

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -134,7 +134,7 @@ class UpdateConfig:
         "^openWB/chargepoint/[0-9]+/set/current$",
         "^openWB/chargepoint/[0-9]+/set/energy_to_charge$",
         "^openWB/chargepoint/[0-9]+/set/manual_lock$",
-        "^openWB/chargepoint/[0-9]+/get/charge_state_prev$",
+        "^openWB/chargepoint/[0-9]+/set/charge_state_prev$",
         "^openWB/chargepoint/[0-9]+/set/plug_state_prev$",
         "^openWB/chargepoint/[0-9]+/set/plug_time$",
         "^openWB/chargepoint/[0-9]+/set/rfid$",

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -134,6 +134,7 @@ class UpdateConfig:
         "^openWB/chargepoint/[0-9]+/set/current$",
         "^openWB/chargepoint/[0-9]+/set/energy_to_charge$",
         "^openWB/chargepoint/[0-9]+/set/manual_lock$",
+        "^openWB/chargepoint/[0-9]+/get/charge_state_prev$",
         "^openWB/chargepoint/[0-9]+/set/plug_state_prev$",
         "^openWB/chargepoint/[0-9]+/set/plug_time$",
         "^openWB/chargepoint/[0-9]+/set/rfid$",


### PR DESCRIPTION
Force an immediate SoC-Update after charging has stopped
- introduce in CP structure new variable set/charge_state_prev
- when charge_state is False and charge_state_prev is True send True to get/force_soc_update of connected vehicle