### PR TITLE
ostrom tariff: reuse access token until expired

### DIFF
--- a/packages/modules/electricity_tariffs/ostrom/config.py
+++ b/packages/modules/electricity_tariffs/ostrom/config.py
@@ -1,14 +1,26 @@
 from typing import Optional
 
 
+class OstromToken():
+    def __init__(self,
+                 access_token: Optional[str] = None,
+                 expires_in: Optional[str] = None,
+                 created_at: Optional[str] = None) -> None:
+        self.access_token = access_token
+        self.expires_in = expires_in
+        self.created_at = created_at
+
+
 class OstromTariffConfiguration:
     def __init__(self,
                  client_id: Optional[str] = None,
                  client_secret: Optional[str] = None,
-                 zip: Optional[str] = None):
+                 zip: Optional[str] = None,
+                 token: OstromToken = None):
         self.client_id = client_id
         self.client_secret = client_secret
         self.zip = zip
+        self.token = token or OstromToken()
 
 
 class OstromTariff:


### PR DESCRIPTION
Mir war anfangs nicht bewusst, dass die Strompreise alle 5 Minuten neu bezogen werden. Mit dem PR wird beim ostrom-Modul das access token zwischengespeichert und zum Preisabruf verwendet, bis es (nach 60 Minuten) abläuft, so dass weniger Anfragen an den authentication server gestellt werden müssen.