### PR TITLE
Only display battery data if a battery is configured

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChartLegend.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChartLegend.vue
@@ -54,7 +54,7 @@ const legendLarge = computed(() => {
   return legendItems.value.length > 20;
 });
 
-const isBattery = computed(() => {
+const batteryConfigured = computed(() => {
   return mqttStore.batteryConfigured;
 });
 
@@ -64,7 +64,7 @@ const updateLegendItems = () => {
     props.chart.options.plugins?.legend?.labels?.generateLabels?.(
       props.chart,
     ) || [];
-  if (!isBattery.value) {
+  if (!batteryConfigured.value) {
     items = items.filter(
       (item: LegendItemWithCategory) =>
         item.text !== 'Speicher ges.' && item.text !== 'Speicher SoC',

--- a/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChartLegend.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChartLegend.vue
@@ -54,12 +54,22 @@ const legendLarge = computed(() => {
   return legendItems.value.length > 20;
 });
 
+const isBattery = computed(() => {
+  return mqttStore.batteryConfigured;
+});
+
 const updateLegendItems = () => {
   if (!props.chart) return;
-  const items =
+  let items =
     props.chart.options.plugins?.legend?.labels?.generateLabels?.(
       props.chart,
     ) || [];
+  if (!isBattery.value) {
+    items = items.filter(
+      (item: LegendItemWithCategory) =>
+        item.text !== 'Speicher ges.' && item.text !== 'Speicher SoC',
+    );
+  }
   (items as LegendItemWithCategory[]).forEach((item) => {
     if (item.text && localDataStore.isDatasetHidden(item.text)) {
       item.hidden = true;

--- a/packages/modules/web_themes/koala/source/src/pages/IndexPage.vue
+++ b/packages/modules/web_themes/koala/source/src/pages/IndexPage.vue
@@ -14,7 +14,7 @@
         <q-tab name="vehicles" title="Fahrzeuge">
           <q-icon name="directions_car" size="md" color="primary" />
         </q-tab>
-        <q-tab name="batteries" title="Speicher">
+        <q-tab v-if="isBattery" name="batteries" title="Speicher">
           <q-icon name="battery_full" size="md" color="primary" />
         </q-tab>
         <!-- <q-tab name="smart-home" title="SmartHome">
@@ -32,7 +32,7 @@
           <VehicleInformation />
         </q-tab-panel>
         <!-- Batteries -->
-        <q-tab-panel name="batteries">
+        <q-tab-panel v-if="isBattery" name="batteries">
           <BatteryInformation />
         </q-tab-panel>
         <!-- Smart Home -->
@@ -45,7 +45,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
+import { useMqttStore } from 'src/stores/mqtt-store';
 import ChartCarousel from 'src/components/ChartCarousel.vue';
 import ChargePointInformation from 'src/components/ChargePointInformation.vue';
 import BatteryInformation from 'src/components/BatteryInformation.vue';
@@ -57,6 +58,11 @@ defineOptions({
 });
 
 const tab = ref<string>('charge-points');
+const mqttStore = useMqttStore();
+
+const isBattery = computed(() => {
+  return mqttStore.batteryConfigured;
+});
 </script>
 
 <style scoped>

--- a/packages/modules/web_themes/koala/source/src/pages/IndexPage.vue
+++ b/packages/modules/web_themes/koala/source/src/pages/IndexPage.vue
@@ -14,7 +14,7 @@
         <q-tab name="vehicles" title="Fahrzeuge">
           <q-icon name="directions_car" size="md" color="primary" />
         </q-tab>
-        <q-tab v-if="isBattery" name="batteries" title="Speicher">
+        <q-tab v-if="batteryConfigured" name="batteries" title="Speicher">
           <q-icon name="battery_full" size="md" color="primary" />
         </q-tab>
         <!-- <q-tab name="smart-home" title="SmartHome">
@@ -32,7 +32,7 @@
           <VehicleInformation />
         </q-tab-panel>
         <!-- Batteries -->
-        <q-tab-panel v-if="isBattery" name="batteries">
+        <q-tab-panel v-if="batteryConfigured" name="batteries">
           <BatteryInformation />
         </q-tab-panel>
         <!-- Smart Home -->
@@ -60,7 +60,7 @@ defineOptions({
 const tab = ref<string>('charge-points');
 const mqttStore = useMqttStore();
 
-const isBattery = computed(() => {
+const batteryConfigured = computed(() => {
   return mqttStore.batteryConfigured;
 });
 </script>


### PR DESCRIPTION
Batteriedaten sollen nur angezeigt werden, wenn eine Batterie konfiguriert ist. Falls keine Batterie konfiguriert ist, werden der Speicher-Tab sowie batterierelevante Elemente im Verlaufsdiagramm und im Flussdiagramm ausgeblendet.

https://forum.openwb.de/viewtopic.php?p=129811#p129811