### PR TITLE
Fix SoC slider displayed for standard fahrzeug

### DIFF
--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -1737,7 +1737,7 @@ export const useMqttStore = defineStore('mqtt', () => {
     return computed(() => {
       const vehicleId =
         chargePointConnectedVehicleInfo(chargePointId).value?.id;
-      if (!vehicleId) return undefined;
+      if (vehicleId === undefined) return undefined;
       const socConfig = getValue.value(
         `openWB/vehicle/${vehicleId}/soc_module/config`,
       ) as { type: string } | null;


### PR DESCRIPTION
Problem
Das SoC-Modul (z.B. der SoC-Slider) wurde für das Standardfahrzeug mit der ID 0 nicht angezeigt, obwohl ein SoC-Modul konfiguriert war. Andere Fahrzeuge funktionierten wie erwartet.

Ursache
Die Prüfung auf eine gültige Fahrzeug-ID im Code erfolgte mit if (!vehicleId), wodurch die ID 0 (Standardfahrzeug) als "falsy" behandelt und wie undefined ignoriert wurde. Dadurch wurde das SoC-Modul für das Fahrzeug mit ID 0 nie angezeigt.

Lösung
Die Prüfung wurde auf if (vehicleId === undefined) geändert, sodass nur wirklich nicht definierte IDs ausgeschlossen werden. Fahrzeuge mit der ID 0 werden nun korrekt erkannt und das SoC-Modul wird angezeigt.