### PR TITLE
Koala - Update card layout - add ellipsis for charge point, vehicle and battery names

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/BatteryCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BatteryCard.vue
@@ -4,39 +4,49 @@
     class="full-height card-width"
     :class="{ 'battery-sum': props.batteryId === -1 }"
   >
-    <q-card-section>
-      <div class="row text-h6 items-center text-bold justify-between">
-        {{ cardTitle }}
-        <q-icon
-          class="cursor-pointer"
-          v-if="showSettings"
-          name="settings"
-          size="sm"
-          @click="dialog?.open()"
-        />
-      </div>
-      <div class="row q-mt-sm text-subtitle2 justify-between full-width">
-        <div>Leistung:</div>
-        <div class="q-ml-sm">
-          {{ power }}
-        </div>
-      </div>
-      <div
+    <q-card-section
+      class="text-h6 items-center text-bold justify-between ellipsis"
+      :title="cardTitle"
+    >
+      {{ cardTitle }}
+    </q-card-section>
+    <q-separator inset />
+    <q-card-section class="row flex justify-end">
+      <q-icon
+        class="cursor-pointer q-mt-sm"
         v-if="showSettings"
-        class="row q-mt-md justify-between text-subtitle2"
-      >
-        <div>Laden mit Überschuss:</div>
-        <div class="q-ml-sm row items-center">
-          <q-icon
-            :name="batteryMode.icon"
-            size="sm"
-            class="q-mr-sm"
-            color="primary"
-          />
-          {{ batteryMode.label }}
-        </div>
+        name="settings"
+        size="sm"
+        @click="dialog?.open()"
+      />
+    </q-card-section>
+    <q-card-section
+      class="row q-mt-sm text-subtitle2 justify-between full-width"
+    >
+      <div>Leistung:</div>
+      <div class="q-ml-sm">
+        {{ power }}
       </div>
-      <div class="text-subtitle1 text-weight-bold q-mt-md">Heute:</div>
+    </q-card-section>
+    <q-separator v-if="showSettings" inset class="q-mt-sm" />
+    <q-card-section
+      v-if="showSettings"
+      class="row q-mt-md justify-between text-subtitle2"
+    >
+      <div>Laden mit Überschuss:</div>
+      <div class="q-ml-sm row items-center">
+        <q-icon
+          :name="batteryMode.icon"
+          size="sm"
+          class="q-mr-sm"
+          color="primary"
+        />
+        {{ batteryMode.label }}
+      </div>
+    </q-card-section>
+    <q-separator inset class="q-mt-sm" />
+    <q-card-section>
+      <div class="text-subtitle1 text-weight-bold q-mt-sm">Heute:</div>
       <div class="row q-mt-sm text-subtitle2 justify-between full-width">
         <div>Geladen:</div>
         <div class="q-ml-sm">
@@ -49,6 +59,9 @@
           {{ dailyExportedEnergy }}
         </div>
       </div>
+    </q-card-section>
+    <q-separator inset class="q-mt-sm" />
+    <q-card-section>
       <SliderDouble
         class="q-mt-sm"
         :current-value="soc"
