### PR TITLE
Sungrow Modbus Register update

### DIFF
--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -35,7 +35,7 @@ class SungrowBat(AbstractBat):
         self.last_mode = 'Undefined'
         self.firmware_check = self.check_firmware_register()
 
-    def check_firmware_register(self):
+    def check_firmware_register(self) -> bool:
         if Firmware(self.device_config.configuration.firmware) == Firmware.v1:
             return False
         unit = self.device_config.configuration.modbus_id

--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -44,7 +44,7 @@ class SungrowBat(AbstractBat):
         except Exception:
             bat_current = self.__tcp_client.read_input_registers(13020, ModbusDataType.INT_16, unit=unit) * -0.1
         currents = [bat_current / 3] * 3
-    
+
         firmware = Firmware(self.device_config.configuration.firmware)
         version = Version(self.device_config.configuration.version)
 
@@ -52,11 +52,11 @@ class SungrowBat(AbstractBat):
         if firmware == Firmware.v2 and version in (Version.SH, Version.SH_winet_dongle):
             try:
                 # Ab FW Version 95.09 gibt es ein neues Register für die Batterieleistung
-                bat_power = self.__tcp_client.read_input_registers(5213, ModbusDataType.INT_32, 
+                bat_power = self.__tcp_client.read_input_registers(5213, ModbusDataType.INT_32,
                                                                    wordorder=Endian.Little, unit=unit) * -1
             except Exception:
                 bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.INT_16, unit=unit) * -1
-                
+
         elif firmware == Firmware.v1 and version == Version.SH:
             bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.INT_16, unit=unit) * -1
         else:

--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -46,7 +46,7 @@ class SungrowBat(AbstractBat):
         currents = [bat_current / 3] * 3
     
         firmware = Firmware(self.device_config.configuration.firmware)
-        version = self.device_config.configuration.version
+        version = Version(self.device_config.configuration.version)
 
         bat_power = None
         if firmware == Firmware.v2:

--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -33,11 +33,11 @@ class SungrowBat(AbstractBat):
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.last_mode = 'Undefined'
-        self.firmware_check = None
+        self.check_firmware_register()
 
-    def check_firmware_register(self, unit):
+    def check_firmware_register(self):
+        unit = self.device_config.configuration.modbus_id
         try:
-            self.__tcp_client.read_input_registers(5630, ModbusDataType.INT_16, unit=unit)
             self.__tcp_client.read_input_registers(5213, ModbusDataType.INT_32,
                                                    wordorder=Endian.Little, unit=unit)
             self.firmware_check = True
@@ -48,9 +48,6 @@ class SungrowBat(AbstractBat):
 
     def update(self) -> None:
         unit = self.device_config.configuration.modbus_id
-
-        if self.firmware_check is None:
-            self.check_firmware_register(unit)
 
         soc = int(self.__tcp_client.read_input_registers(13022, ModbusDataType.UINT_16, unit=unit) / 10)
         firmware = Firmware(self.device_config.configuration.firmware)


### PR DESCRIPTION
Mit der neuen Firmware 95.09 sind wieder Änderungen an den Modbus Registern erfolgt und Register 13021 hat wieder kein Vorzeichen, dafür gibt es ein neues Register 5213