### PR TITLE
Sungrow Battery Readings improvements

### DIFF
--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -33,52 +33,70 @@ class SungrowBat(AbstractBat):
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.last_mode = 'Undefined'
-        self.firmware_check = self.check_firmware_register()
+        self.register_check = self.detect_register_check()
 
-    def check_firmware_register(self) -> bool:
-        if Firmware(self.device_config.configuration.firmware) == Firmware.v1:
-            return False
+    def detect_register_check(self) -> str:
+        # Battery register availability test
         unit = self.device_config.configuration.modbus_id
+
         try:
             self.__tcp_client.read_input_registers(5213, ModbusDataType.INT_32,
                                                    wordorder=Endian.Little, unit=unit)
-            log.debug("Wechselrichter Firmware ist größer gleich 95.09")
-            return True
+            self.__tcp_client.read_input_registers(5630, ModbusDataType.INT_16, unit=unit)
+            log.debug("Battery register check: using new_registers (5213/5630).")
+            return 'new_registers'
         except Exception:
-            log.debug("Wechselrichter Firmware ist kleiner als 95.09")
-            return False
+            pass
+
+        try:
+            self.__tcp_client.read_input_registers(13000, ModbusDataType.UINT_16, unit=unit)
+            log.debug("Battery register check: using old_registers (13021 + 13000 bits for sign).")
+            return 'old_registers'
+        except Exception:
+            pass
+
+        log.debug("Battery register check: using fallback (13021 + total vs PV power).")
+        return 'fallback'
 
     def update(self) -> None:
         unit = self.device_config.configuration.modbus_id
-
         soc = int(self.__tcp_client.read_input_registers(13022, ModbusDataType.UINT_16, unit=unit) / 10)
-        version = Version(self.device_config.configuration.version)
 
-        if Firmware(self.device_config.configuration.firmware) == Firmware.v2:
-            if self.firmware_check:  # Firmware >= 95.09
-                bat_current = self.__tcp_client.read_input_registers(5630, ModbusDataType.INT_16, unit=unit) * -0.1
-                bat_power = self.__tcp_client.read_input_registers(5213, ModbusDataType.INT_32,
-                                                                   wordorder=Endian.Little, unit=unit) * -1
-            else:  # Firmware between 95.03 and 95.09
-                bat_current = self.__tcp_client.read_input_registers(13020, ModbusDataType.INT_16, unit=unit) * -0.1
-                if version == Version.SH:
-                    bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.INT_16, unit=unit)
-                elif version == Version.SH_winet_dongle:
-                    bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, unit=unit)
-                    total_power = self.__tcp_client.read_input_registers(13033, ModbusDataType.INT_32,
-                                                                         wordorder=Endian.Little, unit=unit)
-                    pv_power = self.__tcp_client.read_input_registers(5016, ModbusDataType.UINT_32,
-                                                                      wordorder=Endian.Little, unit=unit)
-                    if total_power > pv_power:
-                        bat_power = bat_power * -1
-        else:  # Firmware.v1 (Firmware < 95.03)
+        # === Mode 1: new_registers ===
+        if self.register_check == 'new_registers':
+            bat_current = self.__tcp_client.read_input_registers(5630, ModbusDataType.INT_16, unit=unit) * -0.1
+            bat_power = self.__tcp_client.read_input_registers(5213, ModbusDataType.INT_32,
+                                                               wordorder=Endian.Little, unit=unit) * -1
+
+        # === Mode 2: old_registers ===
+        elif self.register_check == 'old_registers':
             bat_current = self.__tcp_client.read_input_registers(13020, ModbusDataType.INT_16, unit=unit) * -0.1
             bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, unit=unit)
