### PR TITLE
Koala theme: add apple-mobile-web-app-capable HTML meta tag

### DIFF
--- a/packages/modules/web_themes/koala/source/index.html
+++ b/packages/modules/web_themes/koala/source/index.html
@@ -8,13 +8,6 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="apple-touch-icon" sizes="72x72" href="/openWB/web/img/favicons/apple-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="/openWB/web/img/favicons/apple-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="/openWB/web/img/favicons/apple-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="/openWB/web/img/favicons/apple-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="/openWB/web/img/favicons/apple-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/openWB/web/img/favicons/apple-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/openWB/web/img/favicons/apple-icon-180x180.png">
     <meta
       name="viewport"
       content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %>"

--- a/packages/modules/web_themes/koala/source/index.html
+++ b/packages/modules/web_themes/koala/source/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="<%= productDescription %>" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta
       name="viewport"
       content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %>"

--- a/packages/modules/web_themes/koala/source/index.html
+++ b/packages/modules/web_themes/koala/source/index.html
@@ -8,6 +8,13 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <link rel="apple-touch-icon" sizes="72x72" href="/openWB/web/img/favicons/apple-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="/openWB/web/img/favicons/apple-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/openWB/web/img/favicons/apple-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="/openWB/web/img/favicons/apple-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/openWB/web/img/favicons/apple-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/openWB/web/img/favicons/apple-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/openWB/web/img/favicons/apple-icon-180x180.png">
     <meta
       name="viewport"
       content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %>"


### PR DESCRIPTION
Bei Koala fehlte im Gegensatz zu den anderen Themas das apple-mobile-web-app-capable HTML meta tag.

Dies ist nötig, damit das Theme auf iOS Devices im Vollbild ohne Browser-Adressleiste angezeigt werden kann.
Ansonsten ist auch bei einer direkten Verknüpfung via Homescreen (-> als "App") immer die Adressleiste sichtbar und verdeckt einen Teil der Oberfläche.