### PR TITLE
pytest enhancement for soc_modules: show error details

### DIFF
--- a/packages/conftest.py
+++ b/packages/conftest.py
@@ -25,6 +25,13 @@ from modules.common.store._api import LoggingValueStore
 def pytest_configure(config):
     config.addinivalue_line("markers", "no_mock_full_hour: mark test to disable full_hour mocking.")
     config.addinivalue_line("markers", "no_mock_quarter_hour: mark test to disable quarter_hour mocking.")
+    import sys
+    sys._called_from_test = True
+
+
+def pytest_unconfigure(config):
+    import sys
+    del sys._called_from_test
 
 
 @pytest.fixture(autouse=True)

--- a/packages/modules/configuration.py
+++ b/packages/modules/configuration.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import dataclass_utils
 from helpermodules.pub import Pub
 from modules.io_actions.groups import READABLE_GROUP_NAME, ActionGroup
+import sys
 log = logging.getLogger(__name__)
 
 
@@ -165,8 +166,10 @@ def _pub_configurable_soc_modules() -> None:
                     "text": dev_defaults.name,
                     "defaults": dataclass_utils.asdict(dev_defaults)
                 })
-            except Exception:
-                log.exception("Fehler im configuration-Modul")
+            except Exception as e:
+                log.exception(f"Fehler {e} im configuration-Modul {path}")
+                if hasattr(sys, '_called_from_test'):
+                    print(f"Fehler {e} im configuration-Modul {path}")
         soc_modules = sorted(soc_modules, key=lambda d: d['text'].upper())
         # "leeren" Eintrag an erster Stelle einfügen
         soc_modules.insert(0,
@@ -179,8 +182,10 @@ def _pub_configurable_soc_modules() -> None:
                                }
                            })
         Pub().pub("openWB/set/system/configurable/soc_modules", soc_modules)
-    except Exception:
-        log.exception("Fehler im configuration-Modul")
+    except Exception as e:
+        log.exception(f"Fehler {e} im configuration-Modul {path}")
+        if hasattr(sys, '_called_from_test'):
+            print(f"Fehler {e} im configuration-Modul {path}")
 
 
 def _pub_configurable_devices_components() -> None:


### PR DESCRIPTION

For soc modules: show detailed messages in pytest output 
I am sure this will save a lot of time!

Example import problem which works in python but fails in pytest, the statement:
from aiohttp.hdrs import METH_GET, METH_POST, METH_PUT

with this enhancement it will show this new message in pytest output:
----------------------------- Captured stdout call -----------------------------
Fehler No module named 'aiohttp.hdrs'; 'aiohttp' is not a package im configuration-Modul /var/www/html/openWB/packages/modules/vehicles/vwid/soc.py

I am sure this is also applicable to other configurable modules, but I am mainly working on soc-modules...