### PR TITLE
Refactor fix hour tariff price calculation for quarter hours

### DIFF
--- a/packages/control/optional.py
+++ b/packages/control/optional.py
@@ -150,14 +150,14 @@ class Optional(OcppMixin):
             first_timestamp = (max([timestamp for timestamp in price_data.keys()
                                     if float(timestamp) <= now], default=0))
             return {int(timestamp): price for timestamp, price in price_data.items()
-                    if (timestamp) >= first_timestamp and
+                    if int(timestamp) >= int(first_timestamp) and
                     (int(timestamp) <= last_active_timestamp if last_active_timestamp > 0 else True)}
 
         try:
             if self.data.electricity_pricing.configured:
                 ep = self.data.electricity_pricing
                 #  prices lists are updated in optional_data via mqtt listener
-                if len(ep.get.prices) >= 0:
+                if len(ep.get.prices) > 0:
                     Pub().pub(f"{MQTT_PREFIX}/get/prices", remove(ep.get.prices))
                 if self._flexible_tariff_module:
                     Pub().pub(f"{MQTT_PREFIX}/flexible_tariff/get/prices", remove(ep.flexible_tariff.get.prices))
@@ -171,7 +171,7 @@ class Optional(OcppMixin):
 
     def __get_current_timeslot_start(self) -> int:
         timestamp = self.__get_first_entry()[0]
-        return float(timestamp)
+        return int(timestamp)
 
     def ep_get_current_price(self) -> float:
         if self.data.electricity_pricing.configured:

--- a/packages/control/optional_data.py
+++ b/packages/control/optional_data.py
@@ -9,6 +9,7 @@ from modules.display_themes.cards.config import CardsDisplayTheme
 @dataclass
 class PricingGet:
     fault_state: int = field(default=0)
+    next_query_time: int = field(default=0)
     fault_str: str = field(default=NO_ERROR)
     prices: Dict = field(default_factory=empty_dict_factory)
 
@@ -19,6 +20,7 @@ def create_pricing_get_with_topics(topic_prefix: str) -> PricingGet:
     pricing_get.__dataclass_fields__['fault_state'].metadata = {"topic": f"{topic_prefix}/get/fault_state"}
     pricing_get.__dataclass_fields__['fault_str'].metadata = {"topic": f"{topic_prefix}/get/fault_str"}
     pricing_get.__dataclass_fields__['prices'].metadata = {"topic": f"{topic_prefix}/get/prices"}
+    pricing_get.__dataclass_fields__['next_query_time'].metadata = {"topic": f"{topic_prefix}/get/next_query_time"}
     return pricing_get
 
 
@@ -33,6 +35,7 @@ def grid_fee_get_factory() -> PricingGet:
 @dataclass
 class FlexibleTariff:
     get: PricingGet = field(default_factory=flexible_tariff_get_factory)
+    name: str = field(default="flexible_tariff")
 
 
 def get_flexible_tariff_factory() -> FlexibleTariff:
@@ -42,6 +45,7 @@ def get_flexible_tariff_factory() -> FlexibleTariff:
 @dataclass
 class GridFee:
     get: PricingGet = field(default_factory=grid_fee_get_factory)
+    name: str = field(default="grid_fee")
 
 
 def get_grid_fee_factory() -> GridFee:
@@ -50,7 +54,6 @@ def get_grid_fee_factory() -> GridFee:
 
 @dataclass
 class ElectricityPricingGet:
-    next_query_time: Optional[int] = field(default=None, metadata={"topic": "ep/next_query_time"})
     _prices: Dict = field(default_factory=empty_dict_factory, metadata={"topic": "ep/prices"})
 
     @property

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -877,7 +877,7 @@ class SetData:
             elif "openWB/set/optional/ep/get/prices" in msg.topic:
                 self._validate_value(msg, "json")
             elif "openWB/set/optional/ep/get/next_query_time" in msg.topic:
-                self._validate_value(msg, float)
+                self._validate_value(msg, int)
             elif "openWB/set/optional/ep/configured" in msg.topic:
                 self._validate_value(msg, bool)
             elif "module_update_completed" in msg.topic:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -872,12 +872,12 @@ class SetData:
                     self._validate_value(msg, float)
                 elif re.search(f"{pricing_regex}get/fault_state$", msg.topic) is not None:
                     self._validate_value(msg, int, [(0, 2)])
+                elif re.search(f"{pricing_regex}get/next_query_time$", msg.topic) is not None:
+                    self._validate_value(msg, int)
                 elif re.search(f"{pricing_regex}get/fault_str$", msg.topic) is not None:
                     self._validate_value(msg, str)
             elif "openWB/set/optional/ep/get/prices" in msg.topic:
                 self._validate_value(msg, "json")
-            elif "openWB/set/optional/ep/get/next_query_time" in msg.topic:
-                self._validate_value(msg, int)
             elif "openWB/set/optional/ep/configured" in msg.topic:
                 self._validate_value(msg, bool)
             elif "module_update_completed" in msg.topic:

--- a/packages/modules/common/configurable_tariff.py
+++ b/packages/modules/common/configurable_tariff.py
@@ -21,19 +21,20 @@ log = logging.getLogger(__name__)
 
 class ConfigurableTariff(Generic[T_TARIFF_CONFIG]):
     # Default value, may be overridden in __init__ if config provides it
