### PR TITLE
fix pv: phase switch before charge start

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -376,7 +376,7 @@ class Chargepoint(ChargepointRfidMixin):
                self.check_deviating_contactor_states(self.data.set.phases_to_use,
                                                      self.data.control_parameter.phases)) and
                 # Wenn der Ladevorgang gestartet wird, muss vor dem ersten Laden umgeschaltet werden.
-                self.data.get.charge_state is False):
+                self.data.set.current != 0 and self.data.get.charge_state is False):
             phase_switch_required = True
         if phase_switch_required:
             # Umschaltung fehlgeschlagen


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?p=132540#p132540
Wenn für PV-Laden eine Umschaltung erforderlich ist, soll diese nur gemacht werden, wenn die Wartezeit Einschalten abgelaufen ist und auch wirklich geladen werden soll.