### PR TITLE
Koala theme remove animation from history chart

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChart.vue
@@ -261,6 +261,7 @@ const lineChartData = computed(() => {
 const chartOptions = computed(() => ({
   responsive: true,
   maintainAspectRatio: false,
+  animation: { duration: 0 },
   plugins: {
     legend: {
       display: !legendLarge.value && legendDisplay.value,


### PR DESCRIPTION
Wenn es eine Aktualisierung des Diagramms gibt, wird die Animation jedes Mal ausgeführt, wodurch das Diagramm so wirkt, als würde es springen. Außerdem kann die Animation beim erstmaligen Anzeigen des Diagramms langsam sein und ästhetisch wenig ansprechend wirken.

Wenn eines der Legendenelemente im Verlaufsdiagramm deaktiviert wird und der Benutzer anschließend zum Flussdiagramm wechselt und dann wieder zurückkehrt, wird das deaktivierte Element für ein paar Sekunden angezeigt, bevor es verschwindet. Dies wird ebenfalls durch die Animation in Chart.js verursacht.