### PR TITLE
reset fault state at init for tariffs, backup clouds and vehicles

### DIFF
--- a/packages/modules/common/configurable_backup_cloud.py
+++ b/packages/modules/common/configurable_backup_cloud.py
@@ -15,6 +15,9 @@ class ConfigurableBackupCloud(Generic[T_BACKUP_CLOUD_CONFIG]):
         self.config = config
         self.fault_state = FaultState(ComponentInfo(None, self.config.name,
                                                     ComponentType.BACKUP_CLOUD.value))
+        # nach Init auf NO_ERROR setzen, damit der Fehlerstatus beim Modulwechsel gelöscht wird
+        self.fault_state.no_error()
+        self.fault_state.store_error()
         with SingleComponentUpdateContext(self.fault_state):
             self._component_updater = component_initializer(config)
 

--- a/packages/modules/common/configurable_tariff.py
+++ b/packages/modules/common/configurable_tariff.py
@@ -18,6 +18,9 @@ class ConfigurableElectricityTariff(Generic[T_TARIFF_CONFIG]):
         self.config = config
         self.store = store.get_electricity_tariff_value_store()
         self.fault_state = FaultState(ComponentInfo(None, self.config.name, ComponentType.ELECTRICITY_TARIFF.value))
+        # nach Init auf NO_ERROR setzen, damit der Fehlerstatus beim Modulwechsel gelöscht wird
+        self.fault_state.no_error()
+        self.fault_state.store_error()
         with SingleComponentUpdateContext(self.fault_state):
             self._component_updater = component_initializer(config)
 

--- a/packages/modules/common/configurable_vehicle.py
+++ b/packages/modules/common/configurable_vehicle.py
@@ -53,6 +53,9 @@ class ConfigurableVehicle(Generic[T_VEHICLE_CONFIG]):
         self.vehicle = vehicle
         self.store = store.get_car_value_store(self.vehicle)
         self.fault_state = FaultState(ComponentInfo(self.vehicle, self.vehicle_config.name, "vehicle"))
+        # nach Init auf NO_ERROR setzen, damit der Fehlerstatus beim Modulwechsel gelöscht wird
+        self.fault_state.no_error()
+        self.fault_state.store_error()
 
         try:
             self.__initializer()


### PR DESCRIPTION
Bei Modulen, die es in der Software nur einmal gibt, wird bei Modul-Wechsel erst bei der nächsten Abfrage der Fehlerzustand zurück gesetzt.