### PR TITLE
Revert ValueError for NaN values SMA

### DIFF
--- a/packages/modules/devices/sma/sma_sunny_boy/inverter.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/inverter.py
@@ -91,7 +91,7 @@ class SmaSunnyBoyInverter(AbstractInverter):
             raise ValueError("Unbekannte Version "+str(self.component_config.configuration.version))
         if power_total == self.SMA_INT32_NAN or power_total == self.SMA_NAN:
             power_total = 0
-            # Bei keiner AC Wirkleistung müssen auch die Ströme der Phasen 0 sein.
+            # WR geht nachts in Standby und gibt einen NaN-Wert für die Leistung aus.
             currents = [0, 0, 0]
         if energy == self.SMA_UINT32_NAN:
             raise ValueError(


### PR DESCRIPTION
Revert https://github.com/openWB/core/pull/2844

https://forum.openwb.de/viewtopic.php?p=135192#p135192

https://www.photovoltaikforum.com/thread/253547-hilfe-bei-sma-wechselrichter-modbus-register-30775/

SMA Wechselrichter (Tripower, Sunny Boy mindestens) geben Nachts immer NaN Werte aus, das führt doch jetzt zu vermehrt Support Anfragen weil Leute hier auf einen Fehler hingewiesen werden, der aber keiner ist. Die ursprüngliche Codezeile hat hier einfach power_total nachts auf 0 gesetzt und damit ist auch keine Fehlermeldung für unplausible Werte nötig.