### PR TITLE
 add power_limit_controllable methode

### DIFF
--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -136,9 +136,9 @@ class SunnyBoySmartEnergyBat(AbstractBat):
 
     def _encode_value(self, value: Union[int, float], data_type: ModbusDataType) -> list:
         builder = pymodbus.payload.BinaryPayloadBuilder(
-                byteorder=pymodbus.constants.Endian.Big,
-                wordorder=pymodbus.constants.Endian.Big
-            )
+            byteorder=pymodbus.constants.Endian.Big,
+            wordorder=pymodbus.constants.Endian.Big
+        )
         encode_methods = {
             ModbusDataType.UINT_32: builder.add_32bit_uint,
             ModbusDataType.INT_32: builder.add_32bit_int,
@@ -152,6 +152,9 @@ class SunnyBoySmartEnergyBat(AbstractBat):
             raise ValueError(f"Unsupported data type: {data_type}")
 
         return builder.to_registers()
+
+    def power_limit_controllable(self) -> bool:
+        return True
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SmaSunnyBoySmartEnergyBatSetup)

--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -94,5 +94,8 @@ class SungrowBat(AbstractBat):
             power_value = int(min(power_limit, 5000))
             self.__tcp_client.write_registers(13051, [power_value], data_type=ModbusDataType.UINT_16, unit=unit)
 
+    def power_limit_controllable(self) -> bool:
+        return True
+
 
 component_descriptor = ComponentDescriptor(configuration_factory=SungrowBatSetup)


### PR DESCRIPTION
Nach dem Merge von #2299 kann nun in einer Methode geprüft werden, ob der Speicher die Speicher-Steuerung unterstützt. So können auch verschiedenen Speichermodelle abgebildet werden, die über die gleiche Schnittstelle angesprochen werden können, aber nicht alle die aktive Steuerung anbieten.
Nachführung von #2231 und #2228 