### PR TITLE
fix phase switch for pv and eco charging

### DIFF
--- a/packages/control/algorithm/algorithm.py
+++ b/packages/control/algorithm/algorithm.py
@@ -60,7 +60,7 @@ class Algorithm:
                 if cp.data.set.charging_ev != -1:
                     charging_ev = cp.data.set.charging_ev_data
                     control_parameter = cp.data.control_parameter
-                    if cp.cp_ev_chargemode_support_phase_switch():
+                    if cp.cp_state_hw_support_phase_switch() and control_parameter.template_phases == 0:
                         # Gibt die Stromstärke und Phasen zurück, mit denen nach der Umschaltung geladen werden
                         # soll. Falls keine Umschaltung erforderlich ist, werden Strom und Phasen, die übergeben
                         # wurden, wieder zurückgegeben.

--- a/packages/control/algorithm/integration_test/pv_charging_test.py
+++ b/packages/control/algorithm/integration_test/pv_charging_test.py
@@ -223,9 +223,9 @@ def test_surplus(params: ParamsSurplus, all_cp_pv_charging_3p, all_cp_charging_3
     data.data.counter_data["counter6"].data.set.raw_currents_left = params.raw_currents_left_counter6
     mock_get_component_name_by_id = Mock(return_value="Garage")
     monkeypatch.setattr(loadmanagement, "get_component_name_by_id", mock_get_component_name_by_id)
-    data.data.cp_data["cp3"].data.set.charge_template.data.chargemode.pv_charging.phases_to_use = 1
-    data.data.cp_data["cp4"].data.set.charge_template.data.chargemode.pv_charging.phases_to_use = 1
-    data.data.cp_data["cp5"].data.set.charge_template.data.chargemode.pv_charging.phases_to_use = 1
+    for i in range(3, 6):
+        data.data.cp_data[f"cp{i}"].data.set.charge_template.data.chargemode.pv_charging.phases_to_use = 1
+        data.data.cp_data[f"cp{i}"].data.control_parameter.template_phases = 1
 
     # execution
     Algorithm().calc_current()
@@ -276,6 +276,8 @@ def test_phase_switch(all_cp_pv_charging_3p, all_cp_charging_3p, monkeypatch):
         "cp3"].data.control_parameter.state = ChargepointState.CHARGING_ALLOWED
     data.data.cp_data[
         "cp3"].data.control_parameter.timestamp_last_phase_switch = 1652682252
+    for i in range(3, 6):
+        data.data.cp_data[f"cp{i}"].data.control_parameter.template_phases = 0
 
     # execution
     Algorithm().calc_current()
@@ -298,6 +300,8 @@ def test_phase_switch_1p_3p(all_cp_pv_charging_1p, monkeypatch):
     data.data.cp_data["cp3"].data.control_parameter.timestamp_last_phase_switch = 1652682252
     data.data.cp_data["cp4"].data.get.currents = [0, 0, 0]
     data.data.cp_data["cp5"].data.get.currents = [0, 0, 0]
+    for i in range(3, 6):
+        data.data.cp_data[f"cp{i}"].data.control_parameter.template_phases = 0
 
     # execution
     Algorithm().calc_current()

--- a/packages/control/algorithm/surplus_controlled.py
+++ b/packages/control/algorithm/surplus_controlled.py
@@ -127,10 +127,12 @@ class SurplusControlled:
         for cp in get_chargepoints_by_chargemodes(CONSIDERED_CHARGE_MODES_PV_ONLY):
             try:
                 def phase_switch_necessary() -> bool:
-                    return cp.cp_ev_chargemode_support_phase_switch() and cp.data.get.phases_in_use != 1
+                    return (cp.cp_state_hw_support_phase_switch() and
+                            cp.data.get.phases_in_use != 1 and
+                            cp.data.control_parameter.template_phases == 0)
                 control_parameter = cp.data.control_parameter
                 if cp.chargemode_changed or cp.submode_changed:
-                    if control_parameter.state == ChargepointState.CHARGING_ALLOWED:
+                    if (control_parameter.state in CHARGING_STATES):
                         if cp.data.set.charging_ev_data.ev_template.data.prevent_charge_stop is False:
                             threshold = evu_counter.calc_switch_off_threshold(cp)[0]
                             if evu_counter.calc_raw_surplus() - cp.data.set.required_power < threshold:

--- a/packages/control/chargepoint/control_parameter.py
+++ b/packages/control/chargepoint/control_parameter.py
@@ -23,6 +23,7 @@ class ControlParameter:
     state: ChargepointState = field(default=ChargepointState.NO_CHARGING_ALLOWED,
                                     metadata={"topic": "control_parameter/state"})
     submode: Chargemode_enum = field(default=Chargemode_enum.STOP, metadata={"topic": "control_parameter/submode"})
