### PR TITLE
Prevent warning - opening CP or vehicle card from table

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointCard.vue
@@ -103,8 +103,10 @@ import ChargePointPowerData from './ChargePointPowerData.vue';
 import { useQuasar } from 'quasar';
 
 const cardRef = ref<{ $el: HTMLElement } | null>(null);
-const setCardWidth =
-  inject<(width: number | undefined) => void>('setCardWidth');
+const setCardWidth = inject<(width: number | undefined) => void>(
+  'setCardWidth',
+  undefined as unknown as (width: number | undefined) => void,
+);
 
 const mqttStore = useMqttStore();
 

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointVehicleSelect.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointVehicleSelect.vue
@@ -52,6 +52,3 @@ const connectedVehicle = mqttStore.chargePointConnectedVehicleInfo(
 
 const vehicles = computed(() => mqttStore.vehicleList);
 </script>
-
-<style scoped>
-</style>

--- a/packages/modules/web_themes/koala/source/src/components/VehicleCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/VehicleCard.vue
@@ -51,8 +51,10 @@ import ManualSocDialog from './ManualSocDialog.vue';
 import VehicleConnectionStateIcon from './VehicleConnectionStateIcon.vue';
 
 const cardRef = ref<{ $el: HTMLElement } | null>(null);
-const setCardWidth =
-  inject<(width: number | undefined) => void>('setCardWidth');
+const setCardWidth = inject<(width: number | undefined) => void>(
+  'setCardWidth',
+  undefined as unknown as (width: number | undefined) => void,
+);
 
 const props = defineProps<{
   vehicleId: number;


### PR DESCRIPTION
Um die Kartenbreite zu berechnen und in der Basiskarussell-Komponente die Anzahl der anzuzeigenden Karten zu bestimmen, wird die Funktion setCardWidth in ChargePointCard und VehicleCard injiziert. Wenn jedoch das Karussell nicht verwendet wird und stattdessen die Tabellenansicht aktiv ist, wird eine Warnung ausgegeben, da die Funktion vom Karussell nicht übergeben wurde. Aus diesem Grund wird hier ein Fallback auf undefined verwendet, der jedoch in denselben Funktionstyp wie der von BaseCarousel erwartet wird umgewandelt werden muss, um TypeScript-Fehler zu vermeiden.