### PR TITLE
Integration fix Algodue meter

### DIFF
--- a/packages/modules/devices/algodue/algodue/counter.py
+++ b/packages/modules/devices/algodue/algodue/counter.py
@@ -27,6 +27,15 @@ class AlgodueCounter(AbstractCounter):
         self.store = get_counter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
+    def initialize(self) -> None:
+        return
+        # self.__device_id: int = self.kwargs['device_id']
+        # self.__tcp_client: modbus.ModbusTcpClient_ = self.kwargs['tcp_client']
+        # self.__modbus_id: int = self.kwargs['modbus_id']
+        # self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
+        # self.store = get_counter_value_store(self.component_config.id)
+        # self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
+
     def update(self):
         with self.__tcp_client:
 

--- a/packages/modules/devices/algodue/algodue/counter.py
+++ b/packages/modules/devices/algodue/algodue/counter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-from typing import Dict, Union
+from typing import Any, TypedDict
 
-from dataclass_utils import dataclass_from_dict
 from modules.devices.algodue.algodue.config import AlgodueCounterSetup
 from modules.common import modbus
 from modules.common.abstract_device import AbstractCounter
@@ -13,28 +12,25 @@ from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 
 
+class KwargsDict(TypedDict):
+    device_id: int
+    tcp_client: modbus.ModbusTcpClient_
+    modbus_id: int
+
+
 class AlgodueCounter(AbstractCounter):
-    def __init__(self,
-                 device_id: int,
-                 component_config: Union[Dict, AlgodueCounterSetup],
-                 tcp_client: modbus.ModbusTcpClient_,
-                 modbus_id: int) -> None:
-        self.__device_id = device_id
-        self.component_config = dataclass_from_dict(AlgodueCounterSetup, component_config)
-        self.__tcp_client = tcp_client
-        self.__modbus_id = modbus_id
+    def __init__(self, component_config: AlgodueCounterSetup, **kwargs: Any) -> None:
+        self.component_config = component_config
+        self.kwargs: KwargsDict = kwargs
+
+    def initialize(self) -> None:
+        # return
+        self.__device_id: int = self.kwargs['device_id']
+        self.__tcp_client: modbus.ModbusTcpClient_ = self.kwargs['tcp_client']
+        self.__modbus_id: int = self.kwargs['modbus_id']
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_counter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
-
-    def initialize(self) -> None:
-        return
-        # self.__device_id: int = self.kwargs['device_id']
-        # self.__tcp_client: modbus.ModbusTcpClient_ = self.kwargs['tcp_client']
-        # self.__modbus_id: int = self.kwargs['modbus_id']
-        # self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        # self.store = get_counter_value_store(self.component_config.id)
-        # self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self):
         with self.__tcp_client:
@@ -46,6 +42,8 @@ class AlgodueCounter(AbstractCounter):
             power = sum(powers)
             voltages = self.__tcp_client.read_input_registers(
                 0x1000, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
+            power_factors = self.__tcp_client.read_input_registers(
+                0x1018, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
 
         imported, exported = self.sim_counter.sim_count(power)
 
@@ -56,7 +54,8 @@ class AlgodueCounter(AbstractCounter):
             imported=imported,
             exported=exported,
             power=power,
-            frequency=frequency
+            frequency=frequency,
+            power_factors=power_factors
         )
         self.store.set(counter_state)
 

--- a/packages/modules/devices/algodue/algodue/device.py
+++ b/packages/modules/devices/algodue/algodue/device.py
@@ -13,9 +13,12 @@ log = logging.getLogger(__name__)
 
 
 def create_device(device_config: Algodue):
+    client = None
+
     def create_counter_component(component_config: AlgodueCounterSetup):
-        return counter.AlgodueCounter(device_config.id, component_config, client,
-                                      device_config.configuration.modbus_id)
+        nonlocal client
+        return counter.AlgodueCounter(component_config=component_config, device_id=device_config.id,
+                                           tcp_client=client, modbus_id=device_config.configuration.modbus_id)
 
     def update_components(components: Iterable[counter.AlgodueCounter]):
         with client:


### PR DESCRIPTION
This change fixes Algodue counter failing due to missing "initialize" method and also adds the retrieval of power factors.

With this change, Algodue counter has been tested successfully.