### PR TITLE
Koala - Add all counters to history chart

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/historyChart/HistoryChart.vue
@@ -118,6 +118,26 @@ const chartRange = computed(
   () => mqttStore.themeConfiguration?.history_chart_range || 3600,
 );
 
+const secondaryCounterDatasets = computed(() =>
+  mqttStore.getSecondaryCounterIds.map((id) => ({
+    label: mqttStore.getComponentName(id),
+    category: 'component',
+    unit: 'kW',
+    borderColor: '#FFA9A8',
+    backgroundColor: 'rgba(255,169,168, 0.2)',
+    data: selectedData.value.map((item) => ({
+      x: item.timestamp * 1000,
+      y: item[`counter${id}-power`] ?? 0,
+    })),
+    borderWidth: 2,
+    pointRadius: 0,
+    pointHoverRadius: 4,
+    pointHitRadius: 5,
+    fill: true,
+    yAxisID: 'y',
+  })),
+);
+
 const chargePointDatasets = computed(() =>
   chargePointIds.value.map((cpId) => ({
     label: `${chargePointNames.value(cpId)}`,
@@ -233,6 +253,7 @@ const lineChartData = computed(() => {
         fill: true,
         yAxisID: 'y',
       },
+      ...secondaryCounterDatasets.value,
       {
         label: 'PV ges.',
         category: 'component',

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -3288,6 +3288,38 @@ export const useMqttStore = defineStore('mqtt', () => {
     return undefined;
   });
 
+
+  /**
+   * Get all counter ids from component hierarchy
+   * @returns number[]
+   */
+  const getAllCounterIds = computed(() => {
+    const hierarchy = getValue.value('openWB/counter/get/hierarchy') as
+      | Hierarchy[]
+      | undefined;
+    const getCounterIds = (
+      nodes: Hierarchy[] | undefined,
+      allCounters: number[] = [],
+    ): number[] => {
+      if (!nodes) return allCounters;
+      nodes.forEach((node) => {
+        if (node.type === 'counter') allCounters.push(node.id);
+        allCounters = getCounterIds(node.children, allCounters);
+      });
+      return allCounters;
+    };
+    return getCounterIds(hierarchy);
+  });
+
+  /**
+   * Get all secondary counter ids from all configured counters excluding the grid counter
+   * @returns number[]
+   */
+  const getSecondaryCounterIds = computed(() => {
+    const rootCounter = getGridId.value;
+    return getAllCounterIds.value.filter((id) => id !== rootCounter);
+  });
+
   /**
    * Get the power meter(counter) name identified by the Grid ID
    * @param counterId counter ID
@@ -3670,6 +3702,8 @@ export const useMqttStore = defineStore('mqtt', () => {
     batteryMode,
     // Grid data
     getGridId,
+    getAllCounterIds,
+    getSecondaryCounterIds,
     getComponentName,
     getGridPower,
     gridDailyImported,


### PR DESCRIPTION
Wenn zusätzlich zum Root-Zähler weitere Zähler im System konfiguriert sind, sollen diese im Verlaufsdiagramm angezeigt werden.