### PR TITLE
avm/Fritz counter: fix type of imported to float

### DIFF
--- a/packages/modules/devices/avm/avm/counter.py
+++ b/packages/modules/devices/avm/avm/counter.py
@@ -34,7 +34,7 @@ class AvmCounter(AbstractCounter):
                     if voltageInfo is not None:
                         voltages = [float(voltageInfo.text)/1000, 0, 0]
                     # AVM returns Wh
-                    imported = powermeterBlock.find("energy").text
+                    imported = float(powermeterBlock.find("energy").text)
 
         counter_state = CounterState(
             imported=imported,


### PR DESCRIPTION
Ich sehe immer wieder diese Fehler:
> 2025-12-04 15:24:52,353 - {helpermodules.setdata:324} - {ERROR:Setdata} - Payload ungültig: Topic openWB/set/counter/27/get/imported, Payload 3982451.0 sollte ein Float sein.

Der Fix behebt das.
