### PR TITLE
Koala theme - Charge point card title - entire first row of card

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -1,6 +1,9 @@
 <template>
   <q-card ref="cardRef" class="full-height card-width">
-    <q-card-section class="row justify-between text-h6 text-bold ellipsis" :title="name">
+    <q-card-section
+      class="row justify-between text-h6 text-bold ellipsis"
+      :title="name"
+    >
       {{ name }}
     </q-card-section>
     <q-separator inset />

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -1,6 +1,6 @@
 <template>
   <q-card ref="cardRef" class="full-height card-width">
-    <q-card-section class="row justify-between text-h6 text-bold">
+    <q-card-section class="row justify-between text-h6 text-bold ellipsis" :title="name">
       {{ name }}
     </q-card-section>
     <q-separator inset />
@@ -318,5 +318,12 @@ onMounted(() => {
 .q-card__section:not(:first-of-type):not(:last-of-type) {
   padding-top: 0;
   padding-bottom: 0;
+}
+
+.ellipsis {
+  display: inline-block;
+  max-width: 310px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card ref="cardRef" class="full-height card-width">
     <q-card-section
-      class="row justify-between text-h6 text-bold ellipsis"
+      class="row justify-between text-h6 text-bold ellipsis max-width"
       :title="name"
     >
       {{ name }}
@@ -323,10 +323,8 @@ onMounted(() => {
   padding-bottom: 0;
 }
 
-.ellipsis {
+.max-width {
   display: inline-block;
   max-width: 310px;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card ref="cardRef" class="full-height card-width">
     <q-card-section
-      class="row justify-between text-h6 text-bold ellipsis max-width"
+      class="justify-between text-h6 text-bold ellipsis"
       :title="name"
     >
       {{ name }}
@@ -321,10 +321,5 @@ onMounted(() => {
 .q-card__section:not(:first-of-type):not(:last-of-type) {
   padding-top: 0;
   padding-bottom: 0;
-}
-
-.max-width {
-  display: inline-block;
-  max-width: 310px;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -1,52 +1,57 @@
 <template>
   <q-card ref="cardRef" class="full-height card-width">
-    <q-card-section>
-      <div class="row items-center text-h6 text-bold">
-        <div class="col flex items-center">
-          {{ name }}
-          <ChargePointLock :charge-point-id="props.chargePointId" />
-          <ChargePointStateIcon
-            :charge-point-id="Number(props.chargePointId)"
-          />
-          <ChargePointTimeCharging
-            :charge-point-id="Number(props.chargePointId)"
-            :readonly="true"
-            :iconSize="'xs'"
-            :toolTip="true"
-          />
-        </div>
-        <q-icon
-          class="cursor-pointer"
-          name="settings"
-          size="sm"
-          @click="settingsVisible = true"
+    <q-card-section class="row justify-between text-h6 text-bold">
+      {{ name }}
+    </q-card-section>
+    <q-separator inset />
+    <q-card-section class="row flex items-center justify-between">
+      <div>
+        <ChargePointStateIcon :charge-point-id="Number(props.chargePointId)" />
+        <ChargePointTimeCharging
+          :charge-point-id="Number(props.chargePointId)"
+          :readonly="true"
+          :iconSize="'xs'"
+          :toolTip="true"
         />
+        <ChargePointLock :charge-point-id="props.chargePointId" />
       </div>
+      <q-icon
+        class="cursor-pointer"
+        name="settings"
+        size="sm"
+        @click="settingsVisible = true"
+      />
+    </q-card-section>
+    <q-card-section>
       <ChargePointFaultMessage :charge-point-id="props.chargePointId" />
       <ChargePointStateMessage :charge-point-id="props.chargePointId" />
-      <div class="row items-center q-mt-sm">
-        <ChargePointVehicleSelect
-          :charge-point-id="Number(props.chargePointId)"
-        />
-        <ChargePointPriority :charge-point-id="props.chargePointId" />
-      </div>
+    </q-card-section>
+    <q-card-section class="row items-center q-mt-sm">
+      <ChargePointVehicleSelect
+        :charge-point-id="Number(props.chargePointId)"
+      />
+      <ChargePointPriority :charge-point-id="props.chargePointId" />
+    </q-card-section>
+    <q-card-section>
       <ChargePointModeButtons :charge-point-id="props.chargePointId" />
-      <div class="row q-mt-sm">
-        <div class="col">
-          <div class="text-subtitle2">Leistung</div>
-          <div class="col no-wrap">
-            <ChargePointPowerData
-              :power="power"
-              :phase-number="phaseNumber"
-              :current="chargingCurrent"
-            />
-          </div>
-        </div>
-        <div class="col text-right">
-          <div class="text-subtitle2">geladen</div>
-          {{ energyChargedPlugged }}
+    </q-card-section>
+    <q-card-section class="row q-mt-sm">
+      <div class="col">
+        <div class="text-subtitle2">Leistung</div>
+        <div class="col no-wrap">
+          <ChargePointPowerData
+            :power="power"
+            :phase-number="phaseNumber"
+            :current="chargingCurrent"
+          />
         </div>
       </div>
+      <div class="col text-right">
+        <div class="text-subtitle2">geladen</div>
+        {{ energyChargedPlugged }}
+      </div>
+    </q-card-section>
+    <q-card-section>
       <SliderDouble
         v-if="showSocTargetSlider"
         class="q-mt-sm"
@@ -291,5 +296,27 @@ onMounted(() => {
 <style lang="scss" scoped>
 .card-width {
   width: 22em;
+}
+
+.q-card__section {
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.q-card__section:first-of-type {
+  padding-top: 16px;
+  padding-bottom: 0;
+}
+
+.q-card__section:last-of-type {
+  padding-top: 0;
+  padding-bottom: 16px;
+}
+
+.q-card__section:not(:first-of-type):not(:last-of-type) {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 </style>


### PR DESCRIPTION
Der Titel der Ladepunkt-Karte nimmt die gesamte Breite ein. Die übrigen Elemente wurden in die nächste Zeile verschoben, um bei langen Namen das Layout nicht zu beeinträchtigen.