-            if version in (Version.SH, Version.SH_winet_dongle):
-                resp = self.__tcp_client._delegate.read_input_registers(13000, 1, unit=unit)
-                binary = bin(resp.registers[0])[2:].zfill(8)
-                if binary[5] == "1":
-                    bat_power = bat_power * -1
+
+            resp = self.__tcp_client._delegate.read_input_registers(13000, 1, unit=unit)
+            running_state = resp.registers[0]
+            is_charging = (running_state & 0x02) != 0
+            is_discharging = (running_state & 0x04) != 0
+
+            if is_discharging:
+                bat_power = -abs(bat_power)
+            elif is_charging:
+                bat_power = abs(bat_power)
+
+        # === Mode 3: fallback ===
+        else:
+            bat_current = self.__tcp_client.read_input_registers(13020, ModbusDataType.INT_16, unit=unit) * -0.1
+            bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, unit=unit)
+
+            total_power = self.__tcp_client.read_input_registers(13033, ModbusDataType.INT_32,
+                                                                 wordorder=Endian.Little, unit=unit)
+            pv_power = self.__tcp_client.read_input_registers(5016, ModbusDataType.UINT_32,
+                                                              wordorder=Endian.Little, unit=unit)
+
+            if total_power > pv_power:
+                bat_power = -abs(bat_power)
+            else:
+                bat_power = abs(bat_power)
 
         currents = [bat_current / 3] * 3
 

--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -11,7 +11,6 @@ from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sungrow.sungrow.config import SungrowBatSetup, Sungrow
 from modules.devices.sungrow.sungrow.version import Version
-from modules.devices.sungrow.sungrow.firmware import Firmware
 
 log = logging.getLogger(__name__)
 

--- a/packages/modules/devices/sungrow/sungrow/bat.py
+++ b/packages/modules/devices/sungrow/sungrow/bat.py
@@ -10,7 +10,6 @@ from modules.common.modbus import ModbusDataType, Endian, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.sungrow.sungrow.config import SungrowBatSetup, Sungrow
-from modules.devices.sungrow.sungrow.version import Version
 
 log = logging.getLogger(__name__)
 

--- a/packages/modules/devices/sungrow/sungrow/config.py
+++ b/packages/modules/devices/sungrow/sungrow/config.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from modules.common.component_setup import ComponentSetup
 from modules.devices.sungrow.sungrow.version import Version
-from modules.devices.sungrow.sungrow.firmware import Firmware
 from ..vendor import vendor_descriptor
 
 
@@ -11,13 +10,11 @@ class SungrowConfiguration:
                  ip_address: Optional[str] = None,
                  port: int = 502,
                  modbus_id: int = 1,
-                 version: Version = Version.SG,
-                 firmware: Firmware = Firmware.v1):
+                 version: Version = Version.SG:
         self.ip_address = ip_address
         self.port = port
         self.modbus_id = modbus_id
         self.version = version
-        self.firmware = firmware
 
 
 class Sungrow:

--- a/packages/modules/devices/sungrow/sungrow/config.py
+++ b/packages/modules/devices/sungrow/sungrow/config.py
@@ -10,7 +10,7 @@ class SungrowConfiguration:
                  ip_address: Optional[str] = None,
                  port: int = 502,
                  modbus_id: int = 1,
-                 version: Version = Version.SG:
+                 version: Version = Version.SG):
         self.ip_address = ip_address
         self.port = port
         self.modbus_id = modbus_id

--- a/packages/modules/devices/sungrow/sungrow/firmware.py
+++ b/packages/modules/devices/sungrow/sungrow/firmware.py
@@ -1,6 +1,0 @@
-from enum import Enum
-
-
-class Firmware(Enum):
-    v1 = "v1"  # bis 11/2024
-    v2 = "v2"  # ab 11/2024

--- a/packages/modules/devices/sungrow/sungrow/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow/inverter.py
@@ -38,20 +38,17 @@ class SungrowInverter(AbstractInverter):
             dc_power = self.__tcp_client.read_input_registers(5016, ModbusDataType.UINT_32,
                                                               wordorder=Endian.Little, unit=unit) * -1
 