+    tariff_update_hours = [14]
 
     def __init__(self,
                  config: T_TARIFF_CONFIG,
                  component_initializer: Callable[[], float],
-                 get: PricingGet) -> None:
+                 get: PricingGet,
+                 tariff_type: str = "flexible_tariff") -> None:
         self.config = config
         self.get = get
+        self.tariff_type = tariff_type
 
         # Set update_hours from config if available, else default to [14]
         if hasattr(config.configuration, 'update_hours') and config.configuration.update_hours is not None:
-            self.update_hours = config.configuration.update_hours
-        else:
-            self.update_hours = [14]
+            self.tariff_update_hours = config.configuration.update_hours
 
         # nach Init auf NO_ERROR setzen, damit der Fehlerstatus beim Modulwechsel gelöscht wird
         self.fault_state.no_error()
@@ -43,14 +44,19 @@ class ConfigurableTariff(Generic[T_TARIFF_CONFIG]):
 
     def update(self) -> None:
         if hasattr(self, "_component_updater"):
-            try:
-                with SingleComponentUpdateContext(self.fault_state):
-                    tariff_state, timeslot_length_seconds = self.__update_et_provider_data()
-                    self.__store_and_publish_updated_data(tariff_state)
-                    self.__log_and_publish_progress(timeslot_length_seconds, tariff_state)
-            except Exception as e:
-                log.exception(f"Fehler beim Aktualisieren der Tarifdaten {e}")
-                self.fault_state.warning("Error updating tariff data, retry in 5 minutes")
+            if self.get.next_query_time is None or self.get.next_query_time <= timecheck.create_timestamp():
+                log.debug(f"Tarifaktualisierung für {self.tariff_type}")
+                try:
+                    with SingleComponentUpdateContext(self.fault_state):
+                        tariff_state, timeslot_length_seconds = self.__update_et_provider_data()
+                        self.__store_and_publish_updated_data(tariff_state)
+                        self.__log_and_publish_progress(timeslot_length_seconds, tariff_state)
+                except Exception as e:
+                    log.exception(f"Fehler beim Aktualisieren der Tarifdaten {e}")
+                    self.fault_state.warning("Error updating tariff data, retry in 5 minutes")
+            else:
+                log.info(f"nächste Tarifaktualisierung für {self.tariff_type}" +
+                         f" um {datetime.fromtimestamp(self.get.next_query_time)}")
 
     def __update_et_provider_data(self) -> tuple[TariffState, int]:
         tariff_state = self.__call_component_updater()
@@ -60,26 +66,38 @@ class ConfigurableTariff(Generic[T_TARIFF_CONFIG]):
 
     def __calculate_next_query_time(self) -> float:
         now = datetime.now()
-        current_hour = now.hour
+        current_hour = now.hour + 1  # next full hour
+        log.debug(f"Aktuelle Tarif Update Stunde: {current_hour} Uhr."
+                  f" Berechne nächsten Abruf der {self.tariff_type} Strompreise.")
+        log.debug(f"Konfigurierte Tarifaktualisierungsstunden für {self.tariff_type} : {self.tariff_update_hours}")
         next_hour = min([hour for hour in self.tariff_update_hours
                          if hour > current_hour], default=self.tariff_update_hours[0])
+        log.debug(f"Nächste Tarifaktualisierungsstunde: {next_hour} Uhr.")
+        day_offset = 0 if next_hour > current_hour else 1
+        log.debug(f"Berechneter Tagsoffset für nächsten Abruf: {day_offset} Tage.")
+
         # reduce serverload on their site by trying early and randomizing query time minutes and seconds
         next_query_time = (now.replace(hour=next_hour, minute=0, second=0, microsecond=0) +
-                           timedelta(days=1, minutes=random.randint(1, 7) * -5))
-        Pub().pub("openWB/set/optional/ep/get/next_query_time", int(next_query_time.timestamp()))
+                           timedelta(days=day_offset, minutes=random.randint(1, 7) * -5))
+        if next_query_time <= now:
+            next_query_time += timedelta(hours=1)
+        self.get.next_query_time = int(next_query_time.timestamp())
+        log.debug(f"Nächster Abruf der {self.tariff_type} Strompreise geplant für:"
+                  f" {next_query_time} (Unix Timestamp: {self.get.next_query_time})")
+        Pub().pub(f"openWB/set/optional/ep/{self.tariff_type}/get/next_query_time", int(next_query_time.timestamp()))
 
     def __call_component_updater(self) -> TariffState:
         last_known_timestamp = datetime.fromtimestamp(int(max(self.get.prices.keys()) if self.get.prices else 0))
         tariff_state = self._component_updater()
