### PR TITLE
temp charge templates as option

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -36,7 +36,6 @@ from control.ev.ev import Ev
 from control import phase_switch
 from control.chargepoint.chargepoint_state import CHARGING_STATES, ChargepointState
 from control.text import BidiState
-from helpermodules.broker import BrokerClient
 from helpermodules.phase_mapping import convert_single_evu_phase_to_cp_phase
 from helpermodules.pub import Pub
 from helpermodules import timecheck
@@ -844,7 +843,7 @@ class Chargepoint(ChargepointRfidMixin):
         return charging_ev
 
     def update_charge_template(self, charge_template: ChargeTemplate) -> None:
-        if data.data.general_data.data.temporary_charge_templates:
+        if data.data.general_data.data.temporary_charge_templates_active:
             # Prüfen, ob ein temporäres Ladeprofil aktiv ist und dieses übernehmen
             Pub().pub(f"openWB/set/chargepoint/{self.num}/set/charge_template",
                       dataclasses.asdict(charge_template.data))

--- a/packages/control/general.py
+++ b/packages/control/general.py
@@ -100,7 +100,7 @@ class GeneralData:
     http_api: bool = field(
         default=False, metadata={"topic": "http_api"})
     mqtt_bridge: bool = False
-    temporary_charge_templates: bool = False
+    temporary_charge_templates_active: bool = False
     prices: Prices = field(default_factory=prices_factory)
     range_unit: str = "km"
 

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -10,6 +10,7 @@ import re
 import paho.mqtt.client as mqtt
 
 import logging
+from control import data
 from helpermodules import hardware_configuration, subdata
 from helpermodules.broker import BrokerClient
 from helpermodules.pub import Pub, pub_single
@@ -407,6 +408,26 @@ class SetData:
         try:
             if "charge_template" in msg.topic:
                 self._validate_value(msg, "json")
+                if data.data.general_data.data.temporary_charge_templates_active is False:
+                    if "openWB/set/chargepoint/" in msg.topic and "/set/charge_template" in msg.topic:
+                        payload = decode_payload(msg.payload)
+                        Pub().pub(f"openWB/vehicle/template/charge_template/{payload['id']}", payload)
+                    else:
+                        get_index(msg.topic)
+
+                        for vehicle in data.data.ev_data.values():
+                            if vehicle.data.charge_template == int(get_index(msg.topic)):
+                                for cp in data.data.cp_data.values():
+                                    if ((cp.data.set.charging_ev != -1 and
+                                            cp.data.set.charging_ev == vehicle.num) or
+                                            cp.data.config.ev == vehicle.num):
+                                        if decode_payload(msg.payload) == "":
+                                            Pub().pub(
+                                                f"openWB/chargepoint/{cp.num}/set/charge_template", "")
+                                        else:
+                                            Pub().pub(
+                                                f"openWB/chargepoint/{cp.num}/set/charge_template",
+                                                decode_payload(msg.payload))
             else:
                 self.__unknown_topic(msg)
         except Exception:
@@ -551,7 +572,7 @@ class SetData:
         elif ("/get/evse_current" in msg.topic or
               "/get/max_evse_current" in msg.topic):
             # AC-EVSE: 0, 6-32, 600-3200, DC-EVSE 0-500
-            self._validate_value(msg, float, [(0, 3200)])
+            self._validate_value(msg, float, [(-3200, 3200)])
         elif ("/get/version" in msg.topic or
               "/get/current_branch" in msg.topic or
               "/get/current_commit" in msg.topic):
@@ -610,7 +631,8 @@ class SetData:
                         "/get/yearly_exported" in msg.topic or
                         "/get/energy" in msg.topic):
                     self._validate_value(msg, float, [(0, float("inf"))])
-                elif "/get/exported" in msg.topic:
+                elif ("/get/exported" in msg.topic or
+                      "/get/imported" in msg.topic):
                     self._validate_value(msg, float, [(0, float("inf"))])
                 elif "/get/power" in msg.topic:
                     self._validate_value(msg, float)
@@ -754,6 +776,8 @@ class SetData:
                 self._validate_value(msg, float, [(0, 99.99)])
             elif "openWB/set/general/range_unit" in msg.topic:
                 self._validate_value(msg, str)
+            elif "openWB/set/general/temporary_charge_templates_active" in msg.topic:
+                self._validate_value(msg, bool)
             elif "openWB/set/general/web_theme" in msg.topic:
                 self._validate_value(msg, "json")
             elif ("openWB/set/general/charge_log_data_config" in msg.topic):

--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 import paho.mqtt.client as mqtt
 
-from control import bat_all, bat, counter, counter_all, data, general, io_device, optional, pv, pv_all
+from control import bat_all, bat, counter, counter_all, general, io_device, optional, pv, pv_all
 from control.chargepoint import chargepoint
 from control.chargepoint.chargepoint_all import AllChargepoints
 from control.chargepoint.chargepoint_data import Log
@@ -338,17 +338,7 @@ class SubData:
                 if "ct"+index not in var:
                     var["ct"+index] = ChargeTemplate()
                 var["ct"+index].data = dataclass_from_dict(ChargeTemplateData, decode_payload(msg.payload))
