### PR TITLE
fix: Skoda SoC failed

### DIFF
--- a/packages/modules/vehicles/skoda/libskoda.py
+++ b/packages/modules/vehicles/skoda/libskoda.py
@@ -168,8 +168,6 @@ class skoda:
 
             response = await self.session.get(url, data=form, allow_redirects=False)
 
-        self.headers = dict(response.headers)
-
         # Get final token
         params = {
             'tokenType': 'CONNECT'


### PR DESCRIPTION
Problem
siehe https://forum.openwb.de/viewtopic.php?p=129898#p129898
Nach einer Neuanlage eines Fahrzeuges kann der SoC nicht geladen werden.

Ursache
Beim Abrufen des SoC wird der gesamte Response Header des Anmeldevorganges mitgeführt.
Das führt dann zu einer Fehlermeldung beim HTTP Aufruf: 431 - Request Header Fields Too Large.

Lösung
Der Response Header wird nicht pauschal im Request übernommen.