### PR TITLE
soc_bmwbc: fix quota issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pysmb==1.2.9.1
 pytz==2023.3.post1
 grpcio==1.60.1
 protobuf==4.25.8
-bimmer_connected==0.17.2
+bimmer_connected==0.17.3
 ocpp==1.0.0
 websockets==12.0
 pycarwings3==0.7.14


### PR DESCRIPTION
BMW server checks since 1.9.2025 the number of requests per x_user_agent in a certain period resulting in a frequent "out of quota" error.
The quota for a x_user_agent is replenished only after some time.
Previous versions of bimmer_connectd used a hard coded value for x_user_agent. 
bimmer_connected 0.17.3 resolves that by a dynamic rsp. unique value for x_user_agent per installation, computed from MAC adress, etc.
Please merge asap.