### PR TITLE
Update requirements.txt - rise version of pycarwings3 to 0.7.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ protobuf==4.25.8
 bimmer_connected==0.17.2
 ocpp==1.0.0
 websockets==12.0
-pycarwings3==0.7.13
+pycarwings3==0.7.14


### PR DESCRIPTION
The vehicle module for fetching the SoC of NISSAN Leaf is using the library pycarwings3.
NISSAN has changed the URL of its API as well as the method of encryption from Blowfish to AES.
Details see https://github.com/remuslazar/homeassistant-carwings/issues/100
New API is at URL https://gdcportalgw.its-mo.com/api_v250205_NE/gdc/

Many thanks to @remuslazar and @zwartevogel who already updated pycarwings3 to version 0.7.14, 
see https://github.com/ev-freaks/pycarwings3/pull/14 
and https://github.com/remuslazar/homeassistant-carwings/pull/101
With this PR the changed pycarwings3 library will be introduced into openWB2 V2.1.8 Alpha.1 &.2 by rising the version No of pycarwings3 from 0.7.13 to 0.7.14 in requirements.txt.