### PR TITLE
Koala - Filter energy tariff data (hourly)

### DIFF
--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -3389,9 +3389,9 @@ const prices = getValue.value('openWB/optional/et/get/prices', undefined, {}) as
 };
 // filter prices to only include those with timestamps that are multiples of 3600 (hourly)
 const filtered: { [key: string]: number } = {};
-Object.entries(prices).forEach(([timestamp, value]) => {
+Object.entries(prices).forEach(([timestamp, price]) => {
 if (parseInt(timestamp) % 3600 === 0) {
-filtered[timestamp] = value;
+filtered[timestamp] = price;
 }
 });
 return filtered;


### PR DESCRIPTION
Der Variable Stromtarife-Anbieter Tibber liefert nun offenbar alle 15 Minuten Tarifinformationen. Dadurch entstehen zu viele Datenpunkte im Energietarif-Diagramm. Um zu verhindern, dass zu viele Daten angezeigt werden, wurden die an das Diagramm übergebenen Tarifdaten auf stündliche Werte gefiltert.
<img width="395" height="705" alt="Bildschirmfoto 2025-11-05 um 19 05 22" src="https://github.com/user-attachments/assets/c54d00bf-4215-4be7-a186-bea4aa2a4683" />
