### PR TITLE
Revert "improve syntax"

### DIFF
--- a/packages/helpermodules/command.py
+++ b/packages/helpermodules/command.py
@@ -822,9 +822,9 @@ class Command:
         if not SubData.general_data.data.extern and SubData.system_data["system"].data["secondary_auto_update"]:
             for cp in SubData.cp_data.values():
                 # if chargepoint is external_openwb and not the second CP of duo and version is Release
-                if all(
-                    cp.chargepoint.chargepoint_module.config.type == 'external_openwb',
-                    cp.chargepoint.chargepoint_module.config.configuration.duo_num == 0,
+                if (
+                    cp.chargepoint.chargepoint_module.config.type == 'external_openwb' and
+                    cp.chargepoint.chargepoint_module.config.configuration.duo_num == 0 and
                     cp.chargepoint.data.get.current_branch == "Release"
                 ):
                     time.sleep(2)


### PR DESCRIPTION
This reverts commit 51ea8eeba1af1e9db37e0699ac502d1d87e4328b.

Mit diesem Commit bekomme ich in meiner Testumgebung folgende Meldung beim Starten einer Systemaktualisierung
```
2025-09-27 17:13:48,481 - {helpermodules.messaging:60} - {ERROR:Commands} - ERROR:helpermodules.messaging:Messaging: Fehlermeldung: {'source': 'command', 'type': 'danger', 'message': "Es ist ein interner Fehler aufgetreten: 'MqttConfiguration' object has no attribute 'duo_num'", 'timestamp': 1758986028}
2025-09-27 17:13:48,487 - {helpermodules.command:956} - {ERROR:Commands} - ERROR:helpermodules.command:{'Traceback (most recent call last):\n  File "/var/www/html/openWB/packages/helpermodules/command.py", line 156, in on_message\n    func(connection_id, payload)\n  File "/var/www/html/openWB/packages/helpermodules/command.py", line 827, in systemUpdate\n    cp.chargepoint.chargepoint_module.config.configuration.duo_num == 0,\nAttributeError: \'MqttConfiguration\' object has no attribute \'duo_num\'\n'}
```

Die all()-Funktion hat den Seiteneffekt, dass immer alle übergebenen Elemente geprüft werden. Die vorherige Implementierung hat die Prüfung aber sofort beendet, wenn `external_openwb` nicht gegeben war.
Das alte Verhalten ist doch gewünscht.