+    template_phases: int = field(default=None, metadata={"topic": "control_parameter/template_phases"})
     timestamp_charge_start: Optional[float] = field(
         default=None, metadata={"topic": "control_parameter/timestamp_charge_start"})
     timestamp_chargemode_changed: Optional[float] = field(

--- a/packages/control/chargepoint/get_phases_test.py
+++ b/packages/control/chargepoint/get_phases_test.py
@@ -160,7 +160,7 @@ cases_set_phases = [
 def test_set_phases(monkeypatch, cp: Chargepoint, params: SetPhasesParams):
     # setup
     mock_phase_switch_supported = Mock(name="phase_switch_supported", return_value=params.phase_switch_supported)
-    monkeypatch.setattr(Chargepoint, "cp_ev_support_phase_switch", mock_phase_switch_supported)
+    monkeypatch.setattr(Chargepoint, "hw_supports_phase_switch", mock_phase_switch_supported)
     cp.data.get.phases_in_use = params.phases_in_use
     cp.data.set.log.imported_since_plugged = params.imported_since_plugged
     charging_ev_data = cp.data.set.charging_ev_data
@@ -168,7 +168,7 @@ def test_set_phases(monkeypatch, cp: Chargepoint, params: SetPhasesParams):
     cp.data.control_parameter.phases = params.phases_in_use
 
     # execution
-    phases = cp.set_phases(params.phases)
+    phases = cp.set_phases(params.phases, 3)
 
     # evaluation
     assert phases == params.expected_phases

--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -349,7 +349,7 @@ class Counter:
                 max_phases_power = ev_template.data.min_current * ev_template.data.max_phases * 230
                 if (control_parameter.submode == Chargemode.PV_CHARGING and
                     chargepoint.data.set.charge_template.data.chargemode.pv_charging.phases_to_use == 0 and
-                        chargepoint.cp_ev_support_phase_switch() and
+                        chargepoint.hw_supports_phase_switch() and
                         self.get_usable_surplus(feed_in_yield) > max_phases_power):
                     control_parameter.phases = ev_template.data.max_phases
                     msg += self.SWITCH_ON_MAX_PHASES.format(ev_template.data.max_phases)

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -485,7 +485,8 @@ class SetData:
                         self._validate_value(msg, float, [(0, 0), (6, 32), (0, 450)])
                     else:
                         self._validate_value(msg, float, [(6, 32), (0, 0)])
-                elif "/control_parameter/phases" in msg.topic:
+                elif ("/control_parameter/phases" in msg.topic or
+                      "/control_parameter/template_phases" in msg.topic):
                     self._validate_value(msg, int, [(0, 3)])
                 elif "/control_parameter/failed_phase_switches" in msg.topic:
                     self._validate_value(msg, int, [(0, 4)])

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -106,6 +106,7 @@ class UpdateConfig:
         "^openWB/chargepoint/[0-9]+/control_parameter/required_currents$",
         "^openWB/chargepoint/[0-9]+/control_parameter/state$",
         "^openWB/chargepoint/[0-9]+/control_parameter/submode$",
+        "^openWB/chargepoint/[0-9]+/control_parameter/template_phases$",
         "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_charge_start$",
         "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_chargemode_changed$",
         "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_last_phase_switch$",


### PR DESCRIPTION
Eco-Laden: 

- [x] unter Strompreisgrenze + Automatik: 3 Phasen 
- [x] unter -> über Strompreisgrenze + Automatik + Überschuss für 3p: 3p
- [x] unter -> über Strompreisgrenze + Automatik + Überschuss für 1 Phase: abschalten (bisheriges Verhalten)
- [x] unter -> über Strompreisgrenze + Automatik + kein Überschuss: sofort abschalten
- [x] unter Strompreisgrenze + 3 Phasen: 3 Phasen
- [x] über Strompreisgrenze + 3 Phasen + wenig Überschuss: startet erst bei Überschuss für 3 Phasen

PV-Laden:

- [x] Automatik + Min Strom + viel Überschuss: 1p -> 3p 
- [x] Automatik + Min Strom + wenig Überschuss: 1p 
- [x] Automatik + viel Überschuss: 3p 
- [x] Automatik + wenig Überschuss: 3p->1p 
- [x] Automatik + kein Überschuss: abschalten
- [x] 3 Phasen + wenig Überschuss: keine Ladung
- [x] 3 Phasen für Min-SoC + unter Min-SoC + wenig Überschuss + Automatik: 3p