-        if (last_known_timestamp <
-                datetime.fromtimestamp(int(max(tariff_state.prices.keys())))):
+        if (self.tariff_type == "grid_fee"
+                or last_known_timestamp < datetime.fromtimestamp(int(max(tariff_state.prices.keys())))):
             self.__calculate_next_query_time()
         return tariff_state
 
     def __log_and_publish_progress(self, timeslot_length_seconds, tariff_state):
         def publish_info(message_extension: str) -> None:
             self.fault_state.no_error(
-                f'Die Preisliste hat {message_extension}{len(tariff_state.prices)} Einträge. ')
+                f'Die {self.tariff_type} Preisliste hat {message_extension}{len(tariff_state.prices)} Einträge. ')
         expected_time_slots = int(24 * ONE_HOUR_SECONDS / timeslot_length_seconds)
         publish_info(f'nicht {expected_time_slots}, sondern '
                      if len(tariff_state.prices) < expected_time_slots
@@ -105,15 +123,10 @@ class ConfigurableTariff(Generic[T_TARIFF_CONFIG]):
             self.fault_state.error("no prices to show")
         else:
             now = timecheck.create_timestamp()
-            removed = False
-            for timestamp in list(tariff_state.prices.keys()):
-                if int(timestamp) < now - (timeslot_length_seconds - 1):  # keep current time slot
-                    tariff_state.prices.pop(timestamp)
-                    removed = True
-            if removed:
-                log.debug(
-                    'Die Preisliste startet nicht mit der aktuellen Stunde. '
-                    f'Abgelaufene Eintraäge wurden entfernt: {tariff_state.prices}')
+            first_timestamp = int(max([int(timestamp) for timestamp in tariff_state.prices.keys()
+                                      if int(timestamp) <= now], default=0))
+            tariff_state.prices = {str(timestamp): price for timestamp, price in tariff_state.prices.items()
+                                   if int(timestamp) >= first_timestamp}
         return tariff_state
 
 
@@ -132,4 +145,5 @@ class ConfigurableGridFee(ConfigurableTariff):
                  component_initializer: Callable[[], float]) -> None:
         self.store = store.get_grid_fee_value_store()
         self.fault_state = FaultState(ComponentInfo(None, config.name, ComponentType.GRID_FEE.value))
-        super().__init__(config, component_initializer, OptionalData().electricity_pricing.grid_fee.get)
+        super().__init__(config, component_initializer, OptionalData().electricity_pricing.grid_fee.get,
+                         tariff_type="grid_fee")

--- a/packages/modules/common/configurable_tariff.py
+++ b/packages/modules/common/configurable_tariff.py
@@ -89,8 +89,7 @@ class ConfigurableTariff(Generic[T_TARIFF_CONFIG]):
     def __call_component_updater(self) -> TariffState:
         last_known_timestamp = datetime.fromtimestamp(int(max(self.get.prices.keys()) if self.get.prices else 0))
         tariff_state = self._component_updater()
-        if (self.tariff_type == "grid_fee"
-                or last_known_timestamp < datetime.fromtimestamp(int(max(tariff_state.prices.keys())))):
+        if last_known_timestamp < datetime.fromtimestamp(int(max(tariff_state.prices.keys()))):
             self.__calculate_next_query_time()
         return tariff_state
 

--- a/packages/modules/common/configurable_tariff.py
+++ b/packages/modules/common/configurable_tariff.py
@@ -64,7 +64,7 @@ class ConfigurableTariff(Generic[T_TARIFF_CONFIG]):
         tariff_state = self._remove_outdated_prices(tariff_state, timeslot_length_seconds)
         return tariff_state, timeslot_length_seconds
 
