### PR TITLE
Virtual counter: support uncounted consumers

### DIFF
--- a/packages/modules/common/store/_counter.py
+++ b/packages/modules/common/store/_counter.py
@@ -140,6 +140,9 @@ class PurgeCounterState:
                             imported=self.imported)
 
     def calc_uncounted_consumption(self) -> CounterState:
+        """Berechnet den nicht-gezählten Verbrauch für einen virtuellen Zähler.
+        Dazu wird der Zählerstand des übergeordneten Zählers herangezogen und davon die
+        Werte aller anderen untergeordneten Komponenten abgezogen."""
         parent_id = data.data.counter_all_data.get_entry_of_parent(self.delegate.delegate.num)["id"]
         parent_component = get_component_obj_by_id(parent_id)
         if "counter" not in parent_component.component_config.type:

--- a/packages/modules/common/store/_counter_test.py
+++ b/packages/modules/common/store/_counter_test.py
@@ -16,7 +16,7 @@ from modules.common.simcount._simcounter import SimCounter
 from modules.common.store import _counter
 from modules.common.store._api import LoggingValueStore
 from modules.common.store._battery import BatteryValueStoreBroker, PurgeBatteryState
-from modules.common.store._counter import PurgeCounterState
+from modules.common.store._counter import CounterValueStoreBroker, PurgeCounterState
 from modules.common.store._inverter import InverterValueStoreBroker, PurgeInverterState
 from modules.devices.generic.mqtt.bat import MqttBat
 from modules.devices.generic.mqtt.counter import MqttCounter
@@ -138,3 +138,154 @@ def test_calc_virtual(params: Params, monkeypatch):
 
     # evaluation
     assert vars(state) == vars(params.expected_state)
