### PR TITLE
Fix: Skoda SoC fehlende Restreichweite

### DIFF
--- a/packages/modules/vehicles/skoda/libskoda.py
+++ b/packages/modules/vehicles/skoda/libskoda.py
@@ -244,7 +244,7 @@ class skoda:
                 'batteryStatus': {
                     'value': {
                         'currentSOC_pct': status_data['primaryEngineRange']['currentSoCInPercent'],
-                        'cruisingRangeElectric_km': status_data['primaryEngineRange']['remainingRangeInKm'],
+                        'cruisingRangeElectric_km': status_data['primaryEngineRange'].get('remainingRangeInKm', 0.0),
                         'carCapturedTimestamp': status_data['carCapturedTimestamp'].split('.')[0] + 'Z',
                     }
                 }

--- a/packages/modules/vehicles/skoda/libskoda.py
+++ b/packages/modules/vehicles/skoda/libskoda.py
@@ -214,7 +214,7 @@ class skoda:
         return True
 
     async def get_status(self):
-        status_url = f"{API_BASE}/v2/vehicle-status/{self.vin}/driving-range"
+        status_url = f"{API_BASE}/v1/charging/{self.vin}"
         response = await self.session.get(status_url, headers=self.headers)
 
         # If first attempt fails, try to refresh tokens
@@ -243,9 +243,9 @@ class skoda:
             'charging': {
                 'batteryStatus': {
                     'value': {
-                        'currentSOC_pct': status_data['primaryEngineRange']['currentSoCInPercent'],
-                        'cruisingRangeElectric_km': status_data['primaryEngineRange'].get('remainingRangeInKm', 0.0),
-                        'carCapturedTimestamp': status_data['carCapturedTimestamp'].split('.')[0] + 'Z',
+                        'currentSOC_pct': status_data['status']['battery']['stateOfChargeInPercent'],
+                        'cruisingRangeElectric_km': status_data['status']['battery'].get('remainingCruisingRangeInMeters', 1000) / 1000,
+                        'carCapturedTimestamp': status_data['carCapturedTimestamp'],
                     }
                 }
             }


### PR DESCRIPTION
siehe Forum https://forum.openwb.de/viewtopic.php?p=133323#p133323

Skoda bietet zwei Endpunkte, um die aktuellen SoC Werte abzurufen.
Die Änderung benutzt nun api/v1/charging/{vin}.
Außerdem wird das Fehlen der Restreichweitenangabe toleriert.