### PR TITLE
Koala theme Update formatting in cards and settings dialogs

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/BatteryCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BatteryCard.vue
@@ -24,7 +24,7 @@
           {{ power }}
         </div>
       </div>
-      <div v-if="showSettings" class="row q-mt-md text-subtitle2">
+      <div v-if="showSettings" class="row q-mt-md justify-between text-subtitle2">
         <div>Laden mit Überschuss:</div>
         <div class="q-ml-sm row items-center">
           <q-icon

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointPvSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointPvSettings.vue
@@ -105,10 +105,10 @@
     </div>
   </div>
 
-  <div class="row items-center justify-between q-ma-none q-pa-none no-wrap">
+  <div class="row items-center justify-between q-ma-none q-pa-none no-wrap q-mt-md">
     <div class="text-subtitle2 q-mr-sm">Einspeisegrenze beachten</div>
     <div>
-      <ToggleStandard v-model="feedInLimit.value" />
+      <ToggleStandard dense v-model="feedInLimit.value" />
     </div>
   </div>
 </template>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointSettings.vue
@@ -12,11 +12,9 @@
         </div>
       </q-card-section>
       <q-card-section class="q-py-none">
-        <div class="row items-center no-wrap">
-          <div class="col text-subtitle2">Ladepunkt sperren</div>
-          <div class="col">
-            <ChargePointLock :charge-point-id="props.chargePointId" dense />
-          </div>
+        <div class="row items-center justify-between">
+          <div class="text-subtitle2">Ladepunkt sperren</div>
+          <ChargePointLock :charge-point-id="props.chargePointId" dense />
         </div>
         <q-separator class="q-mt-sm" />
         <div class="row items-center q-mt-sm">
@@ -28,17 +26,13 @@
             :readonly="false"
           />
         </div>
-        <div class="row items-center no-wrap q-mt-sm">
-          <div class="col row items-center">
-            <div class="col text-subtitle2">Priorität</div>
-            <div class="col">
-              <ChargePointPriority
-                :charge-point-id="props.chargePointId"
-                :readonly="false"
-                dense
-              />
-            </div>
-          </div>
+        <div class="row items-center justify-between q-mt-sm">
+          <div class="text-subtitle2">Priorität</div>
+          <ChargePointPriority
+            :charge-point-id="props.chargePointId"
+            :readonly="false"
+            dense
+          />
         </div>
         <q-separator class="q-mt-sm" />
         <div class="row items-center no-wrap">


### PR DESCRIPTION
Ladepunkt-Einstellungen: Die Toggle-Elemente für Sperre, Priorität und Zeitladen sollten rechtsbündig angezeigt werden, so wie es bei "Einspeisegrenze beachten" der Fall ist. Dann ist es einheitlich wirkt. ebenso bei "Laden mit Überschuss" in Battery-Card