+
+
+def test_calc_uncounted_consumption(monkeypatch):
+    """
+    Test für calc_uncounted_consumption mit folgendem Szenario:
+    - Übergeordnete Ebene: Ein Zähler (id=0, parent counter)
+    - Gleiche Ebene wie virtueller Zähler: Ein Ladepunkt (id=1) und ein weiterer Zähler (id=2)
+    - Virtueller Zähler: id=3 (soll nicht-gezählten Verbrauch berechnen)
+
+    Hierarchie:
+    Counter 0 (parent, 8000W total)
+    ├── Chargepoint 1 (3000W)
+    ├── Counter 2 (2000W) 
+    └── Virtual Counter 3 (uncounted: 8000 - 3000 - 2000 = 3000W)
+    """
+    # setup
+    data.data_init(Mock())
+    data.data.counter_all_data = CounterAll()
+
+    # Setup parent counter (id=0) auf übergeordneter Ebene
+    data.data.counter_data["counter0"] = Mock(
+        spec=Counter,
+        data=Mock(
+            spec=CounterData,
+            get=Mock(
+                spec=Get,
+                power=8000,  # Gesamtverbrauch
+                exported=500,
+                imported=1000,
+                currents=[20.0, 22.0, 18.0]  # Gesamtstrom
+            )
+        )
+    )
+
+    # Setup Ladepunkt (id=1) auf gleicher Ebene wie virtueller Zähler
+    add_chargepoint(1)
+    data.data.cp_data["cp1"].data.get.power = 3000
+    data.data.cp_data["cp1"].data.get.currents = [8.0, 9.0, 7.0]
+    data.data.cp_data["cp1"].chargepoint_module.store.delegate.state.power = 3000
+    data.data.cp_data["cp1"].chargepoint_module.store.delegate.state.currents = [8.0, 9.0, 7.0]
+    data.data.cp_data["cp1"].chargepoint_module.store.delegate.state.imported = 150
+    data.data.cp_data["cp1"].chargepoint_module.store.delegate.state.exported = 0
+
+    # Setup weiterer Zähler (id=2) auf gleicher Ebene
+    data.data.counter_data["counter2"] = Mock(
+        spec=Counter,
+        data=Mock(
+            spec=CounterData,
+            get=Mock(
+                spec=Get,
+                power=2000,
+                exported=100,
+                imported=300,
+                currents=[5.0, 6.0, 4.0]
+            )
+        )
+    )
+
+    # Hierarchie: Parent Counter 0 hat Kinder: CP 1, Counter 2, Virtual Counter 3
+    data.data.counter_all_data.data.get.hierarchy = [
+        {
+            "id": 0,
+            "type": "counter",
+            "children": [
+                {"id": 1, "type": "cp", "children": []},
+                {"id": 2, "type": "counter", "children": []},
+                {"id": 3, "type": "counter", "children": []}  # Virtual counter
+            ]
+        }
+    ]
+
+    # Mock für Parent-Lookup
+    def mock_get_parent_of_element(element_id):
+        if element_id == 3:  # Virtual counter
+            return 0  # Parent counter
+        return None
+
+    # Mock für get_elements_for_downstream_calculation
+    def mock_get_elements_for_downstream_calculation(parent_id):
+        if parent_id == 0:  # Parent counter
+            return [
+                {"id": 1, "type": "cp"},
+                {"id": 2, "type": "counter"}
+                # Virtual counter 3 wird nicht in eigene Berechnung einbezogen
+            ]
+        return []
+
+    data.data.counter_all_data.get_parent_of_element = Mock(side_effect=mock_get_parent_of_element)
+    data.data.counter_all_data.get_elements_for_downstream_calculation = Mock(
+        side_effect=mock_get_elements_for_downstream_calculation
+    )
+
+    # Mock parent counter component
+    parent_counter_component = Mock()
+    parent_counter_component.component_config.type = "counter"
+    parent_counter_component.store.add_child_values = False  # Nicht virtuell
+
+    # Mock regular counter component (id=2)
+    regular_counter_component = Mock(
+        spec=MqttCounter,
+        store=Mock(
+            spec=PurgeCounterState,
+            delegate=Mock(
+                spec=LoggingValueStore,
+                delegate=Mock(
+                    spec=CounterValueStoreBroker,
+                    state=CounterState(
+                        power=2000,
+                        exported=100,
+                        imported=300,
+                        currents=[5.0, 6.0, 4.0]
+                    )
+                )
+            )
+        )
+    )
+
+    def mock_get_component_obj_by_id(component_id):
+        if component_id == 0:  # Parent counter
+            return parent_counter_component
+        elif component_id == 2:  # Regular counter
+            return regular_counter_component
+        return None
+
+    monkeypatch.setattr(_counter, "get_component_obj_by_id", mock_get_component_obj_by_id)
+
+    # Setup virtual counter (id=3)
+    virtual_counter_purge = PurgeCounterState(
+        delegate=Mock(delegate=Mock(num=3)),
+        add_child_values=True,
+        simcounter=SimCounter(0, 0, prefix="virtual")
+    )
+
+    # execution
+    result_state = virtual_counter_purge.calc_uncounted_consumption()
+
+    # evaluation
+    # Erwartete Werte: Parent Counter - (Chargepoint + Regular Counter)
+    # Power: 8000 - (3000 + 2000) = 3000W
+    # Currents: [20.0, 22.0, 18.0] - ([8.0, 9.0, 7.0] + [5.0, 6.0, 4.0]) = [7.0, 7.0, 7.0]
+    # Imported: 1000 - (150 + 300) = 550
+    # Exported: 500 - (0 + 100) = 400
+
+    expected_state = CounterState(
+        power=3000,
+        currents=[7.0, 7.0, 7.0],
+        imported=550,
+        exported=400
+    )
+
+    assert vars(result_state) == vars(expected_state)

--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -32,7 +32,7 @@ class Loadvars:
                 self._update_values_of_level_buttom_top(level, not_finished_threads)
                 wait_for_module_update_completed(self.event_module_update_completed, topic)
                 data.data.copy_module_data()
-            self._update_values_virtual_counter_uncounted_consumption(level, not_finished_threads)
+            self._update_values_virtual_counter_uncounted_consumption(not_finished_threads)
             wait_for_module_update_completed(self.event_module_update_completed, topic)
             data.data.copy_module_data()
             wait_for_module_update_completed(self.event_module_update_completed, topic)

