### PR TITLE
fix power_limit sign, limit bat power only if cp is charging

### DIFF
--- a/packages/control/bat_all.py
+++ b/packages/control/bat_all.py
@@ -286,25 +286,31 @@ class BatAll:
             self.data.get.power_limit_controllable = False
 
     def get_power_limit(self):
+        chargepoint_by_chagemodes = get_chargepoints_by_chargemodes(CONSIDERED_CHARGE_MODES_ADDITIONAL_CURRENT)
+        power_of_chargepoints_by_chagemodes = sum(
+            [cp.data.get.power for cp in chargepoint_by_chagemodes if cp.data.get.power is not None])
         if (self.data.config.power_limit_mode != BatPowerLimitMode.NO_LIMIT.value
-                and len(get_chargepoints_by_chargemodes(CONSIDERED_CHARGE_MODES_ADDITIONAL_CURRENT)) > 0 and
+                and len(chargepoint_by_chagemodes) > 0 and
+                power_of_chargepoints_by_chagemodes > 0 and
                 self.data.get.power_limit_controllable and
                 # Nur wenn kein Überschuss im System ist, Speicherleistung begrenzen.
                 self.data.get.power <= 0 and
-                data.data.counter_all_data.get_evu_counter().data.get.power >= 0):
+                data.data.counter_all_data.get_evu_counter().data.get.power >= -100):
             if self.data.config.power_limit_mode == BatPowerLimitMode.LIMIT_STOP.value:
                 self.data.set.power_limit = 0
             elif self.data.config.power_limit_mode == BatPowerLimitMode.LIMIT_TO_HOME_CONSUMPTION.value:
-                self.data.set.power_limit = data.data.counter_all_data.data.set.home_consumption
+                self.data.set.power_limit = data.data.counter_all_data.data.set.home_consumption * -1
             log.debug(f"Speicher-Leistung begrenzen auf {self.data.set.power_limit/1000}kW")
         else:
             self.data.set.power_limit = None
             control_range_low = data.data.general_data.data.chargemode_config.pv_charging.control_range[0]
             control_range_high = data.data.general_data.data.chargemode_config.pv_charging.control_range[1]
             control_range_center = control_range_high - (control_range_high - control_range_low) / 2
-            if len(get_chargepoints_by_chargemodes(CONSIDERED_CHARGE_MODES_ADDITIONAL_CURRENT)) == 0:
+            if len(chargepoint_by_chagemodes) == 0:
                 log.debug("Speicher-Leistung nicht begrenzen, "
                           "da keine Ladepunkte in einem Lademodus mit Netzbezug sind.")
+            elif power_of_chargepoints_by_chagemodes <= 0:
+                log.debug("Speicher-Leistung nicht begrenzen, da kein Ladepunkt mit Netzubezug lädt.")
             elif self.data.get.power_limit_controllable is False:
                 log.debug("Speicher-Leistung nicht begrenzen, da keine regelbaren Speicher vorhanden sind.")
             elif self.data.get.power > 0:

--- a/packages/control/bat_all_test.py
+++ b/packages/control/bat_all_test.py
@@ -154,7 +154,9 @@ def test_get_charging_power_left(params: Params, caplog, data_fixture, monkeypat
 
 
 def default_chargepoint_factory() -> List[Chargepoint]:
-    return [Chargepoint(3, None)]
+    cp = Chargepoint(3, None)
+    cp.data.get.power = 1400
+    return [cp]
 
 
 @dataclass
@@ -176,10 +178,10 @@ cases = [
                      power_limit_mode=BatPowerLimitMode.LIMIT_STOP.value),
     PowerLimitParams("Begrenzung immer, Speicher lädt", None, bat_power=100,
                      power_limit_mode=BatPowerLimitMode.LIMIT_STOP.value),
-    PowerLimitParams("Begrenzung immer,Einspeisung", None, evu_power=-100,
+    PowerLimitParams("Begrenzung immer,Einspeisung", None, evu_power=-110,
                      power_limit_mode=BatPowerLimitMode.LIMIT_STOP.value),
     PowerLimitParams("Begrenzung immer", 0, power_limit_mode=BatPowerLimitMode.LIMIT_STOP.value),
-    PowerLimitParams("Begrenzung Hausverbrauch", 456,
+    PowerLimitParams("Begrenzung Hausverbrauch", -456,
                      power_limit_mode=BatPowerLimitMode.LIMIT_TO_HOME_CONSUMPTION.value),
 ]
 

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -114,7 +114,7 @@ class SunnyBoySmartEnergyBat(AbstractBat):
             log.debug("Aktive Batteriesteuerung vorhanden. Setze externe Steuerung.")
             values_to_write = {
                 "Externe_Steuerung": 802,
-                "Wirkleistungsvorgabe": power_limit
+                "Wirkleistungsvorgabe": abs(power_limit)
             }
             self._write_registers(values_to_write, unit)
             self.last_mode = 'limited'

--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -94,7 +94,8 @@ class SungrowBat(AbstractBat):
                 self.__tcp_client.write_registers(13050, [0xBB], data_type=ModbusDataType.UINT_16, unit=unit)
                 self.last_mode = 'discharge'
             # Die maximale Entladeleistung begrenzen auf 5000W, maximaler Wertebereich Modbusregister.
-            power_value = int(min(power_limit, 5000))
+            power_value = int(min(abs(power_limit), 5000))
+            log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
             self.__tcp_client.write_registers(13051, [power_value], data_type=ModbusDataType.UINT_16, unit=unit)
 
     def power_limit_controllable(self) -> bool:

--- a/packages/modules/devices/victron/victron/bat.py
+++ b/packages/modules/devices/victron/victron/bat.py
@@ -78,7 +78,7 @@ class VictronBat(AbstractBat):
                 self.__tcp_client.write_registers(39, [0], data_type=ModbusDataType.UINT_16, unit=228)
                 self.last_mode = 'discharge'
             # Die maximale Entladeleistung begrenzen auf 5000W
-            power_value = int(min(power_limit, 5000)) * -1
+            power_value = int(min(power_limit, 5000))
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen")
             self.__tcp_client.write_registers(37, [power_value & 0xFFFF], data_type=ModbusDataType.INT_16, unit=228)
 


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?p=128580#p128580

Der Wert für die Speicherbegrenzug wird nun mit Vorzeichen übergeben.
Wenn kein Auto lädt, die Speicherentladung nicht begrenzen.