### PR TITLE
Koala theme - Add tooltips to lock and priority toggles

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ChargePointLock.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointLock.vue
@@ -13,7 +13,11 @@
     unchecked-icon="lock_open"
     size="lg"
     :dense="props.dense"
-  />
+  >
+    <q-tooltip>
+      {{ locked ? 'Ladepunkt gesperrt' : 'Ladepunkt entsperrt' }}
+    </q-tooltip>
+  </q-toggle>
 </template>
 
 <script setup lang="ts">

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointPriority.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointPriority.vue
@@ -13,7 +13,11 @@
     :unchecked-icon="icon.off"
     size="lg"
     :dense="props.dense"
-  />
+  >
+    <q-tooltip>
+      {{ priority ? 'Fahrzeug priorisiert' : 'Fahrzeug nicht priorisiert' }}
+    </q-tooltip>
+  </q-toggle>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
in Ladepunkt-Karte wurden die Schalter Sperren und Priorität mit einem Tooltip versehen