### PR TITLE
component-wise error handling

### DIFF
--- a/docs/samples/sample_modbus/sample_modbus/device.py
+++ b/docs/samples/sample_modbus/sample_modbus/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable,  Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.sample_modbus.sample_modbus.bat import SampleBat
@@ -31,7 +32,8 @@ def create_device(device_config: Sample):
     def update_components(components: Iterable[Union[SampleBat, SampleCounter, SampleInverter]]):
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/docs/samples/sample_request_by_device/sample_request_by_device/device.py
+++ b/docs/samples/sample_request_by_device/sample_request_by_device/device.py
@@ -4,6 +4,7 @@ from typing import Iterable, Union
 
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.devices.sample_request_by_device.sample_request_by_device.bat import SampleBat
 from modules.devices.sample_request_by_device.sample_request_by_device.config import Sample, SampleBatSetup, SampleCounterSetup, SampleInverterSetup
@@ -26,7 +27,8 @@ def create_device(device_config: Sample):
     def update_components(components: Iterable[Union[SampleBat, SampleCounter, SampleInverter]]):
         response = req.get_http_session().get(device_config.configuration.ip_address, timeout=5).json()
         for component in components:
-            component.update(response)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(response)
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/algodue/algodue/device.py
+++ b/packages/modules/devices/algodue/algodue/device.py
@@ -23,7 +23,7 @@ def create_device(device_config: Algodue):
     def update_components(components: Iterable[counter.AlgodueCounter]):
         with client:
             for component in components:
-                with SingleComponentUpdateContext(component.fault_state):
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
                     component.update()
 
     def initializer():

--- a/packages/modules/devices/alpha_ess/alpha_ess/device.py
+++ b/packages/modules/devices/alpha_ess/alpha_ess/device.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Iterable, Union
 
 from helpermodules.utils.run_command import run_command
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.alpha_ess.alpha_ess.config import (
     AlphaEss, AlphaEssBatSetup, AlphaEssCounterSetup, AlphaEssInverterSetup)
@@ -48,7 +49,8 @@ def create_device(device_config: AlphaEss):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/ampere/ampere/device.py
+++ b/packages/modules/devices/ampere/ampere/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.ampere.ampere.bat import AmpereBat
@@ -40,7 +41,8 @@ def create_device(device_config: Ampere):
     def update_components(components: Iterable[Union[AmpereBat, AmpereCounter, AmpereInverter]]):
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/avm/avm/device.py
+++ b/packages/modules/devices/avm/avm/device.py
@@ -9,6 +9,7 @@ from dataclass_utils._dataclass_asdict import asdict
 from helpermodules.pub import Pub
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.devices.avm.avm.config import Avm, AvmCounterSetup
 from modules.devices.avm.avm.counter import AvmCounter
@@ -36,7 +37,8 @@ def create_device(device_config: Avm):
         deviceListElementTree = ET.fromstring(response.text.strip())
 
         for component in components:
-            component.update(deviceListElementTree)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(deviceListElementTree)
 
     def get_session_id():
         # checking existing sessionID

--- a/packages/modules/devices/azzurro_zcs/azzurro_zcs/device.py
+++ b/packages/modules/devices/azzurro_zcs/azzurro_zcs/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.azzurro_zcs.azzurro_zcs.bat import ZCSBat
@@ -36,7 +37,8 @@ def create_device(device_config: ZCS):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/batterx/batterx/device.py
+++ b/packages/modules/devices/batterx/batterx/device.py
@@ -4,7 +4,7 @@ from typing import Iterable, Optional, Union, List
 
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import DeviceDescriptor
-from modules.common.component_context import MultiComponentUpdateContext
+from modules.common.component_context import MultiComponentUpdateContext, SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common.store import get_inverter_value_store
 from modules.devices.batterx.batterx import bat, external_inverter
@@ -39,7 +39,8 @@ def create_device(device_config: BatterX):
             'http://' + device_config.configuration.ip_address + '/api.php?get=currentstate',
             timeout=5).json()
         for component in components:
-            component.update(resp_json)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(resp_json)
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/carlo_gavazzi/carlo_gavazzi/device.py
+++ b/packages/modules/devices/carlo_gavazzi/carlo_gavazzi/device.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Iterable
 
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.carlo_gavazzi.carlo_gavazzi import counter
 from modules.devices.carlo_gavazzi.carlo_gavazzi.config import CarloGavazzi, CarloGavazziCounterSetup
