### PR TITLE
Deye counter fix

### DIFF
--- a/packages/modules/devices/deye/deye/bat.py
+++ b/packages/modules/devices/deye/deye/bat.py
@@ -52,8 +52,7 @@ class DeyeBat(AbstractBat):
             if self.device_type == DeviceType.THREE_PHASE_HV:
                 power = power * 10
             soc = self.client.read_holding_registers(588, ModbusDataType.INT_16, unit=unit)
-            imported = self.client.read_holding_registers(516, ModbusDataType.UINT_16, unit=unit) * 100
-            exported = self.client.read_holding_registers(518, ModbusDataType.UINT_16, unit=unit) * 100
+            imported, exported = self.sim_counter.sim_count(power)
 
         bat_state = BatState(
             power=power,

--- a/packages/modules/devices/deye/deye/inverter.py
+++ b/packages/modules/devices/deye/deye/inverter.py
@@ -36,18 +36,17 @@ class DeyeInverter(AbstractInverter):
 
         if self.device_type == DeviceType.SINGLE_PHASE_STRING or self.device_type == DeviceType.SINGLE_PHASE_HYBRID:
             power = sum(self.client.read_holding_registers(186, [ModbusDataType.INT_16]*4, unit=unit)) * -1
-            exported = self.sim_counter.sim_count(power)[1]
 
         else:  # THREE_PHASE_LV (0x0500, 0x0005), THREE_PHASE_HV (0x0006)
             power = sum(self.client.read_holding_registers(672, [ModbusDataType.INT_16]*2, unit=unit)) * -1
 
             if self.device_type == DeviceType.THREE_PHASE_HV:
                 power = power * 10
-            # 534: Gesamt Produktion Wechselrichter unsigned integer in kWh * 0,1
-            exported = self.client.read_holding_registers(534, ModbusDataType.UINT_16, unit=unit) * 100
+        imported, exported = self.sim_counter.sim_count(power)
 
         inverter_state = InverterState(
             power=power,
+            imported=imported,
             exported=exported,
         )
         self.store.set(inverter_state)


### PR DESCRIPTION
Bei den Deye HV Hybrid werden die Zählerstände zu gering aufgelöst und nur alle 10min aktualisiert, gleiches für die Batterie Zähler, daher Umstellung auf simcounter. 

Fix für https://github.com/openWB/core/issues/2286 

