### PR TITLE
SoC Module evcc: fixed API call

### DIFF
--- a/packages/modules/vehicles/evcc/api.py
+++ b/packages/modules/vehicles/evcc/api.py
@@ -34,7 +34,8 @@ def create_vehicle(config: EVCCVehicleSocConfiguration, stub: vehicle_pb2_grpc.V
     response = stub.New(
         vehicle_pb2.NewRequest(
             token=config.sponsor_token,
-            type=config.vehicle_type,
+            type=template,
+            template=config.vehicle_type,
             config=cast(Mapping[str, str], {
                 'User': config.user_id,
                 'Password': config.password,

--- a/packages/modules/vehicles/evcc/api.py
+++ b/packages/modules/vehicles/evcc/api.py
@@ -34,7 +34,7 @@ def create_vehicle(config: EVCCVehicleSocConfiguration, stub: vehicle_pb2_grpc.V
     response = stub.New(
         vehicle_pb2.NewRequest(
             token=config.sponsor_token,
-            type=template,
+            type="template",
             template=config.vehicle_type,
             config=cast(Mapping[str, str], {
                 'User': config.user_id,

--- a/packages/modules/vehicles/evcc/api.py
+++ b/packages/modules/vehicles/evcc/api.py
@@ -69,7 +69,7 @@ def fetch_soc(
         stub = vehicle_pb2_grpc.VehicleStub(channel)
 
         if not evcc_config.vehicle_id:  # create and fetch vehicle id if not included in config
-             vehicle_to_fetch = create_and_save_vehicle_id(stub, evcc_config, vehicle)
+            vehicle_to_fetch = create_and_save_vehicle_id(stub, evcc_config, vehicle)
 #            vehicle_to_fetch = create_vehicle(evcc_config, stub)
 #            log.debug("Vehicle client received: " + str(vehicle_to_fetch))
 

--- a/packages/modules/vehicles/evcc/api.py
+++ b/packages/modules/vehicles/evcc/api.py
@@ -34,8 +34,7 @@ def create_vehicle(config: EVCCVehicleSocConfiguration, stub: vehicle_pb2_grpc.V
     response = stub.New(
         vehicle_pb2.NewRequest(
             token=config.sponsor_token,
-            type="template",
-            template=config.vehicle_type,
+            type=config.vehicle_type,
             config=cast(Mapping[str, str], {
                 'User': config.user_id,
                 'Password': config.password,
@@ -69,7 +68,7 @@ def fetch_soc(
         stub = vehicle_pb2_grpc.VehicleStub(channel)
 
         if not evcc_config.vehicle_id:  # create and fetch vehicle id if not included in config
-            create_and_save_vehicle_id(stub, evcc_config, vehicle)
+             vehicle_to_fetch = create_and_save_vehicle_id(stub, evcc_config, vehicle)
 #            vehicle_to_fetch = create_vehicle(evcc_config, stub)
 #            log.debug("Vehicle client received: " + str(vehicle_to_fetch))
 

--- a/packages/modules/vehicles/evcc/api.py
+++ b/packages/modules/vehicles/evcc/api.py
@@ -70,12 +70,12 @@ def fetch_soc(
 
         if not evcc_config.vehicle_id:  # create and fetch vehicle id if not included in config
             vehicle_to_fetch = create_and_save_vehicle_id(stub, evcc_config, vehicle)
-#            vehicle_to_fetch = create_vehicle(evcc_config, stub)
-#            log.debug("Vehicle client received: " + str(vehicle_to_fetch))
+            # vehicle_to_fetch = create_vehicle(evcc_config, stub)
+            # log.debug("Vehicle client received: " + str(vehicle_to_fetch))
 
             # saving vehicle id in config
-#            topic = "openWB/set/vehicle/" + str(vehicle) + "/soc_module/config"
-#            write_vehicle_id_mqtt(topic, vehicle_to_fetch, evcc_config)
+            # topic = "openWB/set/vehicle/" + str(vehicle) + "/soc_module/config"
+            # write_vehicle_id_mqtt(topic, vehicle_to_fetch, evcc_config)
         else:
             log.debug("Vehicle id found in config: " + str(evcc_config.vehicle_id))
             vehicle_to_fetch = evcc_config.vehicle_id

--- a/packages/modules/vehicles/evcc/vehicle_pb2.pyi
+++ b/packages/modules/vehicles/evcc/vehicle_pb2.pyi
@@ -19,11 +19,12 @@ class NewRequest(_message.Message):
         def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
     TOKEN_FIELD_NUMBER: _ClassVar[int]
     TYPE_FIELD_NUMBER: _ClassVar[int]
+    TEMPLATE_FIELD_NUMBER: _ClassVar[int]
     CONFIG_FIELD_NUMBER: _ClassVar[int]
     token: str
     type: str
     config: _containers.ScalarMap[str, str]
-    def __init__(self, token: _Optional[str] = ..., type: _Optional[str] = ..., config: _Optional[_Mapping[str, str]] = ...) -> None: ...
+    def __init__(self, token: _Optional[str] = ..., type: _Optional[str] = ..., template: _Optional[str] = ..., config: _Optional[_Mapping[str, str]] = ...) -> None: ...
 
 class NewReply(_message.Message):
     __slots__ = ("vehicle_id",)


### PR DESCRIPTION
The evcc module was broken in current master for two reasons:

1) API call had been modified to use "template" field in NewRequest() call in previous commit, which however did not exist in NewRequest() -> added template field to request in vehicle2_pb2.pyi.
It likely still requires modifications to the proto files and recompilation of the pb2 "do not edit" files, I am not familiar with pb2 though.

2) Vehicle_to_fetch is not returned by function call but is referenced and used later. Added it.

Successfully tested with two different Audi models in two differenct accounts.