### PR TITLE
Koala theme DC power value for settings sliders set to zero decimal places

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ChargePointPvSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointPvSettings.vue
@@ -18,7 +18,7 @@
     :max="300"
     :step="1"
     unit="kW"
-    v-model="pvMinDcCurrent.value"
+    v-model="pvMinDcPower.value"
     class="q-mt-md"
   />
 
@@ -87,6 +87,17 @@
       :max="32"
       unit="A"
       v-model="pvMinSocCurrent.value"
+      class="q-mt-md"
+    />
+
+    <SliderStandard
+      v-if="dcCharging"
+      title="DC Mindest-SoC-Leistung"
+      :min="0"
+      :max="300"
+      :step="1"
+      unit="kW"
+      v-model="pvMinDcMinSocPower.value"
       class="q-mt-md"
     />
     <div class="text-subtitle2 q-mt-sm q-mr-sm">Anzahl Phasen Mindest-SoC</div>
@@ -158,8 +169,12 @@ const pvMinCurrent = computed(() =>
 
 const dcCharging = computed(() => mqttStore.dcChargingEnabled);
 
-const pvMinDcCurrent = computed(() =>
+const pvMinDcPower = computed(() =>
   mqttStore.chargePointConnectedVehiclePvDcChargePower(props.chargePointId),
+);
+
+const pvMinDcMinSocPower = computed(() =>
+  mqttStore.chargePointConnectedVehiclePvDcMinSocPower(props.chargePointId),
 );
 
 const numPhases = computed(() =>

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -981,7 +981,7 @@ export const useMqttStore = defineStore('mqtt', () => {
           chargePointConnectedVehicleChargeTemplate(chargePointId).value
             ?.chargemode?.instant_charging?.dc_current;
         if (dcCurrent !== undefined) {
-          return (dcCurrent * 3 * 230) / 1000;
+          return Math.round((dcCurrent * 3 * 230) / 1000);
         } else {
           return 0;
         }
@@ -1144,7 +1144,7 @@ export const useMqttStore = defineStore('mqtt', () => {
           chargePointConnectedVehicleChargeTemplate(chargePointId).value
             ?.chargemode?.pv_charging?.dc_min_current;
         if (dcMinCurrent !== undefined) {
-          return (dcMinCurrent * 3 * 230) / 1000;
+          return Math.round((dcMinCurrent * 3 * 230) / 1000);
         } else {
           return 0;
         }
@@ -1405,7 +1405,7 @@ export const useMqttStore = defineStore('mqtt', () => {
           chargePointConnectedVehicleChargeTemplate(chargePointId).value
             ?.chargemode?.eco_charging?.dc_current;
         if (dcCurrent !== undefined) {
-          return (dcCurrent * 3 * 230) / 1000;
+          return Math.round((dcCurrent * 3 * 230) / 1000);
         } else {
           return 0;
         }

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -1163,6 +1163,38 @@ export const useMqttStore = defineStore('mqtt', () => {
   };
 
   /**
+   * Get or set the charge point connected vehicle PV charging DC minimum SoC Power identified by the charge point id
+   * @param chargePointId charge point id
+   * @returns number
+   */
+  const chargePointConnectedVehiclePvDcMinSocPower = (
+    chargePointId: number,
+  ) => {
+    return computed({
+      get() {
+        const dcMinSocCurrent =
+          chargePointConnectedVehicleChargeTemplate(chargePointId).value
+            ?.chargemode?.pv_charging?.dc_min_soc_current;
+        if (dcMinSocCurrent !== undefined) {
+          return Math.round((dcMinSocCurrent * 3 * 230) / 1000);
+        } else {
+          return 0;
+        }
+      },
+      set(newValue: number) {
+        console.debug('set instant charging power', newValue, chargePointId);
+        const newPower = (newValue * 1000) / 230 / 3;
+        return updateTopic(
+          `openWB/chargepoint/${chargePointId}/set/charge_template`,
+          newPower,
+          'chargemode.pv_charging.dc_min_soc_current',
+          true,
+        );
+      },
+    });
+  };
+
+  /**
    * Get or set the charge point connected vehicle pv min SoC identified by the charge point id
    * @param chargePointId charge point id
    * @returns object | undefined
@@ -2762,6 +2794,7 @@ export const useMqttStore = defineStore('mqtt', () => {
     chargePointConnectedVehiclePvChargeMinSoc,
     chargePointConnectedVehiclePvChargeMinSocCurrent,
     chargePointConnectedVehiclePvDcChargePower,
+    chargePointConnectedVehiclePvDcMinSocPower,
     chargePointConnectedVehiclePvChargePhasesMinSoc,
     chargePointConnectedVehiclePvChargeFeedInLimit,
     chargePointConnectedVehicleEcoChargeCurrent,


### PR DESCRIPTION
Leistungswerte mit vielen Nachkommastellen hat Formatierungsprobleme bei den DC- Einstellungs-Slider verursacht.