-    def __calculate_next_query_time(self) -> float:
+    def __calculate_next_query_time(self) -> None:
         now = datetime.now()
         current_hour = now.hour + 1  # next full hour
         log.debug(f"Aktuelle Tarif Update Stunde: {current_hour} Uhr."

--- a/packages/modules/common/store/_tariff.py
+++ b/packages/modules/common/store/_tariff.py
@@ -58,8 +58,8 @@ class PriceValueStore(ValueStore[TariffState]):
         grid_fee_prices = data.data.optional_data.data.electricity_pricing.grid_fee.get.prices
         if len(grid_fee_prices) == 0 and data.data.optional_data.grid_fee_module is not None:
             raise ValueError("Keine Preise für konfigurierten Netzentgelttarif vorhanden.")
-        flexible_tariff_prices = {float(k): v for k, v in flexible_tariff_prices.items()}
-        grid_fee_prices = {float(k): v for k, v in grid_fee_prices.items()}
+        flexible_tariff_prices = {int(float(k)): v for k, v in flexible_tariff_prices.items()}
+        grid_fee_prices = {int(float(k)): v for k, v in grid_fee_prices.items()}
         if len(flexible_tariff_prices) == 0 and len(grid_fee_prices) > 0:
             return grid_fee_prices
         if len(grid_fee_prices) == 0 and len(flexible_tariff_prices) > 0:

--- a/packages/modules/common/store/_tariff.py
+++ b/packages/modules/common/store/_tariff.py
@@ -65,8 +65,14 @@ class PriceValueStore(ValueStore[TariffState]):
         if len(grid_fee_prices) == 0 and len(flexible_tariff_prices) > 0:
             return flexible_tariff_prices
 
-        grid_fee_keys = sorted(grid_fee_prices.keys())
         flexible_tariff_keys = sorted(flexible_tariff_prices.keys())
+        grid_fee_keys = sorted(grid_fee_prices.keys())
+        # Get distinct grid_fee_prices values, sort and take the middle one
+        distinct_grid_fee_values = sorted(set(grid_fee_prices.values()))
+        median_grid_fee = (
+            distinct_grid_fee_values[len(distinct_grid_fee_values) // 2]
+            if distinct_grid_fee_values else 0)
+        grid_fee_prices = {float(k): v - median_grid_fee for k, v in grid_fee_prices.items()}
 
         def median_delta(keys):
             """Typische Schrittweite bestimmen (Median der Deltas)"""
@@ -77,6 +83,7 @@ class PriceValueStore(ValueStore[TariffState]):
             return timedelta(seconds=deltas[len(deltas)//2])
         grid_fee_delta = median_delta(grid_fee_keys)
         electricity_tariff_delta = median_delta(flexible_tariff_keys)
+
         # Feinere und gröbere Auflösung bestimmen
         if grid_fee_delta < electricity_tariff_delta:
             fine_dict, coarse_dict = grid_fee_prices, flexible_tariff_prices

--- a/packages/modules/common/store/_tariff.py
+++ b/packages/modules/common/store/_tariff.py
@@ -73,8 +73,8 @@ class PriceValueStore(ValueStore[TariffState]):
         def __get_default_grid_fee_price(prices: Dict[str, float]) -> float:
             if (hasattr(data.data.optional_data.grid_fee_module.config, "default_price") and
                     data.data.optional_data.grid_fee_module.config.default_price is not None):
-                print("Using default grid fee price from configuration: " +
-                      f"{data.data.optional_data.grid_fee_module.config.default_price}")
+                log.debug("Using default grid fee price from configuration: " +
+                          f"{data.data.optional_data.grid_fee_module.config.default_price}")
                 return data.data.optional_data.grid_fee_module.config.default_price
             else:
                 # Fallback: Median der vorhandenen Netzentgelte wird
@@ -87,7 +87,7 @@ class PriceValueStore(ValueStore[TariffState]):
         def __normalize_grid_fee_prices(grid_fee_prices: Dict[int, float], max_timestamp: int) -> Dict[int, float]:
             '''
               Normalisiert die Netzentgelte.
-              Dies ist notwendig, da Nettzentgelte die Preisen einiger Stromanbieter
+              Dies ist notwendig, da die Preise einiger Stromanbieter
               bereits ein festes Netzentgeld enthalten.
             '''
             grid_fee_prices = __reduce_prices(grid_fee_prices)
@@ -97,7 +97,7 @@ class PriceValueStore(ValueStore[TariffState]):
                     and data.data.optional_data.flexible_tariff_module.config.includes_grid_fee is False):
                 return grid_fee_prices
             else:
-                #  Bei flexiblen Tarifen, die das Netzentgeln _nicht_ enthalten,
+                #  Bei flexiblen Tarifen, die das Netzentgelt _nicht_ enthalten,
                 #  muss "includes_grid_fee" explizit auf False gesetzt werden.
                 return {int(float(k)): v - __get_default_grid_fee_price(grid_fee_prices)
                         for k, v in grid_fee_prices.items()}

--- a/packages/modules/common/store/_tariff_test.py
+++ b/packages/modules/common/store/_tariff_test.py
@@ -13,7 +13,10 @@ from modules.common.store._tariff import PriceValueStore
 def make_prices(count, step, base):
     start = datetime.datetime.fromtimestamp(1761127200.0)  # 2025-10-22 12:00
     # json.loads macht keys immer zu str
-    return {str((start + timedelta(minutes=step*i)).timestamp()): base+i for i in range(count)}
+    return {
+        str((start + timedelta(minutes=step * i)).timestamp()): base + i
+        for i in range(count)
+    }
 
 
 @pytest.fixture(autouse=True)
@@ -22,44 +25,76 @@ def mock_data() -> None:
     data.data.optional_data = Optional()
 
 
-@pytest.mark.parametrize("flexible_tariff, grid_fee, expected_prices", [
-    pytest.param(make_prices(4, 15, 10), make_prices(12, 5, 1), {1761127200: 11,
-                                                                 1761127500: 12,
-                                                                 1761127800: 13,
-                                                                 1761128100: 15,
-                                                                 1761128400: 16,
-                                                                 1761128700: 17,
-                                                                 1761129000: 19,
-                                                                 1761129300: 20,
-                                                                 1761129600: 21,
-                                                                 1761129900: 23,
-                                                                 1761130200: 24,
-                                                                 1761130500: 25},
-                 id="grid_fee_finer"),  # grid_fee: 12x5min, flexible_tariff: 4x15min
-    pytest.param(make_prices(12, 5, 1), make_prices(4, 14, 10), {1761127200: 11,
-                                                                 1761127500: 12,
-                                                                 1761127800: 13,
-                                                                 1761128100: 15,
-                                                                 1761128400: 16,
-                                                                 1761128700: 17,
-                                                                 1761129000: 19,
-                                                                 1761129300: 20,
-                                                                 1761129600: 21,
-                                                                 1761129900: 23,
-                                                                 1761130200: 24,
-                                                                 1761130500: 25},
-                 id="flexible tariff finer"),  # flexible_tariff: 12x5min, grid_fee: 4x14min
-    pytest.param(make_prices(4, 15, 1), make_prices(4, 15, 10), {1761127200: 11,
-                                                                 1761128100: 13,
-                                                                 1761129000: 15,
-                                                                 1761129900: 17},
-                 id="same resolution"),  # flexible_tariff & grid_fee: 4x15min
-])
-def test_sum_prices(flexible_tariff: Dict[int, float],
-                    grid_fee: Dict[int, float],
-                    expected_prices: Dict[int, float]):
+@pytest.mark.parametrize(
+    "flexible_tariff, grid_fee, expected_prices",
+    [
+        pytest.param(
+            make_prices(4, 15, 16),  # flexible_tariff: 4x15min
+            make_prices(11, 5, 1),  # grid_fee: 11x5min
+            {
+                1761127200: 11,
+                1761127500: 12,
+                1761127800: 13,
+                1761128100: 15,
+                1761128400: 16,
+                1761128700: 17,
+                1761129000: 19,
+                1761129300: 20,
+                1761129600: 21,
+                1761129900: 23,
+                1761130200: 24,
+            },
+            id="grid_fee_finer",
+        ),
+        pytest.param(
+            make_prices(12, 5, 13),  # flexible_tariff: 12x5min,
+            make_prices(5, 14, 10),  # grid_fee: 5x14min
+            {
+                1761127200: 11,
+                1761127500: 12,
+                1761127800: 13,
+                1761128100: 15,
+                1761128400: 16,
+                1761128700: 17,
+                1761129000: 19,
+                1761129300: 20,
+                1761129600: 21,
+                1761129900: 23,
+                1761130200: 24,
+                1761130500: 25,
+            },
+            id="flexible tariff finer",
+        ),
+        pytest.param(
+            make_prices(5, 15, 13),  # flexible_tariff & grid_fee: 5x15min
+            make_prices(5, 15, 10),
+            {
+                1761127200: 11,
+                1761127500: 12,
+                1761128100: 13,
+                1761129000: 15,
+                1761129900: 17,
+                1761130800: 19,
+            },
+            id="same resolution",
+        ),
+    ],
+)
+def test_sum_prices(
+    flexible_tariff: Dict[int, float],
+    grid_fee: Dict[int, float],
+    expected_prices: Dict[int, float],
+):
+    """
+    It is expected that the flexible tariff contains a fix grid fee
+    which is the median (the middle) of the distinct grid fee values.
+    therefore the result is calculated like this:
+        result = flexible_tariff_price + grid_fee_price - median_grid_fee
+    """
     value_Store = PriceValueStore()
-    data.data.optional_data.data.electricity_pricing.flexible_tariff.get.prices = flexible_tariff
+    data.data.optional_data.data.electricity_pricing.flexible_tariff.get.prices = (
+        flexible_tariff
+    )
     data.data.optional_data.data.electricity_pricing.grid_fee.get.prices = grid_fee
     summed = value_Store.sum_prices()
     for timestamp, price in summed.items():

--- a/packages/modules/common/store/_tariff_test.py
+++ b/packages/modules/common/store/_tariff_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 import datetime
 from typing import Dict
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -76,7 +76,6 @@ def mock_data() -> None:
             make_prices(5, 15, 10),
             {
                 1761127200: 11,
-                1761127500: 12,
                 1761128100: 13,
                 1761129000: 15,
                 1761129900: 17,
@@ -103,8 +102,7 @@ def test_sum_prices(
     )
     data.data.optional_data.data.electricity_pricing.grid_fee.get.prices = grid_fee
     summed = value_Store.sum_prices()
-    for timestamp, price in summed.items():
-        assert price == expected_prices[timestamp]
+    assert summed == expected_prices
 
 
 @pytest.mark.parametrize(

--- a/packages/modules/common/store/_tariff_test.py
+++ b/packages/modules/common/store/_tariff_test.py
@@ -114,7 +114,7 @@ def mock_data() -> None:
         ),
         pytest.param(
             {DEFAULT_START_TIMESTAMP + step * 900: 10 for step in range(5)},
-            {DEFAULT_START_TIMESTAMP + step * 900: 14 for step in range(5)},  # nedian 14
+            {DEFAULT_START_TIMESTAMP + step * 900: 14 for step in range(5)},  # median 14
             True,
             10,  # default_grid_fee_price overrides median grid fee price of 14
             {

--- a/packages/modules/configuration.py
+++ b/packages/modules/configuration.py
@@ -129,8 +129,8 @@ def _pub_configurable_tariffs() -> None:
                         "text": dev_defaults.name,
                         "defaults": dataclass_utils.asdict(dev_defaults)
                     })
-                except Exception:
-                    log.exception("Fehler im configuration-Modul")
+                except Exception as e:
+                    log.exception(f"Fehler im configuration-Modul, {path}: {e}")
             tariffs = sorted(tariffs, key=lambda d: d['text'].upper())
             # "leeren" Eintrag an erster Stelle einfügen
             tariffs.insert(0,

--- a/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/config.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/config.py
@@ -2,9 +2,12 @@ from typing import List, Dict
 
 
 class FixedHoursTariffConfiguration:
-    def __init__(self, default_price: float = 0, tariffs: List[Dict[str, any]] = []) -> None:
+    def __init__(self,
+                 default_price: float = 0,
+                 tariffs: List[Dict[str, any]] = []) -> None:
         self.default_price = default_price
         self.tariffs = tariffs
+        self.update_hours = list(range(24))
         '''
         Example configuration:
         "tariffs": [

--- a/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/config.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/config.py
@@ -4,10 +4,11 @@ from typing import List, Dict
 class FixedHoursTariffConfiguration:
     def __init__(self,
                  default_price: float = 0,
-                 tariffs: List[Dict[str, any]] = []) -> None:
+                 tariffs: List[Dict[str, any]] = None,
+                 update_hours: List[int] = None) -> None:
         self.default_price = default_price
-        self.tariffs = tariffs
-        self.update_hours = list(range(24))
+        self.tariffs = tariffs if tariffs is not None else []
+        self.update_hours = update_hours if update_hours is not None else list(range(24))
         '''
         Example configuration:
         "tariffs": [

--- a/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff.py
@@ -48,7 +48,6 @@ def _fetch(config: FixedHoursTariffConfiguration) -> TariffState:
     for i in range(24 - current_time.hour + (24 if 14 < current_time.hour else 0)):
         for j in range(4):  # get prices for quarter hours
             time_slot = current_time + datetime.timedelta(hours=i, minutes=j * 15)
-            time_slot = current_time + datetime.timedelta(hours=i)
             epoch_time = int(time.mktime(time_slot.timetuple()))
             price = config.default_price / 1000
 

--- a/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff.py
@@ -10,6 +10,7 @@ from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_state import TariffState
 
 log = logging.getLogger(__name__)
+AS_EURO_PER_WH = 1000
 
 
 def _to_time(time_str: str) -> datetime.time:
@@ -40,30 +41,35 @@ def _validate_tariff_times(config: FixedHoursTariffConfiguration) -> None:
 
 def _fetch(config: FixedHoursTariffConfiguration) -> TariffState:
     _validate_tariff_times(config)
+    return _calculate_price_timeslots(config)
 
-    current_time = datetime.datetime.now().replace(minute=0, second=0, microsecond=0)
+
+def _fetch_price_for_time_slot(config: FixedHoursTariffConfiguration,
+                               time_slot: datetime.datetime
+                               ) -> float:
+    for tariff in config.tariffs:
+        active_times = [(_to_time(start), _to_time(end)) for start, end in tariff["active_times"]["times"]]
+        active_dates = [
+            (_to_date(start, time_slot), _to_date(end, time_slot))
+            for start, end in tariff["active_times"]["dates"]
+        ]
+        if (any(start <= time_slot.time() < end for start, end in active_times) and
+                any(start <= time_slot.date() <= end for start, end in active_dates)):
+            return tariff["price"]
+    return config.default_price
+
+
+def _calculate_price_timeslots(config: FixedHoursTariffConfiguration) -> int:
+    current_hour = datetime.datetime.now().replace(minute=0, second=0, microsecond=0)
     prices: Dict[str, float] = {}
-
-    # get prices untill (next) day end
-    for i in range(24 - current_time.hour + (24 if 14 < current_time.hour else 0)):
+    # 36 hours to cover the next day and the current day,
+    # this ensures enough values in prises list when used as grid fee adjustment for flexible tariffs
+    # that might provide prices untill midnight next day.
+    for i in range(36):
         for j in range(4):  # get prices for quarter hours
-            time_slot = current_time + datetime.timedelta(hours=i, minutes=j * 15)
+            time_slot = current_hour + datetime.timedelta(hours=i, minutes=j * 15)
             epoch_time = int(time.mktime(time_slot.timetuple()))
-            price = config.default_price / 1000
-
-            for tariff in config.tariffs:
-                active_times = [(_to_time(start), _to_time(end)) for start, end in tariff["active_times"]["times"]]
-                active_dates = [
-                    (_to_date(start, time_slot), _to_date(end, time_slot))
-                    for start, end in tariff["active_times"]["dates"]
-                ]
-                if (any(start <= time_slot.time() < end for start, end in active_times) and
-                        any(start <= time_slot.date() <= end for start, end in active_dates)):
-                    price = tariff["price"] / 1000
-                    break  # Break since we found a matching tariff
-
-            prices[str(epoch_time)] = price
-
+            prices[str(epoch_time)] = _fetch_price_for_time_slot(config, time_slot) / AS_EURO_PER_WH
     return TariffState(prices=prices)
 
 

--- a/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff.py
@@ -59,12 +59,12 @@ def _fetch_price_for_time_slot(config: FixedHoursTariffConfiguration,
     return config.default_price
 
 
-def _calculate_price_timeslots(config: FixedHoursTariffConfiguration) -> int:
+def _calculate_price_timeslots(config: FixedHoursTariffConfiguration) -> TariffState:
     current_hour = datetime.datetime.now().replace(minute=0, second=0, microsecond=0)
     prices: Dict[str, float] = {}
     # 36 hours to cover the next day and the current day,
-    # this ensures enough values in prises list when used as grid fee adjustment for flexible tariffs
-    # that might provide prices untill midnight next day.
+    # this ensures enough values in prices list when used as grid fee adjustment for flexible tariffs
+    # that might provide prices until midnight next day.
     for i in range(36):
         for j in range(4):  # get prices for quarter hours
             time_slot = current_hour + datetime.timedelta(hours=i, minutes=j * 15)

--- a/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff_test.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff_test.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+import datetime
+import time
+import pytest
+
+from modules.electricity_pricing.flexible_tariffs.fixed_hours.tariff import (
+    _to_time,
+    _to_date,
+    _validate_tariff_times,
+    _fetch,
+    create_electricity_tariff,
+)
+from modules.electricity_pricing.flexible_tariffs.fixed_hours.config import (
+    FixedHoursTariff,
+    FixedHoursTariffConfiguration,
+)
+from modules.common.component_state import TariffState
+
+
+class TestToTime:
+    """Test _to_time function"""
+
+    @pytest.mark.parametrize(
+        "time_str,expected",
+        [
+            pytest.param("14:30", datetime.time(14, 30), id="14:30"),
+            pytest.param("00:00", datetime.time(0, 0), id="midnight"),
+            pytest.param("24:00", datetime.time(23, 59, 59), id="24:00"),
+            pytest.param("08:00", datetime.time(8, 0), id="08:00"),
+            pytest.param("18:45", datetime.time(18, 45), id="18:45"),
+            pytest.param("23:59", datetime.time(23, 59), id="23:59"),
+        ],
+    )
+    def test_to_time_conversion(self, time_str, expected):
+        """Test conversion of various time strings"""
+        result = _to_time(time_str)
+        assert result == expected
+
+
+class TestToDate:
+    """Test _to_date function"""
+
+    @pytest.mark.parametrize(
+        "date_str,time_slot,expected",
+        [
+            pytest.param(
+                "15-06",
+                datetime.datetime(2025, 6, 15, 12, 0),
+                datetime.date(2025, 6, 15),
+                id="normal_date",
+            ),
+            pytest.param(
+                "01-01",
+                datetime.datetime(2025, 1, 15, 12, 0),
+                datetime.date(2025, 1, 1),
+                id="new_year",
+            ),
+            pytest.param(
+                "31-03",
+                datetime.datetime(2025, 3, 31, 12, 0),
+                datetime.date(2025, 3, 31),
+                id="month_end",
+            ),
+            pytest.param(
+                "28-02",
+                datetime.datetime(2025, 2, 28, 12, 0),
+                datetime.date(2025, 2, 28),
+                id="feb_28",
+            ),
+            pytest.param(
+                "25-12",
+                datetime.datetime(2025, 12, 25, 12, 0),
+                datetime.date(2025, 12, 25),
+                id="christmas",
+            ),
+        ],
+    )
+    def test_to_date_conversion(self, date_str, time_slot, expected):
+        """Test conversion of various date strings"""
+        result = _to_date(date_str, time_slot)
+        assert result == expected
+
+
+class TestValidateTariffTimes:
+    """Test _validate_tariff_times function"""
+
+    @pytest.mark.parametrize(
+        "tariffs,should_pass",
+        [
+            # Non-overlapping times
+            pytest.param(
+                [
+                    {
+                        "name": "tariff1",
+                        "price": 100,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("08:00", "12:00")],
+                        },
+                    },
+                    {
+                        "name": "tariff2",
+                        "price": 200,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("14:00", "18:00")],
+                        },
+                    },
+                ],
+                True,
+                id="non_overlapping",
+            ),
+            # Adjacent times
+            pytest.param(
+                [
+                    {
+                        "name": "tariff1",
+                        "price": 100,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("08:00", "12:00")],
+                        },
+                    },
+                    {
+                        "name": "tariff2",
+                        "price": 200,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("12:00", "14:00")],
+                        },
+                    },
+                ],
+                True,
+                id="adjacent_times",
+            ),
+            # Empty tariffs
+            pytest.param([], True, id="empty_tariffs"),
+        ],
+    )
+    def test_validate_tariff_times(self, tariffs, should_pass):
+        """Test validation of tariff time configurations"""
+        config = FixedHoursTariffConfiguration(default_price=1000, tariffs=tariffs)
+
+        if should_pass:
+            _validate_tariff_times(config)
+        else:
+            with pytest.raises(ValueError, match="Overlapping time window detected"):
+                _validate_tariff_times(config)
+
+
+class TestFetch:
+    """Test _fetch function"""
+
+    @pytest.mark.parametrize(
+        "default_price,tariffs,expected_price",
+        [
+            # No tariffs, use default price
+            pytest.param(1500, [], 1.5, id="no_tariffs"),
+            # All-day tariff
+            pytest.param(
+                1500,
+                [
+                    {
+                        "name": "all_day_tariff",
+                        "price": 2000,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("00:00", "24:00")],
+                        },
+                    }
+                ],
+                2.0,
+                id="all_day_tariff",
+            ),
+            # Tariff that matches all times
+            pytest.param(
+                1500,
+                [
+                    {
+                        "name": "tariff1",
+                        "price": 2500,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("00:00", "24:00")],
+                        },
+                    }
+                ],
+                2.5,
+                id="full_day_tariff",
+            ),
+            # Very low price
+            pytest.param(500, [], 0.5, id="low_price"),
+            # Very high price
+            pytest.param(5000, [], 5.0, id="high_price"),
+        ],
+    )
+    def test_fetch_price_configurations(self, default_price, tariffs, expected_price):
+        """Test fetch with various price configurations"""
+        config = FixedHoursTariffConfiguration(
+            default_price=default_price, tariffs=tariffs
+        )
+
+        result = _fetch(config)
+
+        assert isinstance(result, TariffState)
+        assert len(result.prices) > 0
+        for price in result.prices.values():
+            assert isinstance(price, float)
+            assert price == expected_price
+
+    @pytest.mark.parametrize(
+        "default_price,tariffs",
+        [
+            # No tariffs
+            pytest.param(1500, [], id="no_tariffs"),
+            # All-day tariff
+            pytest.param(
+                1500,
+                [
+                    {
+                        "name": "all_day_tariff",
+                        "price": 2000,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("00:00", "24:00")],
+                        },
+                    }
+                ],
+                id="all_day_tariff",
+            ),
+        ],
+    )
+    def test_fetch_first_entry_starts_with_current_quarter_hour(
+        self, default_price, tariffs
+    ):
+        """Test that the first entry in the prices map starts with the current quarter hour"""
+        config = FixedHoursTariffConfiguration(
+            default_price=default_price, tariffs=tariffs
+        )
+
+        result = _fetch(config)
+
+        assert isinstance(result, TariffState)
+        assert len(result.prices) > 0
+
+        # Get the first timestamp (smallest key)
+        first_timestamp_str = min(result.prices.keys())
+        first_timestamp = int(float(first_timestamp_str))
+
+        # Get current time rounded to the current hour
+        current_time = datetime.datetime.now().replace(minute=0, second=0, microsecond=0)
+        expected_timestamp = int(time.mktime(current_time.timetuple()))
+
+        # The first entry should be at or after the current hour
+        assert first_timestamp >= expected_timestamp
+
+
+class TestCreateElectricityTariff:
+    """Test create_electricity_tariff function"""
+
+    @pytest.mark.parametrize(
+        "default_price,tariffs,expected_price",
+        [
+            # No tariffs, use default
+            pytest.param(1500, [], 1.5, id="no_tariffs"),
+            # With all-day tariff
+            pytest.param(
+                1500,
+                [
+                    {
+                        "name": "test_tariff",
+                        "price": 2500,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("00:00", "24:00")],
+                        },
+                    }
+                ],
+                2.5,
+                id="all_day_tariff",
+            ),
+            # Another tariff configuration
+            pytest.param(
+                2000,
+                [
+                    {
+                        "name": "premium_tariff",
+                        "price": 3500,
+                        "active_times": {
+                            "dates": [("01-01", "31-12")],
+                            "times": [("00:00", "24:00")],
+                        },
+                    }
+                ],
+                3.5,
+                id="premium_tariff",
+            ),
+        ],
+    )
+    def test_create_electricity_tariff_updater(
+        self, default_price, tariffs, expected_price
+    ):
+        """Test the create_electricity_tariff updater with various configurations"""
+        config = FixedHoursTariff(
+            configuration=FixedHoursTariffConfiguration(
+                default_price=default_price, tariffs=tariffs
+            )
+        )
+
+        updater = create_electricity_tariff(config)
+
+        assert callable(updater)
+        result = updater()
+
+        assert isinstance(result, TariffState)
+        assert len(result.prices) > 0
+        for price in result.prices.values():
+            assert price == expected_price

