### PR TITLE
Koala theme Fix - New Vehicle SoC slider visible when SoC module present (Vehicle card)

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/VehicleCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/VehicleCard.vue
@@ -17,7 +17,7 @@
         </div>
       </div>
       <VehicleConnectionStateIcon :vehicle-id="vehicleId" class="q-mt-sm" />
-      <div v-if="vehicleSocValue !== null">
+      <div v-if="isVehicleSocModule !== undefined">
         <SliderDouble
           class="q-mt-sm"
           :current-value="vehicleSocValue"
@@ -82,12 +82,16 @@ const vehicleInfo = computed(() => {
   return mqttStore.vehicleInfo(props.vehicleId);
 });
 
+const isVehicleSocModule = computed(() => {
+  return mqttStore.vehicleSocModule(props.vehicleId)?.name;
+});
+
 const vehicleSocModuleType = computed(() => {
   return mqttStore.vehicleSocModule(props.vehicleId)?.type;
 });
 
 const vehicleSocValue = computed(() => {
-  return mqttStore.vehicleSocValue(props.vehicleId);
+  return mqttStore.vehicleSocValue(props.vehicleId) || 0;
 });
 
 const refreshSoc = () => {


### PR DESCRIPTION
Problem
Beim Hinzufügen eines neuen Fahrzeugs mit SoC-Modul wurde der SoC-Slider in der VehicleCard nicht angezeigt, solange das Fahrzeug noch keinem Ladepunkt zugewiesen war . Erst nach Zuweisung zu einem Ladepunkt erschien der Slider dauerhaft.

Ursache
Die Anzeige des Sliders war an das Vorhandensein eines SoC-Werts im MQTT-Store gekoppelt. Für neue Fahrzeuge existiert dieses Topic jedoch noch nicht, solange  das Fahrzeug nicht zugewiesen wurde.

Lösung
Die Anzeige des SoC-Sliders in der VehicleCard wurde so angepasst, dass der Slider immer angezeigt wird, sobald ein SoC-Modul konfiguriert ist (ein Name hat)– unabhängig davon, ob bereits ein SoC-Wert existiert. Damit ist die SoC-Eingabe sofort nach dem Anlegen eines Fahrzeugs mit SoC-Modul möglich.