### PR TITLE
Revert "Widen the main layout area and display 3 cards on screen > 1400px"

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/BaseCarousel.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseCarousel.vue
@@ -48,7 +48,7 @@ const animated = ref<boolean>(true);
  * Group the items in chunks of 2 for large screens and 1 for small screens.
  */
 const groupedItems = computed(() => {
-  const groupSize = $q.screen.width > 1400 ? 3 : $q.screen.width > 800 ? 2 : 1;
+  const groupSize = $q.screen.width > 800 ? 2 : 1;
   return props.items.reduce((resultArray, item, index) => {
     const chunkIndex = Math.floor(index / groupSize);
     if (!resultArray[chunkIndex]) {

--- a/packages/modules/web_themes/koala/source/src/layouts/MainLayout.vue
+++ b/packages/modules/web_themes/koala/source/src/layouts/MainLayout.vue
@@ -116,23 +116,14 @@
     </q-drawer>
 
     <!-- Page container that takes the remaining height -->
-    <q-page-container
-      :class="[
-        'column',
-        'flex',
-        {
-          'centered-container': !isLargeScreen,
-          'centered-container-large': isLargeScreen,
-        },
-      ]"
-    >
+    <q-page-container class="column flex centered-container">
       <router-view />
     </q-page-container>
   </q-layout>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
 const $q = useQuasar();
 
@@ -142,7 +133,6 @@ defineOptions({
 
 const drawer = ref(false);
 const themeMode = ref('auto');
-const isLargeScreen = computed(() => $q.screen.width > 1400);
 
 const setTheme = (mode: 'light' | 'dark' | 'auto') => {
   themeMode.value = mode;
@@ -170,12 +160,6 @@ onMounted(() => {
 <style scoped>
 .centered-container {
   max-width: 1000px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.centered-container-large {
-  max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
Reverts openWB/core#2547
Problem mit der Größenanpassung des Verlaufsdiagramms aufgrund der Reaktivität der Chart.js-Bibliothek.