--- a/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff_test.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/fixed_hours/tariff_test.py
@@ -295,6 +295,21 @@ class TestCreateElectricityTariff:
                 3.5,
                 id="premium_tariff",
             ),
+            pytest.param(
+                2000,
+                [
+                    {
+                        "name": "never active_tariff",
+                        "price": 3500,
+                        "active_times": {
+                            "dates": [("01-01", "01-01")],
+                            "times": [("00:00", "00:00")],
+                        },
+                    }
+                ],
+                2.0,
+                id="not_matching_tariff returns default price",
+            ),
         ],
     )
     def test_create_electricity_tariff_updater(

--- a/packages/modules/electricity_pricing/flexible_tariffs/ostrom/config.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/ostrom/config.py
@@ -9,6 +9,7 @@ class OstromTariffConfiguration:
         self.client_id = client_id
         self.client_secret = client_secret
         self.zip = zip
+        self.update_hours = [2, 8, 14, 20]  # expected time to get next chunk of prices
 
 
 class OstromTariff:

--- a/packages/modules/electricity_pricing/flexible_tariffs/tibber/config.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/tibber/config.py
@@ -5,7 +5,12 @@ class TibberTariffConfiguration:
     def __init__(self, token: Optional[str] = None, home_id: Optional[str] = None):
         self.token = token
         self.home_id = home_id
-        self.update_hours = [14]  # expected time to get next chunk of prices
+        self.update_hours = [14]  # tibber publishes once daily before 14:00
+        '''
+         dynamische Netzentgelte müssen umgerechnet werden,
+         damit der Gesamtpreis nicht um den Normalpreis der Netzentgelte verzerrt wird.
+        '''
+        self.includes_grid_fee = True
 
 
 class TibberTariff:

--- a/packages/modules/electricity_pricing/flexible_tariffs/tibber/config.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/tibber/config.py
@@ -5,6 +5,7 @@ class TibberTariffConfiguration:
     def __init__(self, token: Optional[str] = None, home_id: Optional[str] = None):
         self.token = token
         self.home_id = home_id
+        self.update_hours = [14]  # expected time to get next chunk of prices
 
 
 class TibberTariff:

--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -39,7 +39,7 @@ class Loadvars:
             joined_thread_handler(self._get_io(), data.data.general_data.data.control_interval/3)
             joined_thread_handler(self._set_io(), data.data.general_data.data.control_interval/3)
             wait_for_module_update_completed(self.event_module_update_completed, topic)
-            if data.data.optional_data.data.electricity_pricing.get.next_query_time is None:
+            if (data.data.optional_data.data.electricity_pricing.configured):
                 self.ep_get_prices()
         except Exception:
             log.exception("Fehler im loadvars-Modul")


### PR DESCRIPTION
harmonize fixed hours tariff with dynamic tariffs 
- [x] shortening the intervals to 15 minutes
- [x] extend Grid_Fee prices to 36 hours (fixed_hours tariff) to cover flexible tariff  prices until next day midnight
- [x] expect flex ep tariff containig fix grid fee
   - select median of grid fee (standard fee)
   - final price = current_ep_price -  median_grid_fee + current_grid_fee
- [x] Publish updated prices via MQTT in optional.py 
   backend updates are done via MQTT listener in optional_data.py
- [x] move next_query_date calculation 
- [x] move tariff update hours to tariff module configuration
- [x] introduce separate MQTT topics for next_query_time of ep tariff and grid fee 
- [x] implement independent update of ep tariff and grid fee

# known issue

- grid fee configuration must be completely removed an configured from scratch to make changes work 

see [forum](https://forum.openwb.de/viewtopic.php?t=11843&sid=ef96c07251b30416a12a793d006d871b)