### PR TITLE
Add SimCounter to SolaredgeInverter and update read_state for imported power

### DIFF
--- a/packages/modules/devices/solaredge/solaredge/inverter_test.py
+++ b/packages/modules/devices/solaredge/solaredge/inverter_test.py
@@ -26,6 +26,7 @@ def test_read_state():
         power=-1415.2,
         exported=8980404,
         currents=[6.16, 0, 0],
-        dc_power=-1436.8000000000002
+        dc_power=-1436.8000000000002,
+        imported=100,
     )
     )


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?p=126172#p126172

Fügt import Zähler für den Solaredge Wechselrichter hinzu. Dies sorgt für korrekte Zählerstände bei Batterieladung mit AC-seitiger Stromaufnahme (mehrere Wechselrichter, Notladung, etc.)