### PR TITLE
Fix precise current calculation satellit + Abschaltung bei Ziel SOC erreicht.

### DIFF
--- a/packages/control/ev/charge_template.py
+++ b/packages/control/ev/charge_template.py
@@ -237,7 +237,7 @@ class ChargeTemplate:
             phases = pv_charging.phases_to_use
             min_pv_current = (pv_charging.min_current if charging_type == ChargingType.AC.value
                               else pv_charging.dc_min_current)
-            if pv_charging.limit.selected == "soc" and soc and soc > pv_charging.limit.soc:
+            if pv_charging.limit.selected == "soc" and soc and soc >= pv_charging.limit.soc:
                 current = 0
                 sub_mode = "stop"
                 message = self.SOC_REACHED

--- a/packages/modules/chargepoints/openwb_series2_satellit/chargepoint_module.py
+++ b/packages/modules/chargepoints/openwb_series2_satellit/chargepoint_module.py
@@ -120,7 +120,9 @@ class ChargepointModule(AbstractChargepoint):
                         self.delay_second_cp(self.CP1_DELAY)
                         with self._client.client:
                             if self.version:
-                                self._client.evse_client.set_current(int(current))
+                                formatted_current = round(current*100) if self._client.evse_client._precise_current else round(current)
+                                self._client.evse_client.set_current(formatted_current)
+                                log.debug("Current Set to EVSE(Satelite): %s", formatted_current)
                             else:
                                 self._client.evse_client.set_current(0)
                     except AttributeError:


### PR DESCRIPTION
2 Änderungen in diesem Pullrequest

1. Bei nutzung der EVSE precise current. was in dem neuen Release 2.1.8 P1 automatisch passiert wird für die Satellit die Umrechnung im Faktor 100 nicht durchgeführt.
Referenz aus dem Forum: https://forum.openwb.de/viewtopic.php?p=133793#p133793

2. Wallbox schaltet nicht ab wenn Ziel SOC erreicht. 
Box schaltet erst ab wenn SOC > Ziel SOC ist. Wenn das Fahrzeug bei erreichen des Ziel SOC selber abschaltet bleibt die Wallbox an.
Referenz aus dem Forum: https://forum.openwb.de/viewtopic.php?p=133802#p133802





