### PR TITLE
electricity tariff: use cached price list in case of error

### DIFF
--- a/packages/control/ev/charge_template.py
+++ b/packages/control/ev/charge_template.py
@@ -149,7 +149,7 @@ class ChargeTemplate:
                 plan = timecheck.check_plans_timeframe(self.data.time_charging.plans)
                 if plan is not None:
                     current = plan.current if charging_type == ChargingType.AC.value else plan.dc_current
-                    if self.data.et.active and data.data.optional_data.et_provider_available():
+                    if self.data.et.active:
                         if not data.data.optional_data.et_charging_allowed(self.data.et.max_price):
                             return 0, "stop", self.CHARGING_PRICE_EXCEEDED, plan.id
                     if plan.limit.selected == "none":  # kein Limit konfiguriert, mit konfigurierter Stromstärke laden
@@ -195,7 +195,7 @@ class ChargeTemplate:
                 current = instant_charging.current
             else:
                 current = instant_charging.dc_current
-            if self.data.et.active and data.data.optional_data.et_provider_available():
+            if self.data.et.active:
                 if not data.data.optional_data.et_charging_allowed(self.data.et.max_price):
                     return 0, "stop", self.CHARGING_PRICE_EXCEEDED
             if instant_charging.limit.selected == "none":
@@ -446,7 +446,7 @@ class ChargeTemplate:
         else:
             # Wenn dynamische Tarife aktiv sind, prüfen, ob jetzt ein günstiger Zeitpunkt zum Laden
             # ist.
-            if self.data.et.active and data.data.optional_data.et_provider_available():
+            if self.data.et.active:
                 hour_list = data.data.optional_data.et_get_loading_hours(plan_data.duration, plan_data.remaining_time)
                 hours_message = ("Geladen wird zu folgenden Uhrzeiten: " +
                                  ", ".join([datetime.datetime.fromtimestamp(hour).strftime('%-H:%M')

--- a/packages/control/ev/charge_template_test.py
+++ b/packages/control/ev/charge_template_test.py
@@ -297,8 +297,6 @@ def test_scheduled_charging_calc_current_electricity_tariff(loading_hour, expect
     mock_et_get_loading_hours = Mock(return_value=[datetime.datetime(
         year=2022, month=5, day=16, hour=8, minute=0).timestamp()])
     monkeypatch.setattr(data.data.optional_data, "et_get_loading_hours", mock_et_get_loading_hours)
-    mock_et_provider_available = Mock(return_value=True)
-    monkeypatch.setattr(data.data.optional_data, "et_provider_available", mock_et_provider_available)
     mock_is_list_valid = Mock(return_value=loading_hour)
     monkeypatch.setattr(timecheck, "is_list_valid", mock_is_list_valid)
 

--- a/packages/control/optional_test.py
+++ b/packages/control/optional_test.py
@@ -1,10 +1,13 @@
+from unittest.mock import Mock
 from control.optional import Optional
 
 
-def test_et_get_loading_hours():
+def test_et_get_loading_hours(monkeypatch):
     # setup
     opt = Optional()
     opt.data.et.get.prices = PRICE_LIST
+    mock_et_provider_available = Mock(return_value=True)
+    monkeypatch.setattr(opt, "_et_provider_available", mock_et_provider_available)
 
     # execution
     loading_hours = opt.et_get_loading_hours(3600, 7200)


### PR DESCRIPTION
Wenn keine Preisliste abgefragt werden kann, wird solange die bestehende weiter verwendet. Wenn diese nicht mehr aktuell ist oder noch gar keine Preisliste abgefragt wurde, wird nicht geladen.