--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -29,9 +29,12 @@ class Loadvars:
             levels = data.data.counter_all_data.get_list_of_elements_per_level()
             levels.reverse()
             for level in levels:
-                self._update_values_of_level(level, not_finished_threads)
+                self._update_values_of_level_buttom_top(level, not_finished_threads)
                 wait_for_module_update_completed(self.event_module_update_completed, topic)
                 data.data.copy_module_data()
+            self._update_values_virtual_counter_uncounted_consumption(level, not_finished_threads)
+            wait_for_module_update_completed(self.event_module_update_completed, topic)
+            data.data.copy_module_data()
             wait_for_module_update_completed(self.event_module_update_completed, topic)
             joined_thread_handler(self._get_io(), data.data.general_data.data.control_interval/3)
             joined_thread_handler(self._set_io(), data.data.general_data.data.control_interval/3)
@@ -59,8 +62,8 @@ class Loadvars:
                 log.exception(f"Fehler im loadvars-Modul bei Element {cp.num}")
         return joined_thread_handler(modules_threads, data.data.general_data.data.control_interval/3)
 
-    def _update_values_of_level(self, elements, not_finished_threads: List[str]) -> None:
-        """Threads, um von der niedrigsten Ebene der Hierarchie Werte ggf. miteinander zu verrechnen und zu
+    def _update_values_of_level_buttom_top(self, elements, not_finished_threads: List[str]) -> None:
+        """Threads, um von der niedrigsten Ebene der Hierarchie beginnend Werte ggf. miteinander zu verrechnen und zu
         veröffentlichen"""
         modules_threads: List[Thread] = []
         for element in elements:
@@ -81,6 +84,23 @@ class Loadvars:
                         component,), name=f"component{component.component_config.id}"))
             except Exception:
                 log.exception(f"Fehler im loadvars-Modul bei Element {element}")
+        joined_thread_handler(modules_threads, data.data.general_data.data.control_interval/3)
+
+    def _update_values_virtual_counter_uncounted_consumption(self, not_finished_threads: List[str]) -> None:
+        modules_threads: List[Thread] = []
+        for counter in data.data.counter_data.values():
+            try:
+                component = get_finished_component_obj_by_id(counter.num, not_finished_threads)
+                if component.component_config.type == "virtual":
+                    if len(data.data.counter_all_data.get_entry_of_element(counter.num)["children"]) == 0:
+                        thread_name = f"component{component.component_config.id}"
+                        if thread_name not in not_finished_threads:
+                            modules_threads.append(Thread(
+                                target=update_values,
+                                args=(component,),
+                                name=f"component{component.component_config.id}"))
+            except Exception:
+                log.exception(f"Fehler im loadvars-Modul bei Zähler {counter}")
         joined_thread_handler(modules_threads, data.data.general_data.data.control_interval/3)
 
     def _get_io(self) -> List[Thread]:


### PR DESCRIPTION
Der virtuelle Zähler kann nun auf zwei Arten genutzt werden: 

- als Summenzähler (wie bisher): zählt alle Komponenten, die in der Hierarchie darunter angeordnet sind, Zählerstände werden aus der Leistung berechnet (simcount)
Konfiguration: der virtuelle Zähler enthält dahinter angeordnete Komponenten in der Hierarchie
- als Zähler für nicht-erfasste Verbräuche: auf der übergeordneten Ebene in der Hierarchie muss ein Zähler sein, dann werden von diesem alle darunter liegenden Komponenten abgezogen und das Ergebnis dem virtuellen Zähler zugeschrieben, Zählerstand wird aus den Komponenten berechnet
Konfiguration: der virtuelle Zähler enthält keine Komponenten in der Hierarchie

[x] Summenzähler
[x] Zähler für nicht erfasste Verbräuche
[x] zwei verschachtelte Summenzähler
[x] Summenzähler und  Zähler für nicht erfasste Verbräuche verschachtelt -> Exception
[x] Zähler für nicht erfasste Verbräuche unter WR -> Exception