### PR TITLE
Link zur SoC-Skoda Seite

### DIFF
--- a/docs/SoC-Skoda.md
+++ b/docs/SoC-Skoda.md
@@ -14,7 +14,7 @@ Die Konfiguration erfolgt im Bereich Einstellungen - Konfiguration - Fahrzeuge:
 
 Für nicht-Skoda Fahrzeuge (Audi, VW, etc.) funktioniert das Modul nicht.
 
-Erfolgreich getestet u.a. für folgende Fahrzeuge: Enyaq.
+Erfolgreich getestet u.a. für folgende Fahrzeuge: Enyaq, Elroq.
 
 **Wichtig für alle Fahrzeuge:**
 Es muss ein aktives Konto im Skoda ID Portal vorhanden sein und die "MySkoda App" muss eingerichtet sein.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -8,6 +8,7 @@
   * [SoC BMW & Mini](https://github.com/openWB/core/wiki/SoC-BMW-Mini)
   * [SoC Cupra](https://github.com/openWB/core/wiki/SoC-Cupra)
   * [SoC OVMS](https://github.com/openWB/core/wiki/SoC-OVMS)
+  * [SoC Skoda](https://github.com/openWB/core/wiki/SoC-Skoda)
   * [SoC VWId](https://github.com/openWB/core/wiki/SoC-VWId)
   * [WiCAN OBD2-Dongle mit manuellem SoC](https://github.com/openWB/core/wiki/WiCAN)
 * [Lademodi](https://github.com/openWB/core/wiki/Lademodi)


### PR DESCRIPTION
In der Navigationsleiste im [OpenWB2 Wiki ](https://github.com/openWB/core/wiki) war die SoC-Skoda Seite noch nicht verlinkt.
Da das Modul mittlerweile auch mit einem Skoda Elroq getestet wurde, habe ich diese Info auch noch ergänzt.