-            current_L1 = self.__tcp_client.read_input_registers(13030, ModbusDataType.INT_16, unit=unit) * -0.1
-            current_L2 = self.__tcp_client.read_input_registers(13031, ModbusDataType.INT_16, unit=unit) * -0.1
-            current_L3 = self.__tcp_client.read_input_registers(13032, ModbusDataType.INT_16, unit=unit) * -0.1
-            currents = [current_L1, current_L2, current_L3]
-        else:
+            currents = self.__tcp_client.read_input_registers(13030, [ModbusDataType.INT_16]*3, unit=unit)
+            currents = [value * -0.1 for value in currents]
+            
+        elif self.device_config.configuration.version in (Version.SG, Version.SG_winet_dongle):
             power = self.__tcp_client.read_input_registers(5030, ModbusDataType.INT_32,
                                                            wordorder=Endian.Little, unit=unit) * -1
             dc_power = self.__tcp_client.read_input_registers(5016, ModbusDataType.UINT_32,
                                                               wordorder=Endian.Little, unit=unit) * -1
 
-            current_L1 = self.__tcp_client.read_input_registers(5021, ModbusDataType.UINT_16, unit=unit) * -0.1
-            current_L2 = self.__tcp_client.read_input_registers(5022, ModbusDataType.UINT_16, unit=unit) * -0.1
-            current_L3 = self.__tcp_client.read_input_registers(5023, ModbusDataType.UINT_16, unit=unit) * -0.1
-            currents = [current_L1, current_L2, current_L3]
+            currents = self.__tcp_client.read_input_registers(5021, [ModbusDataType.INT_16]*3, unit=unit)
+            currents = [value * -0.1 for value in currents]
 
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/sungrow/sungrow/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow/inverter.py
@@ -40,7 +40,7 @@ class SungrowInverter(AbstractInverter):
 
             currents = self.__tcp_client.read_input_registers(13030, [ModbusDataType.INT_16]*3, unit=unit)
             currents = [value * -0.1 for value in currents]
-            
+
         elif self.device_config.configuration.version in (Version.SG, Version.SG_winet_dongle):
             power = self.__tcp_client.read_input_registers(5030, ModbusDataType.INT_32,
                                                            wordorder=Endian.Little, unit=unit) * -1

--- a/packages/modules/devices/sungrow/sungrow/registers.py
+++ b/packages/modules/devices/sungrow/sungrow/registers.py
@@ -1,6 +1,7 @@
-from enum import IntEnum
+from enum import Enum
 
-class RegMode(IntEnum):
+
+class RegMode(Enum):
     NEW_REGISTERS = "new_registers"
     OLD_REGISTERS = "old_registers"
     FALLBACK = "fallback"

--- a/packages/modules/devices/sungrow/sungrow/registers.py
+++ b/packages/modules/devices/sungrow/sungrow/registers.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class RegMode(Enum):
+    NEW_REGISTERS = "new_registers"
+    OLD_REGISTERS = "old_registers"
+    FALLBACK = "fallback"

--- a/packages/modules/devices/sungrow/sungrow/registers.py
+++ b/packages/modules/devices/sungrow/sungrow/registers.py
@@ -1,6 +1,6 @@
-from enum import Enum
+from enum import IntEnum
 
-class RegMode(Enum):
+class RegMode(IntEnum):
     NEW_REGISTERS = "new_registers"
     OLD_REGISTERS = "old_registers"
     FALLBACK = "fallback"


### PR DESCRIPTION
https://github.com/openWB/openwb-ui-settings/pull/781

Dieser Code ist mit aktuell neuer Firmware und alter Firmware getestet (danke heavendenied), auch die alte Firmware (sowohl am LAN als auch am WinetS) greift immer auf die neuen Register 5213/5630 zu. Aber um einen möglichen unbedachten Fall weiterhin abwärtskompatibel zu halten, habe ich die alten Funktionen (Mode 2 und 3) behalten, sollten bei einer ganz alten Firmware oder einem nicht getesteten Fall doch mal die neuen Register nicht zur Verfügung stehen, dann greift die Regelung auf Mode 2 bzw Mode 3 zu.
Perspektivisch kann man aber irgendwann diese Option auch mal entfallen lassen

Erweiterung zu: https://github.com/openWB/core/pull/2631