### PR TITLE
Widen main page content for larger screen sizes - Fix chart.js responsiveness 

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/BaseCarousel.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseCarousel.vue
@@ -48,7 +48,7 @@ const animated = ref<boolean>(true);
  * Group the items in chunks of 2 for large screens and 1 for small screens.
  */
 const groupedItems = computed(() => {
-  const groupSize = $q.screen.width > 800 ? 2 : 1;
+  const groupSize = $q.screen.width > 1400 ? 3 : $q.screen.width > 800 ? 2 : 1;
   return props.items.reduce((resultArray, item, index) => {
     const chunkIndex = Math.floor(index / groupSize);
     if (!resultArray[chunkIndex]) {

--- a/packages/modules/web_themes/koala/source/src/components/BaseCarousel.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseCarousel.vue
@@ -1,5 +1,6 @@
 <template>
   <q-carousel
+    ref="carouselRef"
     v-model="currentSlide"
     swipeable
     :animated="animated"
@@ -33,82 +34,49 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted } from 'vue';
+import {
+  ref,
+  computed,
+  watch,
+  nextTick,
+  onMounted,
+  onBeforeUnmount,
+} from 'vue';
 import { useQuasar } from 'quasar';
 
 const props = defineProps<{
   items: number[];
+  cardWidth?: number;
 }>();
 
 const $q = useQuasar();
 const currentSlide = ref<number>(0);
 const animated = ref<boolean>(true);
-
-/**
- * Group the items in chunks of 2 for large screens and 1 for small screens.
- */
-const groupedItems = computed(() => {
-  const groupSize = $q.screen.width > 1400 ? 3 : $q.screen.width > 800 ? 2 : 1;
-  return props.items.reduce((resultArray, item, index) => {
-    const chunkIndex = Math.floor(index / groupSize);
-    if (!resultArray[chunkIndex]) {
-      resultArray[chunkIndex] = [];
-    }
-    resultArray[chunkIndex].push(item);
-    return resultArray;
-  }, [] as number[][]);
-});
-
-/**
- * Update the current slide when the grouped items change.
- * This may happen when the items are sorted or filtered or when the screen size changes.
- * We try to keep the same item in view when the slide changes.
- */
-watch(
-  () => groupedItems.value,
-  async (newValue, oldValue) => {
-    const findSlide = (itemId: number) => {
-      return newValue.findIndex((group) => group.includes(itemId));
-    };
-    if (!oldValue || oldValue.length === 0) {
-      currentSlide.value = 0;
-      return;
-    }
-    // Prevent animation when the current slide is modified
-    animated.value = false;
-    currentSlide.value = Math.max(
-      findSlide(oldValue[currentSlide.value][0]),
-      0,
-    );
-    await nextTick();
-    animated.value = true;
-  },
-);
-
-const handleSlideChange = () => {
-  const currentScroll = window.scrollY;
-  nextTick(() => {
-    updateMaxCardHeight();
-    observeCardChanges();
-    window.scrollTo(0, currentScroll);
-  });
-};
-
+const carouselRef = ref<{ $el: HTMLElement } | null>(null);
+const carouselWidth = ref(0);
+let resizeObserver: ResizeObserver | null = null;
 const maxCardHeight = ref<number>(0);
 
+// Calculates and sets the maximum card height for all cards in the active slide
 const updateMaxCardHeight = () => {
-  const cards = document.querySelectorAll('.item-container');
+  // Quasar adds CSS class .q-carousel__slide--active when the slide is active - calculation then made only on active slide/s
+  const cards = document.querySelectorAll(
+    '.q-carousel__slide--active .item-container',
+  );
   const heights = Array.from(cards).map(
     (card) => (card as HTMLElement).offsetHeight,
   );
   maxCardHeight.value = Math.max(...heights);
 };
 
+// Sets up a MutationObserver to watch for changes in the cards of the active slide
 const observeCardChanges = () => {
   const observer = new MutationObserver(() => {
     updateMaxCardHeight();
   });
-  const cards = document.querySelectorAll('.item-container');
+  const cards = document.querySelectorAll(
+    '.q-carousel__slide--active .item-container',
+  );
   cards.forEach((card) => {
     observer.observe(card, {
       childList: true,
@@ -120,18 +88,90 @@ const observeCardChanges = () => {
 
 onMounted(() => {
   nextTick(() => {
+    if (carouselRef.value && carouselRef.value.$el) {
+      carouselWidth.value = carouselRef.value.$el.offsetWidth;
+      // Set up ResizeObserver to update width and card height on resize
+      resizeObserver = new ResizeObserver(() => {
+        if (carouselRef.value && carouselRef.value.$el) {
+          carouselWidth.value = carouselRef.value.$el.offsetWidth;
+          updateMaxCardHeight();
+        }
+      });
+      resizeObserver.observe(carouselRef.value.$el);
+    }
+    // Calculate initial card height and set up MutationObserver
     updateMaxCardHeight();
     observeCardChanges();
   });
 });
 
+onBeforeUnmount(() => {
+  if (resizeObserver && carouselRef.value && carouselRef.value.$el) {
+    resizeObserver.unobserve(carouselRef.value.$el);
+  }
+});
+
+const effectiveCardWidth = ref<number | undefined>(undefined);
+
+// Computes how many cards can fit in the carousel based on carousel width and the card width
+const groupSize = computed(() => {
+  return effectiveCardWidth.value
+    ? Math.max(1, Math.floor(carouselWidth.value / effectiveCardWidth.value))
+    : 380;
+});
+
+// Groups the items into arrays for each slide, based on the computed group size
+const groupedItems = computed(() => {
+  return props.items.reduce((resultArray, item, index) => {
+    const chunkIndex = Math.floor(index / groupSize.value);
+    if (!resultArray[chunkIndex]) {
+      resultArray[chunkIndex] = [];
+    }
+    resultArray[chunkIndex].push(item);
+    return resultArray;
+  }, [] as number[][]);
+});
+
+// Updates the current slide and recalculates card heights when the grouped items change
 watch(
-  () => props.items,
-  () => {
-    nextTick(() => {
-      updateMaxCardHeight();
-      observeCardChanges();
-    });
+  () => groupedItems.value,
+  async (newValue, oldValue) => {
+    const findSlide = (itemId: number) => {
+      return newValue.findIndex((group) => group.includes(itemId));
+    };
+    if (!oldValue || oldValue.length === 0) {
+      currentSlide.value = 0;
+      return;
+    }
+    animated.value = false;
+    currentSlide.value = Math.max(
+      findSlide(oldValue[currentSlide.value][0]),
+      0,
+    );
+    await nextTick();
+    animated.value = true;
+    updateMaxCardHeight();
+    observeCardChanges();
+  },
+);
+
+// Called when the slide changes; recalculates card heights and scrolls to the previous position
+const handleSlideChange = () => {
+  const currentScroll = window.scrollY;
+  nextTick(() => {
+    updateMaxCardHeight();
+    observeCardChanges();
+    window.scrollTo(0, currentScroll);
+  });
+};
+
+// watches cardWidth prop because it takes time to be emitted and passed through component hierarchy
+watch(
+  () => props.cardWidth,
+  (newVal) => {
+    if (newVal && newVal > 0) {
+      effectiveCardWidth.value = newVal + 72; // Add 72px to account for padding / margins / navigation buttons in carousel
+    }
   },
 );
 </script>

--- a/packages/modules/web_themes/koala/source/src/components/BatteryCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BatteryCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card class="full-height card-width">
+  <q-card ref="cardRef" class="full-height card-width">
     <q-card-section>
       <div class="row text-h6 items-center text-bold justify-between">
         <div>
@@ -62,11 +62,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useMqttStore } from 'src/stores/mqtt-store';
 import BatterySettingsDialog from './BatterySettingsDialog.vue';
 import { useBatteryModes } from 'src/composables/useBatteryModes.ts';
 import SliderDouble from './SliderDouble.vue';
+
+const cardRef = ref<{ $el: HTMLElement } | null>(null);
+const emit = defineEmits<{
+  (event: 'card-width', width: number | undefined): void;
+}>();
 
 const props = defineProps<{
   batteryId: number | undefined;
@@ -130,6 +135,11 @@ const dailyExportedEnergy = computed(() => {
     (mqttStore.batteryDailyExported(props.batteryId, 'textValue') as string) ||
     '---'
   );
+});
+
+onMounted(() => {
+  const cardWidth = cardRef.value?.$el.clientWidth;
+  emit('card-width', cardWidth);
 });
 </script>
 

--- a/packages/modules/web_themes/koala/source/src/components/BatteryInformation.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BatteryInformation.vue
@@ -1,20 +1,22 @@
 <template>
   <div v-if="showBatteryOverview" class="row justify-center">
-    <BatteryCard :battery-id="undefined" />
+    <BatteryCard :battery-id="undefined"/>
   </div>
-  <BaseCarousel :items="batteryIds">
+  <BaseCarousel :items="batteryIds" :card-width="cardWidth">
     <template #item="{ item }">
-      <BatteryCard :battery-id="item" />
+      <BatteryCard :battery-id="item" @card-width="cardWidth = $event"/>
     </template>
   </BaseCarousel>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useMqttStore } from 'src/stores/mqtt-store';
 
 import BaseCarousel from 'src/components/BaseCarousel.vue';
 import BatteryCard from 'src/components/BatteryCard.vue';
+
+const cardWidth = ref<number | undefined>(undefined);
 
 const mqttStore = useMqttStore();
 

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card class="full-height card-width">
+  <q-card ref="cardRef" class="full-height card-width">
     <q-card-section>
       <div class="row items-center text-h6 text-bold">
         <div class="col flex items-center">
@@ -93,7 +93,7 @@
   />
 </template>
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useMqttStore } from 'src/stores/mqtt-store';
 import SliderDouble from './SliderDouble.vue';
 import ChargePointLock from './ChargePointLock.vue';
@@ -108,6 +108,11 @@ import ManualSocDialog from './ManualSocDialog.vue';
 import ChargePointTimeCharging from './ChargePointTimeCharging.vue';
 import ChargePointPowerData from './ChargePointPowerData.vue';
 import { useQuasar } from 'quasar';
+
+const cardRef = ref<{ $el: HTMLElement } | null>(null);
+const emit = defineEmits<{
+  (event: 'card-width', width: number | undefined): void;
+}>();
 
 const mqttStore = useMqttStore();
 
@@ -278,6 +283,11 @@ const refreshSoc = () => {
     message: 'SoC Update angefordert.',
   });
 };
+
+onMounted(() => {
+  const cardWidth = cardRef.value?.$el.offsetWidth;
+  emit('card-width', cardWidth);
+});
 </script>
 <style lang="scss" scoped>
 .card-width {

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointInformation.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointInformation.vue
@@ -2,9 +2,10 @@
   <BaseCarousel
     v-if="chargePointIds.length <= cardViewBreakpoint"
     :items="chargePointIds"
+    :card-width="cardWidth"
   >
     <template #item="{ item }">
-      <ChargePointCard :charge-point-id="item" />
+      <ChargePointCard :charge-point-id="item" @card-width="cardWidth = $event" />
     </template>
   </BaseCarousel>
 
@@ -144,6 +145,8 @@ import {
   ColumnConfiguration,
   ChargePointRow,
 } from 'src/components/models/table-model';
+
+const cardWidth = ref<number | undefined>(undefined);
 
 const mqttStore = useMqttStore();
 const { chargeModes } = useChargeModes();

--- a/packages/modules/web_themes/koala/source/src/components/VehicleCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/VehicleCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card class="full-height card-width">
+  <q-card ref="cardRef" class="full-height card-width">
     <q-card-section>
       <div class="row items-center text-h6 text-bold">
         <div class="col flex items-center">
@@ -59,12 +59,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useMqttStore } from 'src/stores/mqtt-store';
 import { useQuasar } from 'quasar';
 import SliderDouble from './SliderDouble.vue';
 import ManualSocDialog from './ManualSocDialog.vue';
 import VehicleConnectionStateIcon from './VehicleConnectionStateIcon.vue';
+
+const cardRef = ref<{ $el: HTMLElement } | null>(null);
+const emit = defineEmits<{
+  (event: 'card-width', width: number | undefined): void;
+}>();
 
 const props = defineProps<{
   vehicleId: number;
@@ -97,6 +102,11 @@ const refreshSoc = () => {
     message: 'SoC Update angefordert.',
   });
 };
+
+onMounted(() => {
+  const cardWidth = cardRef.value?.$el.offsetWidth;
+  emit('card-width', cardWidth);
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/modules/web_themes/koala/source/src/components/VehicleInformation.vue
+++ b/packages/modules/web_themes/koala/source/src/components/VehicleInformation.vue
@@ -2,9 +2,10 @@
   <BaseCarousel
     v-if="vehicleIds.length <= cardViewBreakpoint"
     :items="vehicleIds"
+    :card-width="cardWidth"
   >
     <template #item="{ item }">
-      <VehicleCard :vehicle-id="item" />
+      <VehicleCard :vehicle-id="item" @card-width="cardWidth = $event" />
     </template>
   </BaseCarousel>
 
@@ -72,6 +73,8 @@ import ChargePointStateIcon from 'src/components/ChargePointStateIcon.vue';
 import VehicleConnectionStateIcon from './VehicleConnectionStateIcon.vue';
 import VehicleCard from 'src/components/VehicleCard.vue';
 import { ColumnConfiguration } from 'src/components/models/table-model';
+
+const cardWidth = ref<number | undefined>(undefined);
 
 const mqttStore = useMqttStore();
 const isMobile = computed(() => Platform.is.mobile);

--- a/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChart.vue
@@ -376,4 +376,9 @@ const chartOptions = computed(() => ({
   flex: 1;
   min-height: 0;
 }
+
+canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChart.vue
@@ -377,7 +377,7 @@ const chartOptions = computed(() => ({
   min-height: 0;
 }
 
-canvas {
+.chart-wrapper > canvas {
   width: 100% !important;
   height: 100% !important;
 }

--- a/packages/modules/web_themes/koala/source/src/layouts/MainLayout.vue
+++ b/packages/modules/web_themes/koala/source/src/layouts/MainLayout.vue
@@ -116,23 +116,14 @@
     </q-drawer>
 
     <!-- Page container that takes the remaining height -->
-    <q-page-container
-      :class="[
-        'column',
-        'flex',
-        {
-          'centered-container': !isLargeScreen,
-          'centered-container-large': isLargeScreen,
-        },
-      ]"
-    >
+    <q-page-container class="column flex centered-container">
       <router-view />
     </q-page-container>
   </q-layout>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
 const $q = useQuasar();
 
@@ -142,7 +133,6 @@ defineOptions({
 
 const drawer = ref(false);
 const themeMode = ref('auto');
-const isLargeScreen = computed(() => $q.screen.width > 1400);
 
 const setTheme = (mode: 'light' | 'dark' | 'auto') => {
   themeMode.value = mode;
@@ -174,9 +164,9 @@ onMounted(() => {
   margin-right: auto;
 }
 
-.centered-container-large {
-  max-width: 1400px;
-  margin-left: auto;
-  margin-right: auto;
+@media (min-width: 1400px) {
+  .centered-container {
+    max-width: 1400px;
+  }
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/layouts/MainLayout.vue
+++ b/packages/modules/web_themes/koala/source/src/layouts/MainLayout.vue
@@ -116,14 +116,23 @@
     </q-drawer>
 
     <!-- Page container that takes the remaining height -->
-    <q-page-container class="column flex centered-container">
+    <q-page-container
+      :class="[
+        'column',
+        'flex',
+        {
+          'centered-container': !isLargeScreen,
+          'centered-container-large': isLargeScreen,
+        },
+      ]"
+    >
       <router-view />
     </q-page-container>
   </q-layout>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
 const $q = useQuasar();
 
@@ -133,6 +142,7 @@ defineOptions({
 
 const drawer = ref(false);
 const themeMode = ref('auto');
+const isLargeScreen = computed(() => $q.screen.width > 1400);
 
 const setTheme = (mode: 'light' | 'dark' | 'auto') => {
   themeMode.value = mode;
@@ -160,6 +170,12 @@ onMounted(() => {
 <style scoped>
 .centered-container {
   max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.centered-container-large {
+  max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
Für größere Bildschirme wird die Hauptseite auf 1400 Pixel verbreitert, und das Karussell wird so angepasst, dass drei Karten gleichzeitig angezeigt werden.

Chart CSS wurde angepasst, um die Responsivität für größere Bildschirmgrößen zu ermöglichen.
Problem im Pull Request #2547  ist hier behoben