-                for vehicle in self.ev_data.values():
-                    if vehicle.data.charge_template == int(index):
-                        for cp in self.cp_data.values():
-                            if ((cp.chargepoint.data.set.charging_ev != -1 and
-                                    cp.chargepoint.data.set.charging_ev == vehicle.num) or
-                                    cp.chargepoint.data.config.ev == vehicle.num):
-                                if decode_payload(msg.payload) == "":
-                                    Pub().pub(f"openWB/chargepoint/{cp.chargepoint.num}/set/charge_template", "")
-                                elif self.general_data.data.temporary_charge_templates:
-                                    Pub().pub(
-                                        f"openWB/chargepoint/{cp.chargepoint.num}/set/charge_template", decode_payload(msg.payload))
+
         except Exception:
             log.exception("Fehler im subdata-Modul")
 
@@ -411,9 +401,6 @@ class SubData:
                             var["cp"+index].chargepoint.data.set.log = dataclass_from_dict(
                                 Log, decode_payload(msg.payload))
                         elif "charge_template" in msg.topic:
-                            if self.general_data.data.temporary_charge_templates:
-                                payload = decode_payload(msg.payload)
-                                Pub().pub(f'openWB/vehicle/template/{payload["id"]}/charge_template', payload)
                             var["cp"+index].chargepoint.data.set.charge_template = ChargeTemplate()
                             var["cp"+index].chargepoint.data.set.charge_template.data = dataclass_from_dict(
                                 ChargeTemplateData, decode_payload(msg.payload))

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -57,7 +57,7 @@ NO_MODULE = {"type": None, "configuration": {}}
 
 class UpdateConfig:
 
-    DATASTORE_VERSION = 96
+    DATASTORE_VERSION = 97
 
     valid_topic = [
         "^openWB/bat/config/bat_control_permitted$",
@@ -215,6 +215,7 @@ class UpdateConfig:
         "^openWB/general/grid_protection_timestamp$",
         "^openWB/general/grid_protection_random_stop$",
         "^openWB/general/range_unit$",
+        "^openWB/general/temporary_charge_templates_active$",
         "^openWB/general/notifications/selected$",
         "^openWB/general/notifications/configuration$",
         "^openWB/general/notifications/start_charging$",
@@ -565,6 +566,7 @@ class UpdateConfig:
         ("openWB/general/prices/grid", Prices().grid),
         ("openWB/general/prices/pv", Prices().pv),
         ("openWB/general/range_unit", "km"),
+        ("openWB/general/temporary_charge_templates_active", False),
         ("openWB/general/web_theme", dataclass_utils.asdict(StandardLegacyWebTheme())),
         ("openWB/graph/config/duration", 120),
         ("openWB/internal_chargepoint/0/data/parent_cp", None),
@@ -2350,9 +2352,6 @@ class UpdateConfig:
         self.__update_topic("openWB/system/datastore_version", 88)
 
     def upgrade_datastore_88(self) -> None:
-        pub_system_message({}, "Änderungen, die du auf der Hauptseite vornimmst, gelten nur vorübergehend, bis das "
-                           "Fahrzeug abgesteckt wird. \nDie dauerhaften Einstellungen aus dem Einstellungsmenü werden "
-                           "danach automatisch wieder aktiviert.", MessageType.INFO)
         pub_system_message({}, "Es gibt ein neues Theme: das Koala-Theme! Smarthpone-optimiert und mit "
                            "Energiefluss-Diagramm & Karten-Ansicht der Ladepunkte", MessageType.INFO)
         self.__update_topic("openWB/system/datastore_version", 89)
@@ -2560,3 +2559,16 @@ class UpdateConfig:
                     return {topic: payload}
         self._loop_all_received_topics(upgrade)
         self.__update_topic("openWB/system/datastore_version", 96)
+
+    def upgrade_datastore_96(self) -> None:
+        version = decode_payload(self.all_received_topics.get("openWB/system/version", "2.1.9")).split("-")[0]
+        major, minor, feature = (int(x) for x in version.split("."))
+        if (2, 1, 7) <= (major, minor, feature) <= (2, 1, 8):
+            self.__update_topic("openWB/general/temporary_charge_templates_active", True)
+            pub_system_message(
+                {},
+                "Die temporären Ladeeinstellungen können ab jetzt benutzerdefiniert unter Einstellungen -> Allgemein"
+                " -> Darstellung & Bedienung angewendet werden.",
+                MessageType.INFO,
+            )
+        self.__update_topic("openWB/system/datastore_version", 97)


### PR DESCRIPTION
Die temporären Ladeeinstellungen können ab jetzt benutzerdefiniert unter Einstellungen -> Allgemein -> Darstellung & Bedienung angewendet werden.

keine temporären Profile:

- [x] Änderung in den Einstellungsseiten wird sofort übernommen und auf der Hauptseite angezeigt. 
- [x] Änderung aus den Einstellungsseiten wird auch beim Abstecken und nächsten Anstecken beibehalten
- [x] Änderung auf der Hauptseite wird sofort übernommen und in den Einstellungsseiten angezeigt. 

temporären Profile:

- [x] Änderung in den Einstellungsseiten wird erst beim Abstecken übernommen
- [x] Änderung auf der Hauptseite wird nicht in den Einstellungsseiten angezeigt.
- [x] 2.1.6->2.1.9-Alpha.2: keine Meldung, Einstellung auf false 
- [x] 2.1.7->2.1.9-Alpha.2: Meldung dass nun einstellbar, Einstellung auf true 
- [x] 2.1.8->2.1.9-Alpha.2: Meldung dass nun einstellbar, Einstellung auf true 
- [x] Neuinstallation 2.1.9-Alpha.2: keine Meldung, Einstellung auf false 