### PR TITLE
Koala - Energy price buttons - whole cent plus fine adjustment buttons

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ChargePointEcoSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointEcoSettings.vue
@@ -72,81 +72,70 @@
     <div class="text-subtitle2 q-my-sm">
       Preisgrenze für strompreisbasiertes Laden
     </div>
-    <div class="row items-center q-mb-xs q-gutter-x-sm">
-      <div class="col-auto">
-        <q-btn
-          v-if="maxPrice.value"
-          icon="remove"
-          color="grey"
-          size="sm"
-          class="q-mr-md"
-          @click="maxPrice.value = maxPrice.value - 1"
-        />
-        <q-btn
-          v-if="maxPrice.value"
-          icon="add"
-          color="grey"
-          size="sm"
-          @click="maxPrice.value = maxPrice.value + 1"
-        />
+    <div class="row items-center justify-center q-mb-xs q-gutter-x-xs">
+      <q-btn
+        v-if="maxPrice.value"
+        class="col-auto"
+        label="-1,00"
+        color="grey"
+        size="sm"
+        dense
+        @click="maxPrice.value = maxPrice.value - 1"
+      />
+      <q-btn
+        v-if="maxPrice.value"
+        class="col-auto"
+        label="-0,10"
+        color="grey"
+        size="sm"
+        dense
+        @click="maxPrice.value = maxPrice.value - 0.1"
+      />
+      <q-btn
+        v-if="maxPrice.value"
+        class="col-auto"
+        label="-0,01"
+        color="grey"
+        size="sm"
+        dense
+        @click="maxPrice.value = maxPrice.value - 0.01"
+      />
+      <div class="col-auto q-mx-sm">
+        {{
+          maxPrice.value?.toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          }) + ' ct/kWh'
+        }}
       </div>
-      <div class="col text-left">
-        <span class="text-caption">Cent</span>
-      </div>
+      <q-btn
+        v-if="maxPrice.value"
+        class="col-auto"
+        label="+0,01"
+        color="grey"
+        size="sm"
+        dense
+        @click="maxPrice.value = maxPrice.value + 0.01"
+      />
+      <q-btn
+        v-if="maxPrice.value"
+        class="col-auto"
+        label="+0,10"
+        color="grey"
+        size="sm"
+        dense
+        @click="maxPrice.value = maxPrice.value + 0.1"
+      />
+      <q-btn
+        v-if="maxPrice.value"
+        class="col-auto"
+        label="+1,00"
+        color="grey"
+        size="sm"
+        dense
+        @click="maxPrice.value = maxPrice.value + 1"
+      />
     </div>
-    <div class="row items-center q-mb-xs q-gutter-x-sm">
-      <div class="col-auto">
-        <q-btn
-          v-if="maxPrice.value"
-          icon="remove"
-          color="grey"
-          size="sm"
-          class="q-mr-md"
-          @click="maxPrice.value = maxPrice.value - 0.1"
-        />
-        <q-btn
-          v-if="maxPrice.value"
-          icon="add"
-          color="grey"
-          size="sm"
-          @click="maxPrice.value = maxPrice.value + 0.1"
-        />
-      </div>
-      <div class="col text-left">
-        <span class="text-caption">Zehntel Cent</span>
-      </div>
-    </div>
-    <div class="row items-center q-gutter-x-sm">
-      <div class="col-auto">
-        <q-btn
-          v-if="maxPrice.value"
-          icon="remove"
-          color="grey"
-          size="sm"
-          class="q-mr-md"
-          @click="maxPrice.value = maxPrice.value - 0.01"
-        />
-        <q-btn
-          v-if="maxPrice.value"
-          icon="add"
-          color="grey"
-          size="sm"
-          @click="maxPrice.value = maxPrice.value + 0.01"
-        />
-      </div>
-      <div class="col text-left">
-        <span class="text-caption">Hundertstel Cent</span>
-      </div>
-    </div>
-    <div class="q-mt-sm">
-      {{
-        maxPrice.value?.toLocaleString(undefined, {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        }) + ' ct/kWh'
-      }}
-    </div>
-
     <q-field filled class="q-mt-sm">
       <ElectricityTariffChart
         :modelValue="maxPrice.value"

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointEcoSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointEcoSettings.vue
@@ -69,55 +69,84 @@
     class="q-mt-md"
   />
   <div v-if="etConfigured">
-    <div class="text-subtitle2 q-mt-sm q-mr-sm">
+    <div class="text-subtitle2 q-my-sm">
       Preisgrenze für strompreisbasiertes Laden
     </div>
