### PR TITLE
Add icon to Lademodus in standard_legacy theme

### DIFF
--- a/packages/modules/web_themes/standard_legacy/web/index.html
+++ b/packages/modules/web_themes/standard_legacy/web/index.html
@@ -501,7 +501,7 @@
 							<div class="form-row mb-1">
 								<div class="col">
 									<label class="col-form-label">
-										<i class="fas fa-charging-station"></i>
+										<i class="fas fa-hexagon-nodes-bolt"></i>
 										Lademodus
 									</label>
 								</div>


### PR DESCRIPTION
Just a small addition of an icon next to the "Lademodus" label in the standard_legacy theme to have a similar layout.
<img width="1283" height="538" alt="icon-next-to-lademodus" src="https://github.com/user-attachments/assets/ad9d15e4-45fe-45dc-81d3-8b23b67ac3ec" />

Sadly I found not better icon than the `fa-charging-station` like an icon showing some kind of mode selection.