### PR TITLE
Widen the main layout area and display 3 cards on screen > 1400px

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/BaseCarousel.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseCarousel.vue
@@ -48,7 +48,7 @@ const animated = ref<boolean>(true);
  * Group the items in chunks of 2 for large screens and 1 for small screens.
  */
 const groupedItems = computed(() => {
-  const groupSize = $q.screen.width > 800 ? 2 : 1;
+  const groupSize = $q.screen.width > 1400 ? 3 : $q.screen.width > 800 ? 2 : 1;
   return props.items.reduce((resultArray, item, index) => {
     const chunkIndex = Math.floor(index / groupSize);
     if (!resultArray[chunkIndex]) {

--- a/packages/modules/web_themes/koala/source/src/layouts/MainLayout.vue
+++ b/packages/modules/web_themes/koala/source/src/layouts/MainLayout.vue
@@ -116,14 +116,23 @@
     </q-drawer>
 
     <!-- Page container that takes the remaining height -->
-    <q-page-container class="column flex centered-container">
+    <q-page-container
+      :class="[
+        'column',
+        'flex',
+        {
+          'centered-container': !isLargeScreen,
+          'centered-container-large': isLargeScreen,
+        },
+      ]"
+    >
       <router-view />
     </q-page-container>
   </q-layout>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
 const $q = useQuasar();
 
@@ -133,6 +142,7 @@ defineOptions({
 
 const drawer = ref(false);
 const themeMode = ref('auto');
+const isLargeScreen = computed(() => $q.screen.width > 1400);
 
 const setTheme = (mode: 'light' | 'dark' | 'auto') => {
   themeMode.value = mode;
@@ -160,6 +170,12 @@ onMounted(() => {
 <style scoped>
 .centered-container {
   max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.centered-container-large {
+  max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
Für größere Bildschirme wird die Hauptseite auf 1400 Pixel verbreitert, und das Karussell wird so angepasst, dass drei Karten gleichzeitig angezeigt werden.