@@ -23,7 +24,8 @@ def create_device(device_config: CarloGavazzi):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/deye/deye/device.py
+++ b/packages/modules/devices/deye/deye/device.py
@@ -4,6 +4,7 @@ from typing import Iterable, Optional, List, Union
 
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.deye.deye.bat import DeyeBat
@@ -34,7 +35,8 @@ def create_device(device_config: Deye):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/e3dc/e3dc/device.py
+++ b/packages/modules/devices/e3dc/e3dc/device.py
@@ -4,6 +4,7 @@ from typing import List, Union, Iterable
 
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common import modbus
 from modules.devices.e3dc.e3dc.bat import E3dcBat, read_bat
@@ -59,7 +60,8 @@ def create_device(device_config: E3dc) -> ConfigurableDevice:
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/enphase/enphase/device.py
+++ b/packages/modules/devices/enphase/enphase/device.py
@@ -8,6 +8,7 @@ from dataclass_utils import asdict
 from helpermodules.pub import Pub
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.enphase.enphase.bat import EnphaseBat
 from modules.devices.enphase.enphase.config import (EnphaseVersion,
@@ -143,7 +144,8 @@ def create_device(device_config: Enphase):
                 log.error(f"unknown version: {device_config.configuration.version}")
                 return
             for component in components:
-                component.update(json_response, json_live_data)
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update(json_response, json_live_data)
 
     read_live_data = False
     token_tries = 0

--- a/packages/modules/devices/fox_ess/fox_ess/device.py
+++ b/packages/modules/devices/fox_ess/fox_ess/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.fox_ess.fox_ess.bat import FoxEssBat
@@ -32,7 +33,8 @@ def create_device(device_config: FoxEss):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/generic/json/device.py
+++ b/packages/modules/devices/generic/json/device.py
@@ -5,6 +5,7 @@ from typing import List, Union, Iterable
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.devices.generic.json import bat, counter, inverter
 from modules.devices.generic.json.bat import JsonBat
@@ -36,7 +37,8 @@ def create_device(device_config: Json):
     def update_components(components: Iterable[JsonComponent]):
         response = req.get_http_session().get(device_config.configuration.url, timeout=5).json()
         for component in components:
-            component.update(response)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(response)
 
     return ConfigurableDevice(
         device_config,

--- a/packages/modules/devices/generic/mqtt/bat.py
+++ b/packages/modules/devices/generic/mqtt/bat.py
@@ -26,9 +26,10 @@ class MqttBat(AbstractBat):
         self.store = get_bat_value_store(self.component_config.id)
 
     def update(self, received_topics: Dict) -> None:
+        # [] für erforderliche Topics, .get() für optionale Topics
         currents = received_topics.get(f"openWB/mqtt/bat/{self.component_config.id}/get/currents")
-        power = received_topics.get(f"openWB/mqtt/bat/{self.component_config.id}/get/power")
-        soc = received_topics.get(f"openWB/mqtt/bat/{self.component_config.id}/get/soc")
+        power = received_topics[f"openWB/mqtt/bat/{self.component_config.id}/get/power"]
+        soc = received_topics[f"openWB/mqtt/bat/{self.component_config.id}/get/soc"]
         if (received_topics.get(f"openWB/mqtt/bat/{self.component_config.id}/get/imported") and
                 received_topics.get(f"openWB/mqtt/bat/{self.component_config.id}/get/exported")):
             imported = received_topics.get(f"openWB/mqtt/bat/{self.component_config.id}/get/imported")

--- a/packages/modules/devices/generic/mqtt/counter.py
+++ b/packages/modules/devices/generic/mqtt/counter.py
@@ -25,8 +25,9 @@ class MqttCounter(AbstractCounter):
         self.store = get_counter_value_store(self.component_config.id)
 
     def update(self, received_topics: Dict) -> None:
+        # [] für erforderliche Topics, .get() für optionale Topics
         currents = received_topics.get(f"openWB/mqtt/counter/{self.component_config.id}/get/currents")
-        power = received_topics.get(f"openWB/mqtt/counter/{self.component_config.id}/get/power")
+        power = received_topics[f"openWB/mqtt/counter/{self.component_config.id}/get/power"]
         frequency = received_topics.get(f"openWB/mqtt/counter/{self.component_config.id}/get/frequency")
         power_factors = received_topics.get(f"openWB/mqtt/counter/{self.component_config.id}/get/power_factors")
         powers = received_topics.get(f"openWB/mqtt/counter/{self.component_config.id}/get/powers")

--- a/packages/modules/devices/generic/mqtt/device.py
+++ b/packages/modules/devices/generic/mqtt/device.py
@@ -5,6 +5,7 @@ import logging
 from helpermodules.broker import BrokerClient
 from helpermodules.utils.topic_parser import decode_payload
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.component_type import type_to_topic_mapping
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.generic.mqtt import bat, counter, inverter
@@ -38,7 +39,14 @@ def create_device(device_config: Mqtt):
         if received_topics:
             log.debug(f"Empfange MQTT Daten für Gerät {device_config.id}: {received_topics}")
             for component in components:
-                component.update(received_topics)
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    try:
+                        component.update(received_topics)
+                    except KeyError:
+                        raise KeyError(
+                            "Fehlende MQTT-Daten: Stelle sicher, dass Du Werte an die erforderlichen Topics "
+                            "(beschrieben in den Komponenten-Einstellungen) veröffentlichst (Publish)."
+                        )
         else:
             for component in components:
                 component.fault_state.warning(

--- a/packages/modules/devices/generic/mqtt/inverter.py
+++ b/packages/modules/devices/generic/mqtt/inverter.py
@@ -25,7 +25,8 @@ class MqttInverter(AbstractInverter):
         self.store = get_inverter_value_store(self.component_config.id)
 
     def update(self, received_topics: Dict) -> None:
-        power = received_topics.get(f"openWB/mqtt/pv/{self.component_config.id}/get/power")
+        # [] für erforderliche Topics, .get() für optionale Topics
+        power = received_topics[f"openWB/mqtt/pv/{self.component_config.id}/get/power"]
         if received_topics.get(f"openWB/mqtt/pv/{self.component_config.id}/get/exported"):
             exported = received_topics.get(f"openWB/mqtt/pv/{self.component_config.id}/get/exported")
         else:

--- a/packages/modules/devices/good_we/good_we/device.py
+++ b/packages/modules/devices/good_we/good_we/device.py
@@ -4,6 +4,7 @@ from typing import Iterable, Union
 
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.good_we.good_we import bat
 from modules.devices.good_we.good_we import counter
@@ -49,8 +50,8 @@ def create_device(device_config: GoodWe):
         nonlocal client
         with client:
             for component in components:
-
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/growatt/growatt/device.py
+++ b/packages/modules/devices/growatt/growatt/device.py
@@ -5,6 +5,7 @@ from typing import Iterable, Union
 
 from helpermodules.utils.run_command import run_command
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.growatt.growatt.bat import GrowattBat
@@ -44,7 +45,8 @@ def create_device(device_config: Growatt):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/huawei/huawei/device.py
+++ b/packages/modules/devices/huawei/huawei/device.py
@@ -5,6 +5,7 @@ from typing import Iterable, Union
 
 from helpermodules.utils.run_command import run_command
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.huawei.huawei.bat import HuaweiBat
@@ -47,7 +48,8 @@ def create_device(device_config: Huawei):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/huawei/huawei_smartlogger/device.py
+++ b/packages/modules/devices/huawei/huawei_smartlogger/device.py
@@ -4,6 +4,7 @@ from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common import modbus
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.huawei.huawei_smartlogger import counter
 from modules.devices.huawei.huawei_smartlogger import inverter
@@ -40,7 +41,8 @@ def create_device(device_config: Huawei_Smartlogger):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/janitza/janitza/device.py
+++ b/packages/modules/devices/janitza/janitza/device.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Iterable, Union
 
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
@@ -34,7 +35,8 @@ def create_device(device_config: Janitza):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/kaco/kaco_tx/device.py
+++ b/packages/modules/devices/kaco/kaco_tx/device.py
@@ -4,6 +4,7 @@ from typing import Iterable
 
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.kaco.kaco_tx.inverter import KacoInverter
 from modules.devices.kaco.kaco_tx.config import (Kaco, KacoInverterSetup)
@@ -24,7 +25,8 @@ def create_device(device_config: Kaco):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/kostal/kostal_piko_old/device.py
+++ b/packages/modules/devices/kostal/kostal_piko_old/device.py
@@ -6,6 +6,7 @@ from typing import Iterable, Optional, List
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.devices.kostal.kostal_piko_old import inverter
 from modules.devices.kostal.kostal_piko_old.config import (KostalPikoOld,
@@ -24,7 +25,8 @@ def create_device(device_config: KostalPikoOld):
         response = req.get_http_session().get(device_config.configuration.url, verify=False, auth=(
             device_config.configuration.user, device_config.configuration.password), timeout=5).text
         for component in components:
-            component.update(response)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(response)
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/lg/lg/device.py
+++ b/packages/modules/devices/lg/lg/device.py
@@ -6,6 +6,7 @@ from requests import HTTPError, Session
 
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.lg.lg.bat import LgBat
 from modules.devices.lg.lg.config import LG, LgBatSetup, LgCounterSetup, LgInverterSetup
@@ -58,7 +59,8 @@ def create_device(device_config: LG):
             response = _request_data(session, session_key, device_config.configuration.ip_address)
 
         for component in components:
-            component.update(response)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(response)
 
     session_key = " "
     return ConfigurableDevice(

--- a/packages/modules/devices/mtec/mtec/device.py
+++ b/packages/modules/devices/mtec/mtec/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.mtec.mtec.bat import MTecBat
@@ -32,7 +33,8 @@ def create_device(device_config: MTec):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/nibe/nibe/device.py
+++ b/packages/modules/devices/nibe/nibe/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.nibe.nibe.config import Nibe, NibeCounterSetup
@@ -21,7 +22,8 @@ def create_device(device_config: Nibe):
     def update_components(components: Iterable[NibeCounter]):
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/openwb/openwb_bat_kit/device.py
+++ b/packages/modules/devices/openwb/openwb_bat_kit/device.py
@@ -5,6 +5,7 @@ from typing import Iterable
 from helpermodules.utils.run_command import run_command
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.openwb.openwb_bat_kit.config import BatKitSetup, BatKitBatSetup
 from modules.devices.openwb.openwb_bat_kit.bat import BatKit
@@ -23,7 +24,8 @@ def create_device(device_config: BatKitSetup):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/openwb/openwb_evu_kit/device.py
+++ b/packages/modules/devices/openwb/openwb_evu_kit/device.py
@@ -5,6 +5,7 @@ from typing import Iterable, Union
 from helpermodules.utils.run_command import run_command
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.openwb.openwb_bat_kit.bat import BatKit
 from modules.devices.openwb.openwb_evu_kit.counter import EvuKit
@@ -34,7 +35,8 @@ def create_device(device_config: EvuKitSetup):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/openwb/openwb_flex/device.py
+++ b/packages/modules/devices/openwb/openwb_flex/device.py
@@ -5,6 +5,7 @@ from typing import Iterable, Union
 
 from helpermodules.utils.run_command import run_command
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.openwb.openwb_flex.bat import BatKitFlex
@@ -41,8 +42,8 @@ def create_device(device_config: Flex):
 
     def update_components(components: Iterable[Union[BatKitFlex, ConsumptionCounterFlex, EvuKitFlex, PvKitFlex]]):
         for component in components:
-
-            component.update()
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/openwb/openwb_pv_kit/device.py
+++ b/packages/modules/devices/openwb/openwb_pv_kit/device.py
@@ -5,6 +5,7 @@ from typing import Iterable
 from helpermodules.utils.run_command import run_command
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.openwb.openwb_pv_kit import inverter
 from modules.devices.openwb.openwb_pv_kit.config import PvKitSetup, PvKitInverterSetup
@@ -23,7 +24,8 @@ def create_device(device_config: PvKitSetup):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/orno/orno/device.py
+++ b/packages/modules/devices/orno/orno/device.py
@@ -4,6 +4,7 @@ from pymodbus.transaction import ModbusRtuFramer
 from typing import Iterable
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.orno.orno.config import Orno, OrnoCounterSetup
@@ -22,7 +23,8 @@ def create_device(device_config: Orno):
     def update_components(components: Iterable[OrnoCounter]):
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/qcells/qcells/device.py
+++ b/packages/modules/devices/qcells/qcells/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.qcells.qcells.bat import QCellsBat
@@ -32,7 +33,8 @@ def create_device(device_config: QCells):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/saxpower/saxpower/device.py
+++ b/packages/modules/devices/saxpower/saxpower/device.py
@@ -4,6 +4,7 @@ from typing import Iterable
 
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.saxpower.saxpower.bat import SaxpowerBat
 from modules.devices.saxpower.saxpower.config import Saxpower, SaxpowerBatSetup
@@ -25,7 +26,8 @@ def create_device(device_config: Saxpower):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/siemens/siemens/device.py
+++ b/packages/modules/devices/siemens/siemens/device.py
@@ -4,6 +4,7 @@ from typing import Iterable, Union
 
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.siemens.siemens.bat import SiemensBat
 from modules.devices.siemens.siemens.config import Siemens, SiemensBatSetup, SiemensCounterSetup, SiemensInverterSetup
@@ -44,7 +45,8 @@ def create_device(device_config: Siemens):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/siemens/siemens_sentron/device.py
+++ b/packages/modules/devices/siemens/siemens_sentron/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.siemens.siemens_sentron.config import (SiemensSentron, SiemensSentronCounterSetup,
@@ -35,7 +36,8 @@ def create_device(device_config: SiemensSentron):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/sigenergy/sigenergy/device.py
+++ b/packages/modules/devices/sigenergy/sigenergy/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.sigenergy.sigenergy.bat import SigenergyBat
@@ -37,7 +38,8 @@ def create_device(device_config: Sigenergy):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/sma/sma_sunny_boy/device.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.sma.sma_sunny_boy.bat import SunnyBoyBat
@@ -52,7 +53,8 @@ def create_device(device_config: SmaSunnyBoy):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/sma/sma_sunny_island/device.py
+++ b/packages/modules/devices/sma/sma_sunny_island/device.py
@@ -4,6 +4,7 @@ from typing import Iterable
 
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.sma.sma_sunny_island.bat import SunnyIslandBat
 from modules.devices.sma.sma_sunny_island.config import SmaSunnyIsland, SmaSunnyIslandBatSetup
@@ -22,7 +23,8 @@ def create_device(device_config: SmaSunnyIsland):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/sofar/sofar/device.py
+++ b/packages/modules/devices/sofar/sofar/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.sofar.sofar.bat import SofarBat
@@ -32,7 +33,8 @@ def create_device(device_config: Sofar):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/solar_log/solar_log/device.py
+++ b/packages/modules/devices/solar_log/solar_log/device.py
@@ -25,7 +25,8 @@ def create_device(device_config: SolarLog):
         response = req.get_http_session().post('http://'+device_config.configuration.ip_address+'/getjp',
                                                data=json.dumps({"801": {"170": None}}), timeout=5).json()
         for component in components:
-            component.update(response)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(response)
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/solar_world/solar_world/device.py
+++ b/packages/modules/devices/solar_world/solar_world/device.py
@@ -5,6 +5,7 @@ from typing import Iterable, Optional, Union, List
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.devices.solar_world.solar_world import counter, inverter
 from modules.devices.solar_world.solar_world.config import (
@@ -26,7 +27,8 @@ def create_device(device_config: SolarWorld):
         response = req.get_http_session().get("http://"+str(device_config.configuration.ip_address) +
                                               "/rest/solarworld/lpvm/powerAndBatteryData", timeout=5).json()
         for component in components:
-            component.update(response)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(response)
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/solaredge/solaredge/device.py
+++ b/packages/modules/devices/solaredge/solaredge/device.py
@@ -4,6 +4,7 @@ from typing import Iterable, Union
 
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.solaredge.solaredge.bat import SolaredgeBat
 from modules.devices.solaredge.solaredge.counter import SolaredgeCounter
@@ -41,7 +42,8 @@ def create_device(device_config: Solaredge):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/solarmax/solarmax/device.py
+++ b/packages/modules/devices/solarmax/solarmax/device.py
@@ -5,6 +5,7 @@ from typing import Iterable, Optional, List, Union
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.solarmax.solarmax import inverter
 from modules.devices.solarmax.solarmax.bat import SolarmaxBat
@@ -29,7 +30,8 @@ def create_device(device_config: Solarmax):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/solax/solax/device.py
+++ b/packages/modules/devices/solax/solax/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.solax.solax.bat import SolaxBat
@@ -29,7 +30,8 @@ def create_device(device_config: Solax):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/solis/solis/device.py
+++ b/packages/modules/devices/solis/solis/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.solis.solis.bat import SolisBat
@@ -35,7 +36,8 @@ def create_device(device_config: Solis):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/studer/studer/device.py
+++ b/packages/modules/devices/studer/studer/device.py
@@ -4,6 +4,7 @@ from typing import Iterable, Union
 
 from modules.common import modbus
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.devices.studer.studer.bat import StuderBat
 from modules.devices.studer.studer.config import Studer, StuderBatSetup, StuderInverterSetup
@@ -27,7 +28,8 @@ def create_device(device_config: Studer):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/tesla/tesla/device.py
+++ b/packages/modules/devices/tesla/tesla/device.py
@@ -5,6 +5,7 @@ from requests import HTTPError
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common.req import get_http_session
 from modules.devices.tesla.tesla.bat import TeslaBat
@@ -20,7 +21,8 @@ def __update_components(client: PowerwallHttpClient,
                         components: Iterable[Union[TeslaBat, TeslaCounter, TeslaInverter]]):
     aggregate = client.get_json("/api/meters/aggregates")
     for component in components:
-        component.update(client, aggregate)
+        with SingleComponentUpdateContext(component.fault_state, update_always=False):
+            component.update(client, aggregate)
 
 
 def _authenticate(session: requests.Session, url: str, email: str, password: str):

--- a/packages/modules/devices/thermia/thermia/device.py
+++ b/packages/modules/devices/thermia/thermia/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable,  Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.thermia.thermia.config import Thermia, ThermiaCounterSetup
@@ -22,7 +23,8 @@ def create_device(device_config: Thermia):
     def update_components(components: Iterable[Union[ThermiaCounter]]):
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/upower/upower/device.py
+++ b/packages/modules/devices/upower/upower/device.py
@@ -39,7 +39,7 @@ def create_device(device_config: UPower):
     def update_components(components: Iterable[Union[UPowerBat, UPowerCounter, UPowerInverter]]):
         with client:
             for component in components:
-                with SingleComponentUpdateContext(component.fault_state):
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
                     component.update()
 
     def initializer():

--- a/packages/modules/devices/varta/varta/device.py
+++ b/packages/modules/devices/varta/varta/device.py
@@ -54,10 +54,12 @@ def create_device(device_config: Varta):
         with client:
             for component in components:
                 if isinstance(component, (VartaBatModbus, VartaCounter, VartaInverter)):
-                    component.update()
+                    with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                        component.update()
         for component in components:
             if isinstance(component, (VartaBatApi)):
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/victron/victron/device.py
+++ b/packages/modules/devices/victron/victron/device.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Union
 
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ComponentFactoryByType, ConfigurableDevice, MultiComponentUpdater
 from modules.common.modbus import ModbusTcpClient_
 from modules.devices.victron.victron.bat import VictronBat
@@ -32,7 +33,8 @@ def create_device(device_config: Victron):
         nonlocal client
         with client:
             for component in components:
-                component.update()
+                with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                    component.update()
 
     def initializer():
         nonlocal client

--- a/packages/modules/devices/vzlogger/vzlogger/device.py
+++ b/packages/modules/devices/vzlogger/vzlogger/device.py
@@ -4,6 +4,7 @@ from typing import Iterable, Union
 
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.devices.vzlogger.vzlogger.config import VZLogger, VZLoggerCounterSetup, VZLoggerInverterSetup
 from modules.devices.vzlogger.vzlogger.counter import VZLoggerCounter
@@ -22,7 +23,8 @@ def create_device(device_config: VZLogger):
     def update_components(components: Iterable[Union[VZLoggerCounter, VZLoggerInverter]]):
         response = req.get_http_session().get(device_config.configuration.ip_address, timeout=5).json()
         for component in components:
-            component.update(response)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(response)
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/youless/youless/device.py
+++ b/packages/modules/devices/youless/youless/device.py
@@ -5,6 +5,7 @@ from typing import Iterable, Optional, List
 from helpermodules.cli import run_using_positional_cli_args
 from modules.common import req
 from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
 from modules.devices.youless.youless import inverter
 from modules.devices.youless.youless.config import Youless, YoulessConfiguration, YoulessInverterSetup
@@ -22,7 +23,8 @@ def create_device(device_config: Youless):
                                               params=(('f', 'j'),),
                                               timeout=5).json()
         for component in components:
-            component.update(response)
+            with SingleComponentUpdateContext(component.fault_state, update_always=False):
+                component.update(response)
 
     return ConfigurableDevice(
         device_config=device_config,


### PR DESCRIPTION
Wenn Geräte gebündelt abgefragt werden, wird für jede Komponente eine Fehlermeldung ausgegeben und für weitere Komponenten Werte ermittelt, wenn eine Komponente im Fehlerstatus ist, solange die Komponenten unabhängig voneinander sind und zB keine Komponenten miteinander verrechnet werden.