### PR TITLE
HTTP simpleAPI erweitert

### DIFF
--- a/simpleAPI/simpleapi.php
+++ b/simpleAPI/simpleapi.php
@@ -218,6 +218,7 @@ class SimpleAPI
             'get_chargepoint_charge_template_name',
             'get_chargepoint_charge_template_min_current',
             'get_chargepoint_instant_charging_current',
+            'get_chargepoint_pv_charging_min_current',
             'get_chargepoint_soc',
             'get_chargepoint_state_str',
             'get_chargepoint_fault_str',

--- a/simpleAPI/src/ParameterHandler.php
+++ b/simpleAPI/src/ParameterHandler.php
@@ -99,6 +99,8 @@ class ParameterHandler
                 return $this->getChargepointChargeTemplateMinCurrent($id);
             case 'get_chargepoint_instant_charging_current':
                 return $this->getChargepointInstantChargingCurrent($id);
+            case 'get_chargepoint_pv_charging_min_current':
+                return $this->getChargepointPvChargingMinCurrent($id);
             case 'get_chargepoint_soc':
                 return $this->getChargepointSoc($id);
             case 'get_chargepoint_state_str':
@@ -1070,6 +1072,27 @@ class ParameterHandler
             return ["chargepoint_{$id}" => ['instant_charging_current' => floatval($instantCurrent)]];
         } catch (Exception $e) {
             return ["chargepoint_{$id}" => ['instant_charging_current' => 0]];
+        }
+    }
+
+    /**
+     * Chargepoint PV Charging Min Current
+     */
+    private function getChargepointPvChargingMinCurrent($id)
+    {
+        try {
+            $topic = "openWB/chargepoint/{$id}/set/charge_template";
+            $value = $this->mqttClient->getValue($topic);
+            $template = json_decode($value ?? '{}', true) ?: [];
+            
+            $pvMinCurrent = 0;
+            if (isset($template['chargemode']['pv_charging']['min_current'])) {
+                $pvMinCurrent = $template['chargemode']['pv_charging']['min_current'];
+            }
+            
+            return ["chargepoint_{$id}" => ['pv_charging_min_current' => floatval($pvMinCurrent)]];
+        } catch (Exception $e) {
+            return ["chargepoint_{$id}" => ['pv_charging_min_current' => 0]];
         }
     }
 


### PR DESCRIPTION
Dieses Pull Request erweitert die SimpleAPI um zusätzliche lesbare Parameter für Ladepunkte (Chargepoints). Die neuen Parameter ermöglichen den Zugriff auf wichtige Messwerte, Konfigurationsdaten und Statusinformationen über die HTTP-API.

## Neue Features

### 1. Zusätzliche Messwerte

#### Energie und Leistung
- **`get_chargepoint_daily_imported`** - Täglicher Energieimport (kWh)
- **`get_chargepoint_daily_exported`** - Täglicher Energieexport (kWh)
- **`get_chargepoint_frequency`** - Netzfrequenz (Hz)
- **`get_chargepoint_evse_current`** - EVSE-Strom (A)

#### RFID-Daten
- **`get_chargepoint_rfid`** - Aktuelle RFID-Tag ID als String
- **`get_chargepoint_rfid_timestamp`** - Zeitstempel der letzten RFID-Aktivität

### 2. Leistungsfaktoren (Power Factors)

#### Komplexer Parameter (Array-Ausgabe)
- **`get_chargepoint_power_factors`** - Alle drei Phasen als Array `[p1, p2, p3]`

#### Einzelphasen-Parameter
- **`get_chargepoint_power_factor_p1`** - Leistungsfaktor Phase 1
- **`get_chargepoint_power_factor_p2`** - Leistungsfaktor Phase 2  
- **`get_chargepoint_power_factor_p3`** - Leistungsfaktor Phase 3

### 3. Konfigurationsdaten

- **`get_chargepoint_config_name`** - Name des Ladepunkts aus der Konfiguration
- **`get_chargepoint_connected_vehicle_name`** - Name des aktuell verbundenen Fahrzeugs
- **`get_chargepoint_charge_template_name`** - Name des aktiven Lade-Profils
- **`get_chargepoint_charge_template_min_current`** - Minimaler Strom aus PV-Charging Konfiguration


## MQTT Topic Mapping

| API Parameter | MQTT Topic | Datentyp | Beschreibung |
|---------------|------------|----------|--------------|
| `get_chargepoint_daily_imported` | `openWB/chargepoint/{id}/get/daily_imported` | Float | Täglicher Import in kWh |
| `get_chargepoint_daily_exported` | `openWB/chargepoint/{id}/get/daily_exported` | Float | Täglicher Export in kWh |
| `get_chargepoint_frequency` | `openWB/chargepoint/{id}/get/frequency` | Float | Netzfrequenz in Hz |
| `get_chargepoint_rfid` | `openWB/chargepoint/{id}/get/rfid` | String | RFID-Tag ID |
| `get_chargepoint_rfid_timestamp` | `openWB/chargepoint/{id}/get/rfid_timestamp` | Integer | Unix-Timestamp |
| `get_chargepoint_evse_current` | `openWB/chargepoint/{id}/get/evse_current` | Float | EVSE-Strom in A |
| `get_chargepoint_power_factors` | `openWB/chargepoint/{id}/get/power_factors` | JSON Array | `[p1, p2, p3]` |
| `get_chargepoint_config_name` | `openWB/chargepoint/{id}/config` | String | `config.name` |
| `get_chargepoint_connected_vehicle_name` | `openWB/chargepoint/{id}/get/connected_vehicle/info` | String | `info.name` |
| `get_chargepoint_charge_template_name` | `openWB/chargepoint/{id}/set/charge_template` | String | `template.name` |
| `get_chargepoint_charge_template_min_current` | `openWB/chargepoint/{id}/set/charge_template` | Float | `template.chargemode.pv_charging.min_current` |