### PR TITLE
SolarEdge Speichersteuerung change default min_soc

### DIFF
--- a/packages/modules/devices/solaredge/solaredge/bat.py
+++ b/packages/modules/devices/solaredge/solaredge/bat.py
@@ -60,7 +60,7 @@ class SolaredgeBat(AbstractBat):
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
-        self.min_soc = 8
+        self.min_soc = 13
         self.StorageControlMode_Read = DEFAULT_CONTROL_MODE
         self.last_mode = 'undefined'
 


### PR DESCRIPTION
Hallo @LKuemmel ,

ich habe eine Rückmeldung übersehen, dass es auch Speicher mit 15% SoC-Reserve gibt.
Daher Default nochmal angepasst, sorry.
Wiki Eintrag habe ich bereits dazu passend angepasst.
VG
Christoph