### PR TITLE
pv start with 3 phases: fix power calculation

### DIFF
--- a/packages/control/counter.py
+++ b/packages/control/counter.py
@@ -253,7 +253,7 @@ class Counter:
 
     def get_usable_surplus(self, feed_in_yield: float) -> float:
         # verbleibender EVU-Überschuss unter Berücksichtigung der Einspeisegrenze und Speicherleistung
-        return (-self.calc_surplus() - self.data.set.released_surplus +
+        return (-self.calc_surplus() + self.data.set.released_surplus -
                 self.data.set.reserved_surplus - feed_in_yield)
 
     SWITCH_ON_FALLEN_BELOW = "Einschaltschwelle während der Wartezeit unterschritten."


### PR DESCRIPTION
Wenn bei zwei Autos gleichzeitig die Einschaltverzögerung läuft, muss die reservierte Leistung korrekt beim Berechnen, ob ein 3phasiger Start möglich ist, berücksichtigt werden.
#66859768