### PR TITLE
evcc SoC: moved template field into config map and restored API call

### DIFF
--- a/packages/modules/vehicles/evcc/api.py
+++ b/packages/modules/vehicles/evcc/api.py
@@ -35,8 +35,8 @@ def create_vehicle(config: EVCCVehicleSocConfiguration, stub: vehicle_pb2_grpc.V
         vehicle_pb2.NewRequest(
             token=config.sponsor_token,
             type="template",
-            template=config.vehicle_type,
             config=cast(Mapping[str, str], {
+                'template': config.vehicle_type,
                 'User': config.user_id,
                 'Password': config.password,
                 'VIN': config.VIN  # VIN is optional, but must not be None

--- a/packages/modules/vehicles/evcc/vehicle_pb2.pyi
+++ b/packages/modules/vehicles/evcc/vehicle_pb2.pyi
@@ -19,12 +19,11 @@ class NewRequest(_message.Message):
         def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
     TOKEN_FIELD_NUMBER: _ClassVar[int]
     TYPE_FIELD_NUMBER: _ClassVar[int]
-    TEMPLATE_FIELD_NUMBER: _ClassVar[int]
     CONFIG_FIELD_NUMBER: _ClassVar[int]
     token: str
     type: str
     config: _containers.ScalarMap[str, str]
-    def __init__(self, token: _Optional[str] = ..., type: _Optional[str] = ..., template: _Optional[str] = ..., config: _Optional[_Mapping[str, str]] = ...) -> None: ...
+    def __init__(self, token: _Optional[str] = ..., type: _Optional[str] = ..., config: _Optional[_Mapping[str, str]] = ...) -> None: ...
 
 class NewReply(_message.Message):
     __slots__ = ("vehicle_id",)


### PR DESCRIPTION
Die Dikussion mit @andig in
https://github.com/openWB/core/pull/2598
hat mir im Nachhinein jetzt erst die Augen geöffnet.

Der NewRequest()-Aufruf in Richtung evcc cloud muss bleiben, wie er ist. 
"template" muss *innerhalb* der config-map und nicht als extra Feld mit übergeben werden.

Ich habe also den NewRequest()-Aufruf wiederhergestellt. 
Das Datenfeld "template" mit dem Template-Typ (=Fahrzeug-Typ) wird jetzt als der Teil der Config-Map übergeben.

Testhalber habe ich einige Male Fahrzeuge gelöscht und neu angelegt, damit die vehicle ID zwischendurch gelöscht und neu in der evcc cloud angefragt wird. Konnte hier mit zwei verschiedenen Audi-Accounts erfolgreich testen.