### PR TITLE
Fix zero currents / zero power 

### DIFF
--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -71,7 +71,11 @@ class BatState:
         if _check_none(currents):
             currents = [0.0]*3
         else:
-            if not ((sum(currents) < 0 and power < 0) or (sum(currents) > 0 and power > 0)):
+            if not (
+                (sum(currents) < 0 and power < 0) or 
+                (sum(currents) > 0 and power > 0) or 
+                (sum(currents) == 0 and power == 0)
+            ):
                 log.debug("currents sign wrong "+str(currents))
         self.currents = currents
 
@@ -131,7 +135,11 @@ class InverterState:
         if _check_none(currents):
             currents = [0.0]*3
         else:
-            if not ((sum(currents) < 0 and power < 0) or (sum(currents) > 0 and power > 0)):
+            if not (
+                (sum(currents) < 0 and power < 0) or 
+                (sum(currents) > 0 and power > 0) or 
+                (sum(currents) == 0 and power == 0)
+            ):
                 log.debug("currents sign wrong "+str(currents))
         self.currents = currents
         self.power = power

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -72,8 +72,8 @@ class BatState:
             currents = [0.0]*3
         else:
             if not (
-                (sum(currents) < 0 and power < 0) or 
-                (sum(currents) > 0 and power > 0) or 
+                (sum(currents) < 0 and power < 0) or
+                (sum(currents) > 0 and power > 0) or
                 (sum(currents) == 0 and power == 0)
             ):
                 log.debug("currents sign wrong "+str(currents))
@@ -136,8 +136,8 @@ class InverterState:
             currents = [0.0]*3
         else:
             if not (
-                (sum(currents) < 0 and power < 0) or 
-                (sum(currents) > 0 and power > 0) or 
+                (sum(currents) < 0 and power < 0) or
+                (sum(currents) > 0 and power > 0) or
                 (sum(currents) == 0 and power == 0)
             ):
                 log.debug("currents sign wrong "+str(currents))

--- a/packages/modules/common/component_state.py
+++ b/packages/modules/common/component_state.py
@@ -48,6 +48,15 @@ def _calculate_powers_and_currents(currents: Optional[List[Optional[float]]],
     return currents, powers, voltages
 
 
+def check_currents_power_sign(currents: Optional[List[Optional[float]]], power: float) -> bool:
+    """Check if the sign of the sum of currents matches the power sign or both zero."""
+    return any([
+        sum(currents) < 0 and power < 0,
+        sum(currents) > 0 and power > 0,
+        sum(currents) == 0 and power == 0
+    ])
+
+
 @auto_str
 class BatState:
     def __init__(
@@ -71,11 +80,7 @@ class BatState:
         if _check_none(currents):
             currents = [0.0]*3
         else:
-            if not (
-                (sum(currents) < 0 and power < 0) or
-                (sum(currents) > 0 and power > 0) or
-                (sum(currents) == 0 and power == 0)
-            ):
+            if not check_currents_power_sign(currents, power):
                 log.debug("currents sign wrong "+str(currents))
         self.currents = currents
 
@@ -135,11 +140,7 @@ class InverterState:
         if _check_none(currents):
             currents = [0.0]*3
         else:
-            if not (
-                (sum(currents) < 0 and power < 0) or
-                (sum(currents) > 0 and power > 0) or
-                (sum(currents) == 0 and power == 0)
-            ):
+            if not check_currents_power_sign(currents, power):
                 log.debug("currents sign wrong "+str(currents))
         self.currents = currents
         self.power = power


### PR DESCRIPTION
Wenn die Ströme 0 sind und die Leistung 0, dann gibt es auch die Meldung "currents sign wrong [0.0, 0.0, 0.0]", diese soll ja aber nur bei einem abweichenden Vorzeichen gesetzt werden?

Beispiel:
https://paste.openwb.de/Tr9oaxvbT9iCtU5