### PR TITLE
Koala - dalily totals slide - Change house direction to direction arrow instead of dash

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/charts/dailyTotals/DailyTotalsRow.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/dailyTotals/DailyTotalsRow.vue
@@ -34,10 +34,7 @@
     <div class="col-arrow">
       <q-icon
         v-if="props.currentPowerVisible"
-        :name="
-          item.id === 'house'
-            ? 'horizontal_rule'
-            : arrowDirection(item.id).noCurrent
+        :name=" arrowDirection(item.id).noCurrent
               ? 'horizontal_rule'
               : 'double_arrow'
         "
@@ -129,7 +126,7 @@ const arrowDirection = (id: string) => {
   let rotate180 = false;
 
   if (id === 'grid' || id.startsWith('counter-')) rotate180 = value < 0;
-  else if (id !== 'house') rotate180 = value > 0;
+  else rotate180 = value > 0;
 
   return { noCurrent, rotate180 };
 };


### PR DESCRIPTION
Pfeil statt Bindestrich anzeigen, um die Richtung der Hausleistung in "daily totals slide" zu kennzeichnen.

<img width="962" height="543" alt="Bildschirmfoto 2026-01-06 um 14 30 03" src="https://github.com/user-attachments/assets/c77fff68-52a8-4427-a1f5-23357a07f9ab" />

<img width="970" height="552" alt="Bildschirmfoto 2026-01-06 um 14 29 25" src="https://github.com/user-attachments/assets/db171201-9b83-4777-be53-a0cc7105a629" />
