### PR TITLE
improve scheduled charging

### DIFF
--- a/packages/control/ev/charge_template_test.py
+++ b/packages/control/ev/charge_template_test.py
@@ -254,8 +254,8 @@ def test_scheduled_charging_recent_plan(end_time_mock,
                      False, (16, "instant_charging",
                      ChargeTemplate.SCHEDULED_CHARGING_MAX_CURRENT.format(16), 3),
                      id="few minutes too late, but didn't miss for today"),
-        pytest.param(SelectedPlan(remaining_time=301, duration=3600), 79, 0, "soc",
-                     False, (6, "pv_charging", ChargeTemplate.SCHEDULED_CHARGING_USE_PV.format("um 8:45 Uhr"), 0),
+        pytest.param(SelectedPlan(remaining_time=601, duration=3600), 79, 0, "soc",
+                     False, (6, "pv_charging", ChargeTemplate.SCHEDULED_CHARGING_USE_PV.format("um 8:50 Uhr"), 0),
                      id="too early, use pv"),
     ])
 def test_scheduled_charging_calc_current(plan_data: SelectedPlan,
@@ -275,7 +275,7 @@ def test_scheduled_charging_calc_current(plan_data: SelectedPlan,
         plan_data.plan = plan
 
     # execution
-    ret = ct.scheduled_charging_calc_current(plan_data, soc, used_amount, 3, 6,
+    ret = ct.scheduled_charging_calc_current(plan_data, soc, used_amount, 3, 3, 6,
                                              0, ChargingType.AC.value, EvTemplate(), BidiState.BIDI_CAPABLE)
 
     # evaluation
@@ -288,7 +288,7 @@ def test_scheduled_charging_calc_current_no_plans():
 
     # execution
     ret = ct.scheduled_charging_calc_current(
-        None, 63, 5, 3, 6, 0, ChargingType.AC.value, EvTemplate(), BidiState.BIDI_CAPABLE)
+        None, 63, 5, 3, 3, 6, 0, ChargingType.AC.value, EvTemplate(), BidiState.BIDI_CAPABLE)
 
     # evaluation
     assert ret == (0, "stop", ChargeTemplate.SCHEDULED_CHARGING_NO_PLANS_CONFIGURED, 3)
@@ -382,8 +382,8 @@ def test_scheduled_charging_calc_current_electricity_tariff(
 
     # execution
     ret = ct.scheduled_charging_calc_current(
-        SelectedPlan(plan=plan, remaining_time=301, phases=3, duration=3600),
-        current_soc, 0, 3, 6, 0, ChargingType.AC.value, EvTemplate(), BidiState.BIDI_CAPABLE)
+        SelectedPlan(plan=plan, remaining_time=601, phases=3, duration=3600),
+        current_soc, 0, 3, 3, 6, 0, ChargingType.AC.value, EvTemplate(), BidiState.BIDI_CAPABLE)
 
     # evaluation
     assert ret == expected


### PR DESCRIPTION
- 10 Minuten vor berechnetem Startzeitpunkt anfangen 
Ergänzung im Wiki: Bitte beachten: eine Ladung bis 100% kann aufgrund verschiedener Faktoren wie Vorheizen des Akkus bei kalten Temperaturen, der Absenkung der Ladeleistung zum Ladeende hin oder aufgrund von gelegentlichen Ausgleichsladungen (sog. Zell-Balancing) nicht absolut exakt berechnet werden. Wir haben einen 10-minütigen Zeitpuffer eingerechnet, es obliegt aber dem Nutzer solche Umgebungsvariablen bei der Ziel-Zeit des Ladeplans zu bedenken und das Ladeziel bei Bedarf etwas früher anzusetzen
- Bei Automatik und günstigem Zeitpunkt mit max Phasenzahl laden
- zweiphasige Autos in der Berechnung berücksichtigen

https://forum.openwb.de/viewtopic.php?p=139351#p139351