### PR TITLE
Koala - fix history chart legend button

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ChartCarousel.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChartCarousel.vue
@@ -26,8 +26,9 @@
         <q-btn
           v-if="currentSlide === 'history_chart'"
           size="sm"
+          push
           class="q-mr-sm legend-button-text"
-          label="Legend ein/aus"
+          label="Legende"
           @click="toggleLegend"
         />
       </q-carousel-control>


### PR DESCRIPTION
Gib der Legende-Ein/Aus-Schaltfläche die gleichen visuellen Eigenschaften wie der Vollbild-Schaltfläche auf der anderen Seite des Slide-Containers.

<img width="323" height="698" alt="Bildschirmfoto 2025-11-06 um 17 28 47" src="https://github.com/user-attachments/assets/b8ac0bfc-260a-4066-a366-aa744085b647" />
