### PR TITLE
Koala - add schedule plan info box (next scheduled charging session) to scheduled plan input dialog

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanButton.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanButton.vue
@@ -9,7 +9,6 @@
     <ChargePointScheduledPlanSummary
       :charge-point-id="props.chargePointId"
       :plan="props.plan"
-      :use="'button'"
     />
   </q-btn>
 </template>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -97,7 +97,7 @@
           <ChargePointScheduledPlanSummary
             :charge-point-id="props.chargePointId"
             :plan="props.plan"
-            :use="'info'"
+            mode="info"
           />
         </div>
       </div>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledSettings.vue
@@ -19,7 +19,7 @@
     Keine Ladeziele festgelegt.
   </div>
   <div v-else>
-    <div v-for="(plan, index) in plans" :key="index" class="row q-mt-sm">
+    <div v-for="plan in plans" :key="plan.id" class="row q-mt-sm">
       <ChargePointScheduledPlanButton
         class="full-width"
         :charge-point-id="props.chargePointId"


### PR DESCRIPTION
- Neues, wiederverwendbares ChargePointScheduledPlanSummary-Component eingeführt, das Plan-Name, Datum/Zeit und Ziel (SoC/Energie) sowohl im Button als auch im Info-Kasten anzeigt (mode="button" | "info").

- In ChargePointScheduledPlanDetails den bisherigen Ziel-Termin-Block angepasst: Datum nur noch im Input (einmalig) bearbeitbar, zusätzlich Infobox „Nächster geplanter Termin“ mit berechnetem Datum (once/daily/weekly) und Uhrzeit.

- Wochentags-Anzeige (z. B. „Mo–Fr“) und Berechnung des nächsten Wochentags in das Summary-Component ausgelagert und an den Store (vehicleScheduledChargingPlanWeeklyDays) angebunden.

- In ChargePointScheduledSettings die Auswahl des Plans auf eine ID-basierte Lösung umgestellt (selectedPlanId + selectedPlan als computed), damit Dialog und Buttons immer konsistent die aktuellen Store-Daten anzeigen.

<img width="427" height="452" alt="Bildschirmfoto 2025-12-19 um 12 33 04" src="https://github.com/user-attachments/assets/0aa90bcc-ca6e-4d0e-91e5-c5f95ea5714a" />

<img width="401" height="967" alt="Bildschirmfoto 2025-12-19 um 12 33 21" src="https://github.com/user-attachments/assets/c5f71fab-57c8-4637-98e9-f78952e57bd2" />

<img width="397" height="958" alt="Bildschirmfoto 2025-12-19 um 12 33 28" src="https://github.com/user-attachments/assets/667e2fd8-6e7e-4868-944b-127ae0f8dc05" />

<img width="407" height="1014" alt="Bildschirmfoto 2025-12-19 um 12 33 11" src="https://github.com/user-attachments/assets/40e3a1c7-a64c-4dad-9d81-bb63132a0826" />