-    <div class="row items-center justify-center q-ma-none q-pa-none no-wrap">
-      <!-- <q-btn-group class="col"> -->
-      <q-btn
-        v-if="maxPrice.value"
-        icon="remove"
-        color="grey"
-        size="xs"
-        dense
-        class="col q-mr-sm"
-        @click="maxPrice.value = maxPrice.value - 0.01"
-      />
-      <q-btn
-        v-if="maxPrice.value"
-        icon="remove"
-        color="grey"
-        size="sm"
-        class="col q-mr-sm"
-        @click="maxPrice.value = maxPrice.value - 1"
-      />
-      <q-btn
-        v-if="maxPrice.value"
-        icon="add"
-        color="grey"
-        size="sm"
-        class="col q-mr-sm"
-        @click="maxPrice.value = maxPrice.value + 1"
-      />
-      <q-btn
-        v-if="maxPrice.value"
-        icon="add"
-        color="grey"
-        size="xs"
-        dense
-        class="col"
-        @click="maxPrice.value = maxPrice.value + 0.01"
-      />
-      <!-- </q-btn-group> -->
-      <div class="col-5 text-right">
-        {{
-          maxPrice.value?.toLocaleString(undefined, {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          }) + ' ct/kWh'
-        }}
+    <div class="row items-center q-mb-xs q-gutter-x-sm">
+      <div class="col-auto">
+        <q-btn
+          v-if="maxPrice.value"
+          icon="remove"
+          color="grey"
+          size="sm"
+          class="q-mr-md"
+          @click="maxPrice.value = maxPrice.value - 1"
+        />
+        <q-btn
+          v-if="maxPrice.value"
+          icon="add"
+          color="grey"
+          size="sm"
+          @click="maxPrice.value = maxPrice.value + 1"
+        />
+      </div>
+      <div class="col text-left">
+        <span class="text-caption">Cent</span>
       </div>
     </div>
+    <div class="row items-center q-mb-xs q-gutter-x-sm">
+      <div class="col-auto">
+        <q-btn
+          v-if="maxPrice.value"
+          icon="remove"
+          color="grey"
+          size="sm"
+          class="q-mr-md"
+          @click="maxPrice.value = maxPrice.value - 0.1"
+        />
+        <q-btn
+          v-if="maxPrice.value"
+          icon="add"
+          color="grey"
+          size="sm"
+          @click="maxPrice.value = maxPrice.value + 0.1"
+        />
+      </div>
+      <div class="col text-left">
+        <span class="text-caption">Zehntel Cent</span>
+      </div>
+    </div>
+    <div class="row items-center q-gutter-x-sm">
+      <div class="col-auto">
+        <q-btn
+          v-if="maxPrice.value"
+          icon="remove"
+          color="grey"
+          size="sm"
+          class="q-mr-md"
+          @click="maxPrice.value = maxPrice.value - 0.01"
+        />
+        <q-btn
+          v-if="maxPrice.value"
+          icon="add"
+          color="grey"
+          size="sm"
+          @click="maxPrice.value = maxPrice.value + 0.01"
+        />
+      </div>
+      <div class="col text-left">
+        <span class="text-caption">Hundertstel Cent</span>
+      </div>
+    </div>
+    <div class="q-mt-sm">
+      {{
+        maxPrice.value?.toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        }) + ' ct/kWh'
+      }}
+    </div>
+
     <q-field filled class="q-mt-sm">
       <ElectricityTariffChart
         :modelValue="maxPrice.value"

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointEcoSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointEcoSettings.vue
@@ -78,15 +78,33 @@
         v-if="maxPrice.value"
         icon="remove"
         color="grey"
-        size="sm"
+        size="xs"
+        dense
         class="col q-mr-sm"
         @click="maxPrice.value = maxPrice.value - 0.01"
+      />
+      <q-btn
+        v-if="maxPrice.value"
+        icon="remove"
+        color="grey"
+        size="sm"
+        class="col q-mr-sm"
+        @click="maxPrice.value = maxPrice.value - 1"
       />
       <q-btn
         v-if="maxPrice.value"
         icon="add"
         color="grey"
         size="sm"
+        class="col q-mr-sm"
+        @click="maxPrice.value = maxPrice.value + 1"
+      />
+      <q-btn
+        v-if="maxPrice.value"
+        icon="add"
+        color="grey"
+        size="xs"
+        dense
         class="col"
         @click="maxPrice.value = maxPrice.value + 0.01"
       />


### PR DESCRIPTION
Schaltflächen für ganze Cent und Feineinstellung der Strompreisgrenze hinzugefügt.

<img width="384" height="574" alt="Bildschirmfoto 2025-07-31 um 15 17 09" src="https://github.com/user-attachments/assets/6c8d8ad5-15f7-4317-b68e-cccf8f952e44" />
