### PR TITLE
automatic phase switch: use phases in use if charging for reqiured ph…

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -518,7 +518,7 @@ class Chargepoint(ChargepointRfidMixin):
             # bis der Algorithmus eine Umschaltung vorgibt, zB weil der gewählte Lademodus eine
             # andere Phasenzahl benötigt oder bei PV-Laden die automatische Umschaltung aktiv ist.
             if self.data.get.charge_state:
-                phases = self.data.set.phases_to_use
+                phases = self.data.get.phases_in_use
             else:
                 if ((not charging_ev.ev_template.data.prevent_phase_switch or
                         self.data.set.log.imported_since_plugged == 0) and


### PR DESCRIPTION
…ases

Wenn ein Auto beim Ladeende nur noch 2-phasig lädt, wurde bei der nächsten PV-Ladung die letzte Phases-in-use genommen , um die benötigte Phasenzahl zu ermitteln.

https://forum.openwb.de/viewtopic.php?p=132825#p132825