@@ -150,5 +163,27 @@ onMounted(() => {
 <style scoped>
 .card-width {
   width: 22em;
+}
+
+.q-card__section {
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.q-card__section:first-of-type {
+  padding-top: 16px;
+  padding-bottom: 0;
+}
+
+.q-card__section:last-of-type {
+  padding-top: 0;
+  padding-bottom: 16px;
+}
+
+.q-card__section:not(:first-of-type):not(:last-of-type) {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -26,11 +26,17 @@
       <ChargePointFaultMessage :charge-point-id="props.chargePointId" />
       <ChargePointStateMessage :charge-point-id="props.chargePointId" />
     </q-card-section>
-    <q-card-section class="row items-center justify-between q-mt-sm">
+    <q-card-section
+      class="full-width row no-wrap justify-between content-start items-center q-mt-sm"
+    >
       <ChargePointVehicleSelect
+        class="col"
         :charge-point-id="Number(props.chargePointId)"
       />
-      <ChargePointPriority :charge-point-id="props.chargePointId" />
+      <ChargePointPriority
+        class="col-auto"
+        :charge-point-id="props.chargePointId"
+      />
     </q-card-section>
     <q-card-section>
       <ChargePointModeButtons :charge-point-id="props.chargePointId" />

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -1,9 +1,6 @@
 <template>
   <q-card ref="cardRef" class="full-height card-width">
-    <q-card-section
-      class="justify-between text-h6 text-bold ellipsis"
-      :title="name"
-    >
+    <q-card-section class="text-h6 text-bold ellipsis" :title="name">
       {{ name }}
     </q-card-section>
     <q-separator inset />
@@ -29,7 +26,7 @@
       <ChargePointFaultMessage :charge-point-id="props.chargePointId" />
       <ChargePointStateMessage :charge-point-id="props.chargePointId" />
     </q-card-section>
-    <q-card-section class="row items-center q-mt-sm">
+    <q-card-section class="row items-center justify-between q-mt-sm">
       <ChargePointVehicleSelect
         :charge-point-id="Number(props.chargePointId)"
       />

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointVehicleSelect.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointVehicleSelect.vue
@@ -2,15 +2,15 @@
   <div v-if="props.readonly" class="q-mx-sm">
     {{ connectedVehicle?.name }}
   </div>
-  <q-btn-dropdown
-    v-else
-    color="grey"
-    :label="connectedVehicle?.name"
-    icon="directions_car"
-    dense
-    no-caps
-    class="flex-grow"
-  >
+  <q-btn-dropdown v-else color="grey" dense no-caps icon="directions_car">
+    <template #label>
+      <span
+        class="dropdown-label ellipsis q-ml-xs"
+        :title="connectedVehicle?.name"
+      >
+        {{ connectedVehicle?.name }}
+      </span>
+    </template>
     <q-list>
       <q-item
         v-for="vehicle in vehicles"
@@ -21,7 +21,9 @@
         @click="connectedVehicle = vehicle"
       >
         <q-item-section>
-          <q-item-label>{{ vehicle.name }}</q-item-label>
+          <q-item-label class="ellipsis dropdown-label" :title="vehicle.name">{{
+            vehicle.name
+          }}</q-item-label>
         </q-item-section>
       </q-item>
     </q-list>
@@ -55,5 +57,10 @@ const vehicles = computed(() => mqttStore.vehicleList);
 <style scoped>
 .flex-grow {
   flex-grow: 1;
+}
+
+.dropdown-label {
+  text-align: left;
+  width: 135px;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointVehicleSelect.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointVehicleSelect.vue
@@ -54,7 +54,4 @@ const vehicles = computed(() => mqttStore.vehicleList);
 </script>
 
 <style scoped>
-.flex-grow {
-  flex-grow: 1;
-}
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointVehicleSelect.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointVehicleSelect.vue
@@ -1,13 +1,12 @@
 <template>
   <div v-if="props.readonly" class="q-mx-sm">
+    <q-icon name="directions_car" />
     {{ connectedVehicle?.name }}
   </div>
-  <q-btn-dropdown v-else color="grey" dense no-caps icon="directions_car">
+  <q-btn-dropdown v-else color="grey" dense no-caps>
     <template #label>
-      <span
-        class="dropdown-label ellipsis q-ml-xs"
-        :title="connectedVehicle?.name"
-      >
+      <span class="ellipsis q-ml-xs" :title="connectedVehicle?.name">
+        <q-icon name="directions_car" />
         {{ connectedVehicle?.name }}
       </span>
     </template>
@@ -21,7 +20,7 @@
         @click="connectedVehicle = vehicle"
       >
         <q-item-section>
-          <q-item-label class="ellipsis dropdown-label" :title="vehicle.name">{{
+          <q-item-label class="ellipsis" :title="vehicle.name">{{
             vehicle.name
           }}</q-item-label>
         </q-item-section>
@@ -57,10 +56,5 @@ const vehicles = computed(() => mqttStore.vehicleList);
 <style scoped>
 .flex-grow {
   flex-grow: 1;
-}
-
-.dropdown-label {
-  text-align: left;
-  width: 135px;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/VehicleCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/VehicleCard.vue
@@ -1,22 +1,25 @@
 <template>
   <q-card ref="cardRef" class="full-height card-width">
+    <q-card-section class="text-h6 text-bold ellipsis" :title="vehicle?.name">
+      {{ vehicle?.name }}
+    </q-card-section>
+    <q-separator inset />
+    <q-card-section class="row q-mt-sm">
+      <div class="col">
+        <div class="text-subtitle2">Hersteller:</div>
+        {{ vehicleInfo?.manufacturer || 'keine Angabe' }}
+      </div>
+      <div class="col q-pl-sm">
+        <div class="text-subtitle2">Modell:</div>
+        {{ vehicleInfo?.model || 'keine Angabe' }}
+      </div>
+    </q-card-section>
+    <q-separator inset class="q-mt-sm" />
     <q-card-section>
-      <div class="row items-center text-h6 text-bold">
-        <div class="col flex items-center">
-          {{ vehicle?.name }}
-        </div>
-      </div>
-      <div class="row q-mt-sm">
-        <div class="col">
-          <div class="text-subtitle2">Hersteller:</div>
-          {{ vehicleInfo?.manufacturer || 'keine Angabe' }}
-        </div>
-        <div class="col q-pl-sm">
-          <div class="text-subtitle2">Modell:</div>
-          {{ vehicleInfo?.model || 'keine Angabe' }}
-        </div>
-      </div>
       <VehicleConnectionStateIcon :vehicle-id="vehicleId" class="q-mt-sm" />
+    </q-card-section>
+    <q-separator inset class="q-mt-sm" />
+    <q-card-section>
       <SliderDouble
         v-if="vehicleSocType"
         class="q-mt-sm"
@@ -97,8 +100,25 @@ onMounted(() => {
   width: 22em;
 }
 
-.slider-container {
-  position: relative;
-  height: 40px;
+.q-card__section {
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.q-card__section:first-of-type {
+  padding-top: 16px;
+  padding-bottom: 0;
+}
+
+.q-card__section:last-of-type {
+  padding-top: 0;
+  padding-bottom: 16px;
+}
+
+.q-card__section:not(:first-of-type):not(:last-of-type) {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/VehicleConnectionStateIcon.vue
+++ b/packages/modules/web_themes/koala/source/src/components/VehicleConnectionStateIcon.vue
@@ -12,6 +12,7 @@
         v-for="(chargePoint, index) in vehicleState"
         :key="index"
         :icon="chargePoint.plugged ? 'power' : 'power_off'"
+        class="ellipsis"
         :color="
           chargePoint.plugged
             ? chargePoint.charging


### PR DESCRIPTION
Aktualisiere das Kartenlayout für Fahrzeug- und Batteriekarten:

Füge  (Ellipsis) zu Fahrzeug- und Speichernamen in den Kartenüberschriften hinzu
Füge  (Ellipsis) zur Fahrzeug-Dropdown-Liste in den Ladepunkt-Karten hinzu
Füge  (Ellipsis) zu den Ladepunkt-Chips in den Fahrzeugkarten hinzu

<img width="1091" height="530" alt="Bildschirmfoto 2025-07-31 um 09 06 08" src="https://github.com/user-attachments/assets/e61abbf1-a715-4935-a997-e727623f3ec9" />
<img width="964" height="615" alt="Bildschirmfoto 2025-07-31 um 09 06 20" src="https://github.com/user-attachments/assets/c1b73431-5509-4e04-a7ce-347284e86637" />
<img width="912" height="611" alt="Bildschirmfoto 2025-07-31 um 09 07 15" src="https://github.com/user-attachments/assets/d69a2263-c183-444f-8fe1-c5ea5662d982" />
<img width="959" height="625" alt="Bildschirmfoto 2025-07-31 um 09 07 26" src="https://github.com/user-attachments/assets/c04c4729-090d-4764-a965-0234174949f5" />
