### PR TITLE
Bugfix Smarthome Lambda Wärmepumpe Modbus Kommunikation

### DIFF
--- a/packages/modules/smarthome/lambda_/off.py
+++ b/packages/modules/smarthome/lambda_/off.py
@@ -22,7 +22,7 @@ log.info(' off.py devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)'
          % (devicenumber, ipadr, uberschuss))
 client = ModbusTcpClient(ipadr, port=502)
 start = 103
-resp = client.read_holding_registers(start, 2)
+resp = client.read_holding_registers(start, 2, unit=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])

--- a/packages/modules/smarthome/lambda_/on.py
+++ b/packages/modules/smarthome/lambda_/on.py
@@ -23,7 +23,7 @@ log.info(' on.py devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)'
          % (devicenumber, ipadr, uberschuss))
 client = ModbusTcpClient(ipadr, port=502)
 start = 103
-resp = client.read_holding_registers(start, 2)
+resp = client.read_holding_registers(start, 2, unit=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])

--- a/packages/modules/smarthome/lambda_/watt.py
+++ b/packages/modules/smarthome/lambda_/watt.py
@@ -53,7 +53,7 @@ if os.path.isfile(file_stringpv):
 # aktuelle Leistung lesen
 with ModbusTcpClient(ipadr, port=502) as client:
     start = 103
-    resp = client.read_holding_registers(start, 2)
+    resp = client.read_holding_registers(start, 2, unit=1)
     #
     value1 = resp.registers[0]
     all = format(value1, '04x')

--- a/packages/modules/smarthome/lambda_/watt.py
+++ b/packages/modules/smarthome/lambda_/watt.py
@@ -104,7 +104,7 @@ with ModbusTcpClient(ipadr, port=502) as client:
             builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
             builder.add_16bit_int(neupower)
             pay = builder.to_registers()
-            client.write_registers(102, [pay[0]])
+            client.write_registers(102, [pay[0]], unit=1)
             if count1 < 3:
                 log.info(' %d ipadr %s written %6d %#4X' %
                          (devicenumber, ipadr, pay[0], pay[0]))


### PR DESCRIPTION
Bugfix Smarthome Lambda Wärmepumpe Modbus Kommunikation siehe hier https://forum.openwb.de/viewtopic.php?t=5380&sid=338d90c17e1cdb33fb6dbf193345bac8&start=400
aufgrund neue Hainzl Steuerung in neuen Lambda WP Modellen notwendig