### PR TITLE
colors web theme: fix mqtt connection settings

### DIFF
--- a/packages/modules/web_themes/colors/source/src/components/mqttViewer/mqttClient.ts
+++ b/packages/modules/web_themes/colors/source/src/components/mqttViewer/mqttClient.ts
@@ -10,7 +10,7 @@ import { type QoS } from 'mqtt-packet'
 const defaultQoS: QoS = 0
 const mqttConnection = {
 	host: location.hostname,
-	port: location.protocol == 'https:' ? 443 : 80,
+	port: parseInt(location.port) || (location.protocol == 'https:' ? 443 : 80),
 	endpoint: '/ws',
 	protocol: (location.protocol == 'https:' ? 'wss' : 'ws') as MqttProtocol,
 	clean: true,
@@ -20,8 +20,6 @@ const mqttConnection = {
 		.toString(36)
 		.replace(/[^a-z]+/g, '')
 		.substring(0, 6),
-	username: 'openWB',
-	password: 'openWB',
 }
 const subscription = {
 	topic: '',


### PR DESCRIPTION
- remove not necessary auth settings
- honor current port (allows mqtt connections during remote support sessions)