### PR TITLE
Update smb backup

### DIFF
--- a/packages/modules/backup_clouds/samba/backup_cloud.py
+++ b/packages/modules/backup_clouds/samba/backup_cloud.py
@@ -34,9 +34,7 @@ def upload_backup(config: SambaBackupCloudConfiguration, backup_filename: str, b
 
     # Pfad prüfen
     if re.search(r'[\\\:\*\?\"\<\>\|]+', config.smb_path):
-        log.warning("Ungültige Zeichen im Pfad.")
-        log.warning("Sicherung nicht erfolgreich.")
-        return
+        raise Exception("Ungültige Zeichen im Pfad. Sicherung nicht erfolgreich.")
 
     # ------------------------------------------------------------
     # 1) SMB2/3 über Port 445 testen


### PR DESCRIPTION
Update Samba upload to modern SMB2/SMB3 connection

* Switch SMB connection from outdated NetBIOS/SMB1 (port 139) to direct TCP (port 445)
* Enable `is_direct_tcp=True` in SMBConnection for proper SMB2/3 support
* Remove dependency on NetBIOS session setup
* Improve security and compatibility with modern Samba/Windows servers
* Allow raising `min protocol` in smb.conf to SMB2 or SMB3
* Refactor port handling and logging accordingly

This update modernizes the backup upload mechanism and removes reliance on deprecated SMB1.
