### PR TITLE
Koala-Theme:  Plans - temporary mode warning, link to plan settings

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
@@ -1,0 +1,52 @@
+<template>
+  <div
+    v-if="show"
+    class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer"
+    :class="[{ 'items-center': collapsed }, messageClass]"
+    style="border-radius: 10px"
+    @click="toggleCollapse"
+  >
+    <q-icon :name="iconName" size="sm" class="q-mr-xs" />
+    <div :class="{ ellipsis: collapsed }">
+      {{ message }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+const props = defineProps<{
+  show: boolean;
+  message: string;
+  type?: 'info' | 'warning' | 'error';
+}>();
+
+const collapsed = ref(true);
+
+const toggleCollapse = () => {
+  collapsed.value = !collapsed.value;
+};
+
+const messageClass = computed(() => {
+  switch (props.type) {
+    case 'warning':
+      return 'bg-warning';
+    case 'error':
+      return 'bg-negative';
+    default:
+      return 'bg-primary';
+  }
+});
+
+const iconName = computed(() => {
+  switch (props.type) {
+    case 'warning':
+      return 'warning';
+    case 'error':
+      return 'error';
+    default:
+      return 'info';
+  }
+});
+</script>

--- a/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="show"
+    v-if="showMessage"
     class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer"
     :class="[{ 'items-center': collapsed }, messageClass]"
     style="border-radius: 10px"
@@ -17,7 +17,7 @@
 import { computed, ref } from 'vue';
 
 const props = defineProps<{
-  show: boolean;
+  showMessage: boolean;
   message: string;
   type?: 'info' | 'warning' | 'error';
 }>();

--- a/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
@@ -1,9 +1,8 @@
 <template>
   <div
     v-if="showMessage"
-    class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer"
+    class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer rounded-borders"
     :class="[{ 'items-center': collapsed }, messageClass]"
-    style="border-radius: 10px"
     @click="toggleCollapse"
   >
     <q-icon :name="iconName" size="sm" class="q-mr-xs" />

--- a/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
@@ -17,13 +17,14 @@ import { computed, ref } from 'vue';
 
 const props = withDefaults(
   defineProps<{
-    showMessage: boolean;
+    showMessage?: boolean;
     message: string;
     type?: 'info' | 'warning' | 'error';
     collapsed?: boolean;
   }>(),
   {
     collapsed: true,
+    showMessage: true,
   },
 );
 

--- a/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BaseMessage.vue
@@ -16,13 +16,19 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 
-const props = defineProps<{
-  showMessage: boolean;
-  message: string;
-  type?: 'info' | 'warning' | 'error';
-}>();
+const props = withDefaults(
+  defineProps<{
+    showMessage: boolean;
+    message: string;
+    type?: 'info' | 'warning' | 'error';
+    collapsed?: boolean;
+  }>(),
+  {
+    collapsed: true,
+  },
+);
 
-const collapsed = ref(true);
+const collapsed = ref(props.collapsed);
 
 const toggleCollapse = () => {
   collapsed.value = !collapsed.value;

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointMessage.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointMessage.vue
@@ -1,33 +1,22 @@
 <template>
-  <div
-    v-if="showMessage"
-    class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer"
-    :class="[{ 'items-center': collapsed }, messageClass]"
-    style="border-radius: 10px"
-    @click="toggleCollapse"
-  >
-    <q-icon :name="iconName" size="sm" class="q-mr-xs" />
-    <div :class="{ ellipsis: collapsed }">
-      {{ message }}
-    </div>
-  </div>
+  <BaseMessage
+  :show="showMessage"
+  :message="message"
+  :type="messageType"
+/>
 </template>
 
 <script setup lang="ts">
 import { useMqttStore } from 'src/stores/mqtt-store';
-import { computed, ref } from 'vue';
+import BaseMessage from './BaseMessage.vue';
+import { computed } from 'vue';
 
 const props = defineProps<{
   chargePointId: number;
   faultMessage?: boolean;
 }>();
-
 const mqttStore = useMqttStore();
-const collapsed = ref<boolean>(true);
 
-const toggleCollapse = () => {
-  collapsed.value = !collapsed.value;
-};
 
 const showMessage = computed(() => {
   return state.value !== undefined && state.value !== 0;
@@ -45,18 +34,7 @@ const message = computed(() =>
     : mqttStore.chargePointStateMessage(props.chargePointId),
 );
 
-const messageClass = computed(() => {
-  switch (state.value) {
-    case 1:
-      return 'bg-warning';
-    case 2:
-      return 'bg-negative';
-    default:
-      return 'bg-primary';
-  }
-});
-
-const iconName = computed(() => {
+const messageType = computed(() => {
   switch (state.value) {
     case 1:
       return 'warning';

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointMessage.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointMessage.vue
@@ -28,11 +28,12 @@ const state = computed(() =>
     : -1,
 );
 
-const message = computed(() =>
-  props.faultMessage
+const message = computed(() => {
+  const message = props.faultMessage
     ? mqttStore.chargePointFaultMessage(props.chargePointId)
-    : mqttStore.chargePointStateMessage(props.chargePointId),
-);
+    : mqttStore.chargePointStateMessage(props.chargePointId);
+  return message ?? '';
+});
 
 const messageType = computed(() => {
   switch (state.value) {

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointMessage.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointMessage.vue
@@ -1,6 +1,6 @@
 <template>
   <BaseMessage
-  :show="showMessage"
+  :show-message="showMessage"
   :message="message"
   :type="messageType"
 />

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -3,7 +3,7 @@
     <q-card-section>
       <div class="row no-wrap">
         <div class="text-h6 ellipsis" :title="planName.value">
-          {{ planName.value }}. TEST
+          {{ planName.value }}
         </div>
 
         <q-space />
@@ -266,13 +266,14 @@
           color="positive"
         />
       </div>
-      <div class="row q-mt-md">
+      <div v-if="temporaryChargeModeActive" class="row q-mt-md">
         <q-btn
           size="sm"
           class="col"
           color="warning"
-          href="/openWB/web/settings/#/VehicleConfiguration/charge_template/"
-          >Einstellungen</q-btn
+          :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
+          ><q-icon left size="xs" name="settings" /> Änderungen in Einstellungen
+          Speichern</q-btn
         >
       </div>
       <div class="row q-mt-md">
@@ -490,6 +491,12 @@ const isTemporaryPlan = computed(() => {
 const temporaryChargeModeActive = computed(() => {
   return mqttStore.temporaryChargeModeAktiv;
 });
+
+const chargeTemplateId = computed(
+  () =>
+    mqttStore.chargePointConnectedVehicleChargeTemplate(props.chargePointId)
+      .value?.id,
+);
 </script>
 
 <style scoped>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -5,7 +5,6 @@
         <div class="text-h6 ellipsis" :title="planName.value">
           {{ planName.value }}
         </div>
-
         <q-space />
         <q-btn icon="close" flat round dense v-close-popup />
       </div>
@@ -14,7 +13,6 @@
         message="Temporärer Plan. Der Plan wird nach dem Abstecken verworfen."
         type="warning"
       />
-
       <BaseMessage
         :show-message="temporaryChargeModeActive"
         message="Temporärer Modus aktiv. Alle Planänderungen werden nach dem Abstecken verworfen."
@@ -101,7 +99,6 @@
             class="col"
           />
         </div>
-
         <div
           class="row q-mt-sm q-pa-sm text-white no-wrap items-center bg-primary"
           style="border-radius: 10px"

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -11,13 +11,13 @@
       </div>
       <BaseMessage
         :show-message="isTemporaryPlan"
-        message="Temporär Plan, Plan wird verworfen nach abstecken"
+        message="Temporärer Plan. Der Plan wird nach dem Abstecken verworfen."
         type="warning"
       />
 
       <BaseMessage
         :show-message="temporaryChargeModeActive"
-        message="Temporär Modus aktiv, alle Planänderungen werden verworfen nach abstecken"
+        message="Temporärer Modus aktiv. Alle Planänderungen werden nach dem Abstecken verworfen."
         type="warning"
       />
     </q-card-section>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -258,8 +258,8 @@
           class="col"
           color="warning"
           :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
-          ><q-icon left size="xs" name="settings" /> Änderungen in Einstellungen
-          Speichern</q-btn
+          ><q-icon left size="xs" name="settings" /> Ladeplan
+          Einstellungen</q-btn
         >
       </div>
       <div class="row q-mt-md">

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -10,13 +10,13 @@
         <q-btn icon="close" flat round dense v-close-popup />
       </div>
       <BaseMessage
-        :show="isTemporaryPlan"
+        :show-message="isTemporaryPlan"
         message="Temporär Plan, Plan wird verworfen nach abstecken"
         type="warning"
       />
 
       <BaseMessage
-        :show="temporaryChargeModeActive"
+        :show-message="temporaryChargeModeActive"
         message="Temporär Modus aktiv, alle Planänderungen werden verworfen nach abstecken"
         type="warning"
       />

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -9,11 +9,6 @@
         <q-btn icon="close" flat round dense v-close-popup />
       </div>
       <BaseMessage
-        :show-message="isTemporaryPlan"
-        message="Temporärer Plan. Der Plan wird nach dem Abstecken verworfen."
-        type="warning"
-      />
-      <BaseMessage
         :show-message="temporaryChargeModeActive"
         message="Temporärer Modus aktiv. Alle Planänderungen werden nach dem Abstecken verworfen."
         type="warning"
@@ -249,23 +244,22 @@
           color="positive"
         />
       </div>
-      <div v-if="temporaryChargeModeActive" class="row q-mt-lg">
-        <q-btn
-          size="sm"
-          class="col"
-          color="warning"
-          :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
-          ><q-icon left size="xs" name="settings" /> Ladeplan
-          Einstellungen</q-btn
-        >
-      </div>
-      <div class="row q-mt-md">
+      <div class="row q-mt-lg">
         <q-btn
           size="sm"
           class="col"
           color="negative"
           @click="removeScheduledChargingPlan(plan.id)"
           >Plan löschen</q-btn
+        >
+      </div>
+      <div v-if="temporaryChargeModeActive" class="row q-mt-md">
+        <q-btn
+          size="sm"
+          class="col charge-plan-link-button"
+          :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
+          ><q-icon left size="xs" name="settings" /> persistente Ladeplan
+          Einstellungen</q-btn
         >
       </div>
     </q-card-section>
@@ -455,15 +449,6 @@ const removeScheduledChargingPlan = (planId) => {
   emit('close');
 };
 
-const PermanentScheduledChargingPlansIds = computed(() =>
-  mqttStore
-    .vehicleScheduledChargingPlansPermanent(props.chargePointId)
-    .map((plan) => plan.id),
-);
-const isTemporaryPlan = computed(
-  () => !PermanentScheduledChargingPlansIds.value.includes(props.plan.id),
-);
-
 const temporaryChargeModeActive = computed(
   () => mqttStore.temporaryChargeModeAktiv ?? false,
 );
@@ -482,6 +467,11 @@ const chargeTemplateId = computed(
 .q-btn-group .q-btn {
   min-width: 100px !important;
   font-size: 10px !important;
+}
+
+.charge-plan-link-button {
+  background-color: var(--q-charge-plan-link-button);
+  color: white;
 }
 
 .flex-grow {

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -266,7 +266,7 @@
           color="positive"
         />
       </div>
-      <div v-if="temporaryChargeModeActive" class="row q-mt-md">
+      <div v-if="temporaryChargeModeActive" class="row q-mt-lg">
         <q-btn
           size="sm"
           class="col"

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -9,31 +9,17 @@
         <q-space />
         <q-btn icon="close" flat round dense v-close-popup />
       </div>
-      <div
-        v-if="isTemporaryPlan"
-        class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer bg-warning max-w-s"
-        :class="[{ 'items-center': collapsed }]"
-        style="border-radius: 10px"
-        @click="toggleCollapse"
-      >
-        <q-icon name="warning" size="sm" class="q-mr-xs" />
-        <div :class="{ ellipsis: collapsed }">
-          Temporär Plan, Plan wird verworfen nach abstecken
-        </div>
-      </div>
-      <div
-        v-if="temporaryChargeModeActive"
-        class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer bg-warning"
-        :class="[{ 'items-center': collapsed }]"
-        style="border-radius: 10px"
-        @click="toggleCollapse"
-      >
-        <q-icon name="warning" size="sm" class="q-mr-xs" />
-        <div :class="{ ellipsis: collapsed }">
-          Temporär Modus aktiv, alle Planänderungen werden verworfen nach
-          abstecken
-        </div>
-      </div>
+      <BaseMessage
+        :show="isTemporaryPlan"
+        message="Temporär Plan, Plan wird verworfen nach abstecken"
+        type="warning"
+      />
+
+      <BaseMessage
+        :show="temporaryChargeModeActive"
+        message="Temporär Modus aktiv, alle Planänderungen werden verworfen nach abstecken"
+        type="warning"
+      />
     </q-card-section>
     <q-separator />
     <q-card-section>
@@ -294,7 +280,8 @@ import { useMqttStore } from 'src/stores/mqtt-store';
 import { useQuasar } from 'quasar';
 import SliderStandard from './SliderStandard.vue';
 import ToggleStandard from './ToggleStandard.vue';
-import { computed, ref } from 'vue';
+import BaseMessage from './BaseMessage.vue';
+import { computed } from 'vue';
 import ChargePointScheduledPlanSummary from './ChargePointScheduledPlanSummary.vue';
 import { type ScheduledChargingPlan } from '../stores/mqtt-store-model';
 
@@ -306,12 +293,6 @@ const props = defineProps<{
 const emit = defineEmits(['close']);
 const mqttStore = useMqttStore();
 const $q = useQuasar();
-
-const collapsed = ref<boolean>(true);
-
-const toggleCollapse = () => {
-  collapsed.value = !collapsed.value;
-};
 
 const weekDays = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
 

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -463,15 +463,13 @@ const PermanentScheduledChargingPlansIds = computed(() =>
     .vehicleScheduledChargingPlansPermanent(props.chargePointId)
     .map((plan) => plan.id),
 );
-const isTemporaryPlan = computed(() => {
-  return !PermanentScheduledChargingPlansIds.value.some(
-    (id) => id === props.plan.id,
-  );
-});
+const isTemporaryPlan = computed(
+  () => !PermanentScheduledChargingPlansIds.value.includes(props.plan.id),
+);
 
-const temporaryChargeModeActive = computed(() => {
-  return mqttStore.temporaryChargeModeAktiv;
-});
+const temporaryChargeModeActive = computed(
+  () => mqttStore.temporaryChargeModeAktiv ?? false,
+);
 
 const chargeTemplateId = computed(
   () =>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -465,7 +465,7 @@ const chargeTemplateId = computed(
 
 <style scoped>
 .card-width {
-  width: 26em;
+  max-width: 26em;
 }
 .q-btn-group .q-btn {
   min-width: 100px !important;

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -449,9 +449,7 @@ const removeScheduledChargingPlan = (planId) => {
   emit('close');
 };
 
-const temporaryChargeModeActive = computed(
-  () => mqttStore.temporaryChargeModeAktiv ?? false,
-);
+const temporaryChargeModeActive = mqttStore.temporaryChargeModeAktiv;
 
 const chargeTemplateId = computed(
   () =>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -254,7 +254,7 @@
           >Plan löschen</q-btn
         >
       </div>
-      <div v-if="temporaryChargeModeActive" class="row q-mt-md">
+      <div v-if="temporaryChargeModeActive && chargeTemplateId != null" class="row q-mt-md">
         <q-btn
           size="sm"
           class="col charge-plan-link-button"

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -12,6 +12,7 @@
         :show-message="temporaryChargeModeActive"
         message="Temporärer Modus aktiv. Alle Planänderungen werden nach dem Abstecken verworfen."
         type="warning"
+        :collapsed="false"
       />
     </q-card-section>
     <q-separator />

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -451,7 +451,7 @@ const removeScheduledChargingPlan = (planId) => {
 };
 
 const temporaryChargeModeActive = computed(
-  () => mqttStore.temporaryChargeModeAktiv,
+  () => mqttStore.temporaryChargeModeActive,
 );
 
 const chargeTemplateId = computed(

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -253,7 +253,10 @@
           >Plan löschen</q-btn
         >
       </div>
-      <div v-if="temporaryChargeModeActive && chargeTemplateId != null" class="row q-mt-md">
+      <div
+        v-if="temporaryChargeModeActive && chargeTemplateId != null"
+        class="row q-mt-md"
+      >
         <q-btn
           size="sm"
           class="col charge-plan-link-button"

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -259,8 +259,8 @@
           size="sm"
           class="col charge-plan-link-button"
           :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
-          ><q-icon left size="xs" name="settings" /> persistente Ladeplan
-          Einstellungen</q-btn
+          ><q-icon left size="xs" name="settings" />Persistente
+          Ladeplan-Einstellungen</q-btn
         >
       </div>
     </q-card-section>
@@ -450,9 +450,8 @@ const removeScheduledChargingPlan = (planId) => {
   emit('close');
 };
 
-
 const temporaryChargeModeActive = computed(
-  () => mqttStore.temporaryChargeModeAktiv
+  () => mqttStore.temporaryChargeModeAktiv,
 );
 
 const chargeTemplateId = computed(

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -449,7 +449,10 @@ const removeScheduledChargingPlan = (planId) => {
   emit('close');
 };
 
-const temporaryChargeModeActive = mqttStore.temporaryChargeModeAktiv;
+
+const temporaryChargeModeActive = computed(
+  () => mqttStore.temporaryChargeModeAktiv
+);
 
 const chargeTemplateId = computed(
   () =>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledPlanDetails.vue
@@ -96,8 +96,7 @@
           />
         </div>
         <div
-          class="row q-mt-sm q-pa-sm text-white no-wrap items-center bg-primary"
-          style="border-radius: 10px"
+          class="row q-mt-sm q-pa-sm text-white no-wrap items-center bg-primary rounded-borders"
         >
           <q-icon name="info" size="sm" class="q-mr-xs" />
           <ChargePointScheduledPlanSummary

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointScheduledSettings.vue
@@ -9,15 +9,11 @@
       @click="addScheduledChargingPlan"
     />
   </div>
-  <div
+    <BaseMessage
     v-if="plans.length === 0"
-    class="row q-mt-sm q-pa-sm bg-primary text-white no-wrap message-text"
-    color="primary"
-    style="border-radius: 10px"
-  >
-    <q-icon name="info" size="sm" class="q-mr-xs" />
-    Keine Ladeziele festgelegt.
-  </div>
+    message="Keine Zeitpläne vorhanden."
+    type="info"
+  />
   <div v-else>
     <div v-for="plan in plans" :key="plan.id" class="row q-mt-sm">
       <ChargePointScheduledPlanButton
@@ -47,6 +43,7 @@ import { ref, computed } from 'vue';
 import { useMqttStore } from 'src/stores/mqtt-store';
 import ChargePointScheduledPlanButton from './ChargePointScheduledPlanButton.vue';
 import ChargePointScheduledPlanDetails from './ChargePointScheduledPlanDetails.vue';
+import BaseMessage from './BaseMessage.vue';
 import { Screen } from 'quasar';
 
 const props = defineProps<{

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -204,8 +204,8 @@
           class="col"
           color="warning"
           :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
-          ><q-icon left size="xs" name="settings" /> Änderungen in Einstellungen
-          Speichern</q-btn
+          ><q-icon left size="xs" name="settings" /> Ladeplan
+          Einstellungen</q-btn
         >
       </div>
       <div class="row q-mt-md">

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -8,31 +8,17 @@
         <q-space />
         <q-btn icon="close" flat round dense v-close-popup />
       </div>
-      <div
-        v-if="isTemporaryPlan"
-        class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer bg-warning max-w-s"
-        :class="[{ 'items-center': collapsed }]"
-        style="border-radius: 10px"
-        @click="toggleCollapse"
-      >
-        <q-icon name="warning" size="sm" class="q-mr-xs" />
-        <div :class="{ ellipsis: collapsed }">
-          Temporär Plan, Plan wird verworfen nach abstecken
-        </div>
-      </div>
-      <div
-        v-if="temporaryChargeModeActive"
-        class="row q-mt-sm q-pa-sm text-white no-wrap cursor-pointer bg-warning"
-        :class="[{ 'items-center': collapsed }]"
-        style="border-radius: 10px"
-        @click="toggleCollapse"
-      >
-        <q-icon name="warning" size="sm" class="q-mr-xs" />
-        <div :class="{ ellipsis: collapsed }">
-          Temporär Modus aktiv, alle Planänderungen werden verworfen nach
-          abstecken
-        </div>
-      </div>
+      <BaseMessage
+        :show-message="isTemporaryPlan"
+        message="Temporär Plan, Plan wird verworfen nach abstecken"
+        type="warning"
+      />
+
+      <BaseMessage
+        :show-message="temporaryChargeModeActive"
+        message="Temporär Modus aktiv, alle Planänderungen werden verworfen nach abstecken"
+        type="warning"
+      />
     </q-card-section>
     <q-separator />
 
@@ -225,8 +211,9 @@
 import { useMqttStore } from 'src/stores/mqtt-store';
 import SliderStandard from './SliderStandard.vue';
 import ToggleStandard from './ToggleStandard.vue';
+import BaseMessage from './BaseMessage.vue';
 import { type TimeChargingPlan } from '../stores/mqtt-store-model';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 
 const props = defineProps<{
   chargePointId: number;
@@ -235,12 +222,6 @@ const props = defineProps<{
 
 const mqttStore = useMqttStore();
 const emit = defineEmits(['close']);
-
-const collapsed = ref<boolean>(true);
-
-const toggleCollapse = () => {
-  collapsed.value = !collapsed.value;
-};
 
 const weekDays = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
 
@@ -346,15 +327,13 @@ const PermanentTimeChargingPlansIds = computed(() =>
     .map((plan) => plan.id),
 );
 
-const isTemporaryPlan = computed(() => {
-  return !PermanentTimeChargingPlansIds.value.some(
-    (id) => id === props.plan.id,
-  );
-});
+const isTemporaryPlan = computed(
+  () => !PermanentTimeChargingPlansIds.value.includes(props.plan.id),
+);
 
-const temporaryChargeModeActive = computed(() => {
-  return mqttStore.temporaryChargeModeAktiv;
-});
+const temporaryChargeModeActive = computed(
+  () => mqttStore.temporaryChargeModeAktiv ?? false,
+);
 
 const chargeTemplateId = computed(
   () =>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -10,13 +10,13 @@
       </div>
       <BaseMessage
         :show-message="isTemporaryPlan"
-        message="Temporär Plan, Plan wird verworfen nach abstecken"
+        message="Temporärer Plan. Der Plan wird nach dem Abstecken verworfen."
         type="warning"
       />
 
       <BaseMessage
         :show-message="temporaryChargeModeActive"
-        message="Temporär Modus aktiv, alle Planänderungen werden verworfen nach abstecken"
+        message="Temporärer Modus aktiv. Alle Planänderungen werden nach dem Abstecken verworfen."
         type="warning"
       />
     </q-card-section>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -13,7 +13,6 @@
         message="Temporärer Plan. Der Plan wird nach dem Abstecken verworfen."
         type="warning"
       />
-
       <BaseMessage
         :show-message="temporaryChargeModeActive"
         message="Temporärer Modus aktiv. Alle Planänderungen werden nach dem Abstecken verworfen."
@@ -21,7 +20,6 @@
       />
     </q-card-section>
     <q-separator />
-
     <q-card-section>
       <div class="row items-center q-mb-sm">
         <q-input v-model="planName.value" label="Plan Name" class="col" />

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -9,11 +9,6 @@
         <q-btn icon="close" flat round dense v-close-popup />
       </div>
       <BaseMessage
-        :show-message="isTemporaryPlan"
-        message="Temporärer Plan. Der Plan wird nach dem Abstecken verworfen."
-        type="warning"
-      />
-      <BaseMessage
         :show-message="temporaryChargeModeActive"
         message="Temporärer Modus aktiv. Alle Planänderungen werden nach dem Abstecken verworfen."
         type="warning"
@@ -182,23 +177,22 @@
           <div class="text-body2">kWh</div>
         </template>
       </q-input>
-      <div v-if="temporaryChargeModeActive" class="row q-mt-lg">
-        <q-btn
-          size="sm"
-          class="col"
-          color="warning"
-          :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
-          ><q-icon left size="xs" name="settings" /> Ladeplan
-          Einstellungen</q-btn
-        >
-      </div>
-      <div class="row q-mt-md">
+      <div class="row q-mt-lg">
         <q-btn
           size="sm"
           class="col"
           color="negative"
           @click="removeTimeChargingPlan(plan.id)"
           >Plan löschen</q-btn
+        >
+      </div>
+      <div v-if="temporaryChargeModeActive" class="row q-mt-md">
+        <q-btn
+          size="sm"
+          class="col charge-plan-link-button"
+          :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
+          ><q-icon left size="xs" name="settings" /> persistente Ladeplan
+          Einstellungen</q-btn
         >
       </div>
     </q-card-section>
@@ -319,16 +313,6 @@ const acChargingEnabled = computed(
   () => mqttStore.chargePointChargeType(props.chargePointId).value === 'AC',
 );
 
-const PermanentTimeChargingPlansIds = computed(() =>
-  mqttStore
-    .vehicleTimeChargingPlansPermanent(props.chargePointId)
-    .map((plan) => plan.id),
-);
-
-const isTemporaryPlan = computed(
-  () => !PermanentTimeChargingPlansIds.value.includes(props.plan.id),
-);
-
 const temporaryChargeModeActive = computed(
   () => mqttStore.temporaryChargeModeAktiv ?? false,
 );
@@ -353,6 +337,11 @@ const removeTimeChargingPlan = (planId: number) => {
 .q-btn-group .q-btn {
   min-width: 100px !important;
   font-size: 10px !important;
+}
+
+.charge-plan-link-button {
+  background-color: var(--q-charge-plan-link-button);
+  color: white;
 }
 
 .flex-grow {

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -335,7 +335,7 @@ const removeTimeChargingPlan = (planId: number) => {
 
 <style scoped>
 .card-width {
-  width: 26em;
+  max-width: 26em;
 }
 
 .q-btn-group .q-btn {

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -313,7 +313,9 @@ const acChargingEnabled = computed(
   () => mqttStore.chargePointChargeType(props.chargePointId).value === 'AC',
 );
 
-const temporaryChargeModeActive = mqttStore.temporaryChargeModeAktiv
+const temporaryChargeModeActive =  computed(
+  () => mqttStore.temporaryChargeModeAktiv
+);
 
 const chargeTemplateId = computed(
   () =>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -187,7 +187,7 @@
           >Plan löschen</q-btn
         >
       </div>
-      <div v-if="temporaryChargeModeActive" class="row q-mt-md">
+      <div v-if="temporaryChargeModeActive && chargeTemplateId != null" class="row q-mt-md">
         <q-btn
           size="sm"
           class="col charge-plan-link-button"

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -12,6 +12,7 @@
         :show-message="temporaryChargeModeActive"
         message="Temporärer Modus aktiv. Alle Planänderungen werden nach dem Abstecken verworfen."
         type="warning"
+        :collapsed="false"
       />
     </q-card-section>
     <q-separator />

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -187,7 +187,10 @@
           >Plan löschen</q-btn
         >
       </div>
-      <div v-if="temporaryChargeModeActive && chargeTemplateId != null" class="row q-mt-md">
+      <div
+        v-if="temporaryChargeModeActive && chargeTemplateId != null"
+        class="row q-mt-md"
+      >
         <q-btn
           size="sm"
           class="col charge-plan-link-button"

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -192,8 +192,8 @@
           size="sm"
           class="col charge-plan-link-button"
           :href="`/openWB/web/settings/#/VehicleConfiguration/charge_template/${chargeTemplateId ?? ''}`"
-          ><q-icon left size="xs" name="settings" /> persistente Ladeplan
-          Einstellungen</q-btn
+          ><q-icon left size="xs" name="settings" /> Persistente
+          Ladeplan-Einstellungen</q-btn
         >
       </div>
     </q-card-section>
@@ -314,8 +314,8 @@ const acChargingEnabled = computed(
   () => mqttStore.chargePointChargeType(props.chargePointId).value === 'AC',
 );
 
-const temporaryChargeModeActive =  computed(
-  () => mqttStore.temporaryChargeModeAktiv
+const temporaryChargeModeActive = computed(
+  () => mqttStore.temporaryChargeModeAktiv,
 );
 
 const chargeTemplateId = computed(

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -313,9 +313,7 @@ const acChargingEnabled = computed(
   () => mqttStore.chargePointChargeType(props.chargePointId).value === 'AC',
 );
 
-const temporaryChargeModeActive = computed(
-  () => mqttStore.temporaryChargeModeAktiv ?? false,
-);
+const temporaryChargeModeActive = mqttStore.temporaryChargeModeAktiv
 
 const chargeTemplateId = computed(
   () =>

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingPlanDetails.vue
@@ -315,7 +315,7 @@ const acChargingEnabled = computed(
 );
 
 const temporaryChargeModeActive = computed(
-  () => mqttStore.temporaryChargeModeAktiv,
+  () => mqttStore.temporaryChargeModeActive,
 );
 
 const chargeTemplateId = computed(

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointTimeChargingSettings.vue
@@ -21,15 +21,11 @@
       @click="addScheduledChargingPlan"
     />
   </div>
-  <div
+  <BaseMessage
     v-if="plans.length === 0 && timeChargingEnabled"
-    class="row q-mt-sm q-pa-sm bg-primary text-white no-wrap message-text"
-    color="primary"
-    style="border-radius: 10px"
-  >
-    <q-icon name="info" size="sm" class="q-mr-xs" />
-    Keine Zeitpläne vorhanden.
-  </div>
+    message="Keine Zeitpläne vorhanden."
+    type="info"
+  />
   <div v-else-if="timeChargingEnabled">
     <div v-for="(plan, index) in plans" :key="index" class="row q-mt-sm">
       <ChargePointTimeChargingPlanButton
@@ -61,6 +57,7 @@ import { computed, ref } from 'vue';
 import ChargePointTimeCharging from './ChargePointTimeCharging.vue';
 import ChargePointTimeChargingPlanButton from './ChargePointTimeChargingPlanButton.vue';
 import ChargePointTimeChargingPlanDetails from './ChargePointTimeChargingPlanDetails.vue';
+import BaseMessage from './BaseMessage.vue';
 import { Screen } from 'quasar';
 
 const props = defineProps<{

--- a/packages/modules/web_themes/koala/source/src/css/quasar.variables.scss
+++ b/packages/modules/web_themes/koala/source/src/css/quasar.variables.scss
@@ -49,6 +49,7 @@ $battery-fill: #ba712833;
 $battery-fill-flow-diagram: #c6a583;
 $charge-point-stroke: #5c93d1;
 $charge-point-fill: #5c93d14d;
+$charge-plan-link-button: #6b757d;
 // Light theme (default)
 :root {
   --q-primary: #{$primary};
@@ -78,6 +79,7 @@ $charge-point-fill: #5c93d14d;
   --q-battery-fill-flow-diagram: #{$battery-fill-flow-diagram};
   --q-charge-point-stroke: #{$charge-point-stroke};
   --q-charge-point-fill: #{$charge-point-fill};
+  --q-charge-plan-link-button: #{$charge-plan-link-button};
 
   // Main background
   background-color: var(--q-background-1);

--- a/packages/modules/web_themes/koala/source/src/css/quasar.variables.scss
+++ b/packages/modules/web_themes/koala/source/src/css/quasar.variables.scss
@@ -268,6 +268,7 @@ $dark-daily-totals-battery-stroke: #e7c08a;
 $dark-daily-totals-pv-fill: #27623a;
 $dark-daily-totals-house-fill: #6e6e6e;
 $dark-daily-totals-chargepoint-fill: #254a8c;
+$dark-charge-plan-link-button: #75787a;
 
 // Dark theme
 .body--dark {
@@ -306,6 +307,7 @@ $dark-daily-totals-chargepoint-fill: #254a8c;
   --q-dark-daily-totals-pv-fill: #{$dark-daily-totals-pv-fill};
   --q-dark-daily-totals-house-fill: #{$dark-daily-totals-house-fill};
   --q-dark-daily-totals-chargepoint-fill: #{$dark-daily-totals-chargepoint-fill};
+  --q-charge-plan-link-button: #{$dark-charge-plan-link-button};
 
   // Main background
   background-color: $dark-page;

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -2224,21 +2224,6 @@ export const useMqttStore = defineStore('mqtt', () => {
   };
 
   /**
-   * Get permanent time charging plan/s identified by the charge point id
-   * @param chargePointId charge point id
-   * @returns TimeChargingPlan[]
-   */
-  const vehicleTimeChargingPlansPermanent = (chargePointId: number) => {
-    const templateId =
-      chargePointConnectedVehicleChargeTemplate(chargePointId).value?.id;
-    const plans = getValue.value(
-      `openWB/vehicle/template/charge_template/${templateId}`,
-      'time_charging.plans',
-    ) as TimeChargingPlan[] | undefined;
-    return Array.isArray(plans) ? plans : [];
-  };
-
-  /**
    * Get or set the limit selected mode for the time charging plan identified by the time charging plan id
    * @param chargePointId charge point id
    * @param planId time charging plan id
@@ -3003,21 +2988,6 @@ export const useMqttStore = defineStore('mqtt', () => {
       console.warn('Kein Template für ChargePoint gefunden:', chargePointId);
     }
   }
-
-  /**
-   * Get permanent scheduled charging plan/s identified by the charge point id
-   * @param chargePointId charge point id
-   * @returns ScheduledChargingPlan[]
-   */
-  const vehicleScheduledChargingPlansPermanent = (chargePointId: number) => {
-    const templateId =
-      chargePointConnectedVehicleChargeTemplate(chargePointId).value?.id;
-    const plans = getValue.value(
-      `openWB/vehicle/template/charge_template/${templateId}`,
-      'chargemode.scheduled_charging.plans',
-    ) as ScheduledChargingPlan[] | undefined;
-    return Array.isArray(plans) ? plans : [];
-  };
 
   function removeScheduledChargingPlanForChargePoint(
     chargePointId: number,
@@ -4032,12 +4002,10 @@ export const useMqttStore = defineStore('mqtt', () => {
     vehicleTimeChargingPlanName,
     addTimeChargingPlanForChargePoint,
     removeTimeChargingPlanForChargePoint,
-    vehicleScheduledChargingPlansPermanent,
     vehicleTimeChargingPlanActive,
     vehicleTimeChargingPlanStartTime,
     vehicleTimeChargingPlanEndTime,
     vehicleTimeChargingPlanCurrent,
-    vehicleTimeChargingPlansPermanent,
     vehicleTimeChargingPlanLimitSelected,
     vehicleTimeChargingPlanSocLimit,
     vehicleTimeChargingPlanEnergyAmount,

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -2079,21 +2079,6 @@ export const useMqttStore = defineStore('mqtt', () => {
   };
 
   /**
-   * Get scheduled permanent charging plan/s identified by the charge point id
-   * @param chargePointId charge point id
-   * @returns ScheduledChargingPlan[]
-   */
-  const vehicleScheduledChargingPlansPermanent = (chargePointId: number) => {
-    const templateId =
-      chargePointConnectedVehicleChargeTemplate(chargePointId).value?.id;
-    const plans = getValue.value(
-      `openWB/vehicle/template/charge_template/${templateId}`,
-      'chargemode.scheduled_charging.plans',
-    ) as ScheduledChargingPlan[] | undefined;
-    return Array.isArray(plans) ? plans : [];
-  };
-
-  /**
    * Get temporary charge settings mode selected
    * @returns boolean | undefined
    */
@@ -2236,6 +2221,21 @@ export const useMqttStore = defineStore('mqtt', () => {
         );
       },
     });
+  };
+
+  /**
+   * Get scheduled permanent scheduled charging plan/s identified by the charge point id
+   * @param chargePointId charge point id
+   * @returns ScheduledChargingPlan[]
+   */
+  const vehicleTimeChargingPlansPermanent = (chargePointId: number) => {
+    const templateId =
+      chargePointConnectedVehicleChargeTemplate(chargePointId).value?.id;
+    const plans = getValue.value(
+      `openWB/vehicle/template/charge_template/${templateId}`,
+      'time_charging.plans',
+    ) as TimeChargingPlan[] | undefined;
+    return Array.isArray(plans) ? plans : [];
   };
 
   /**
@@ -3003,6 +3003,21 @@ export const useMqttStore = defineStore('mqtt', () => {
       console.warn('Kein Template für ChargePoint gefunden:', chargePointId);
     }
   }
+
+  /**
+   * Get scheduled permanent scheduled charging plan/s identified by the charge point id
+   * @param chargePointId charge point id
+   * @returns ScheduledChargingPlan[]
+   */
+  const vehicleScheduledChargingPlansPermanent = (chargePointId: number) => {
+    const templateId =
+      chargePointConnectedVehicleChargeTemplate(chargePointId).value?.id;
+    const plans = getValue.value(
+      `openWB/vehicle/template/charge_template/${templateId}`,
+      'chargemode.scheduled_charging.plans',
+    ) as ScheduledChargingPlan[] | undefined;
+    return Array.isArray(plans) ? plans : [];
+  };
 
   function removeScheduledChargingPlanForChargePoint(
     chargePointId: number,
@@ -4022,6 +4037,7 @@ export const useMqttStore = defineStore('mqtt', () => {
     vehicleTimeChargingPlanStartTime,
     vehicleTimeChargingPlanEndTime,
     vehicleTimeChargingPlanCurrent,
+    vehicleTimeChargingPlansPermanent,
     vehicleTimeChargingPlanLimitSelected,
     vehicleTimeChargingPlanSocLimit,
     vehicleTimeChargingPlanEnergyAmount,

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -2093,6 +2093,10 @@ export const useMqttStore = defineStore('mqtt', () => {
     return Array.isArray(plans) ? plans : [];
   };
 
+  /**
+   * Get temporary charge settings mode selected
+   * @returns boolean | undefined
+   */
   const temporaryChargeModeAktiv = computed(() => {
     const chargeMode = getValue.value(
       'openWB/general/temporary_charge_templates_active'

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -2082,7 +2082,7 @@ export const useMqttStore = defineStore('mqtt', () => {
    * Get temporary charge settings mode selected
    * @returns boolean
    */
-  const temporaryChargeModeAktiv: ComputedRef<boolean> = computed(() => {
+  const temporaryChargeModeActive: ComputedRef<boolean> = computed(() => {
   return (
     getValue.value(
       'openWB/general/temporary_charge_templates_active',
@@ -3935,7 +3935,7 @@ export const useMqttStore = defineStore('mqtt', () => {
     chargePointStateMessage,
     chargePointFaultState,
     chargePointFaultMessage,
-    temporaryChargeModeAktiv,
+    temporaryChargeModeActive,
     chargePointChargeType,
     dcChargingEnabled,
     chargePointConnectedVehicleInfo,

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -2079,6 +2079,28 @@ export const useMqttStore = defineStore('mqtt', () => {
   };
 
   /**
+   * Get scheduled permanent charging plan/s identified by the charge point id
+   * @param chargePointId charge point id
+   * @returns ScheduledChargingPlan[]
+   */
+  const vehicleScheduledChargingPlansPermanent = (chargePointId: number) => {
+    const templateId =
+      chargePointConnectedVehicleChargeTemplate(chargePointId).value?.id;
+    const plans = getValue.value(
+      `openWB/vehicle/template/charge_template/${templateId}`,
+      'chargemode.scheduled_charging.plans',
+    ) as ScheduledChargingPlan[] | undefined;
+    return Array.isArray(plans) ? plans : [];
+  };
+
+  const temporaryChargeModeAktiv = computed(() => {
+    const chargeMode = getValue.value(
+      'openWB/general/temporary_charge_templates_active'
+    ) as boolean | undefined;
+    return chargeMode;
+  });
+
+  /**
    * Helper function to update a subtopic of a time charging plan
    * @param chargePointId charge point id
    * @param planId time charging plan id
@@ -3921,6 +3943,7 @@ export const useMqttStore = defineStore('mqtt', () => {
     chargePointStateMessage,
     chargePointFaultState,
     chargePointFaultMessage,
+    temporaryChargeModeAktiv,
     chargePointChargeType,
     dcChargingEnabled,
     chargePointConnectedVehicleInfo,
@@ -3990,6 +4013,7 @@ export const useMqttStore = defineStore('mqtt', () => {
     vehicleTimeChargingPlanName,
     addTimeChargingPlanForChargePoint,
     removeTimeChargingPlanForChargePoint,
+    vehicleScheduledChargingPlansPermanent,
     vehicleTimeChargingPlanActive,
     vehicleTimeChargingPlanStartTime,
     vehicleTimeChargingPlanEndTime,

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -2080,14 +2080,17 @@ export const useMqttStore = defineStore('mqtt', () => {
 
   /**
    * Get temporary charge settings mode selected
-   * @returns boolean | undefined
+   * @returns boolean
    */
-  const temporaryChargeModeAktiv = computed(() => {
-    const chargeMode = getValue.value(
-      'openWB/general/temporary_charge_templates_active'
-    ) as boolean | undefined;
-    return chargeMode;
-  });
+  const temporaryChargeModeAktiv: ComputedRef<boolean> = computed(() => {
+  return (
+    getValue.value(
+      'openWB/general/temporary_charge_templates_active',
+      undefined,
+      false
+    ) === true
+  );
+});
 
   /**
    * Helper function to update a subtopic of a time charging plan

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -2224,9 +2224,9 @@ export const useMqttStore = defineStore('mqtt', () => {
   };
 
   /**
-   * Get scheduled permanent scheduled charging plan/s identified by the charge point id
+   * Get permanent time charging plan/s identified by the charge point id
    * @param chargePointId charge point id
-   * @returns ScheduledChargingPlan[]
+   * @returns TimeChargingPlan[]
    */
   const vehicleTimeChargingPlansPermanent = (chargePointId: number) => {
     const templateId =
@@ -3005,7 +3005,7 @@ export const useMqttStore = defineStore('mqtt', () => {
   }
 
   /**
-   * Get scheduled permanent scheduled charging plan/s identified by the charge point id
+   * Get permanent scheduled charging plan/s identified by the charge point id
    * @param chargePointId charge point id
    * @returns ScheduledChargingPlan[]
    */

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -2083,14 +2083,14 @@ export const useMqttStore = defineStore('mqtt', () => {
    * @returns boolean
    */
   const temporaryChargeModeActive: ComputedRef<boolean> = computed(() => {
-  return (
-    getValue.value(
-      'openWB/general/temporary_charge_templates_active',
-      undefined,
-      false
-    ) === true
-  );
-});
+    return (
+      getValue.value(
+        'openWB/general/temporary_charge_templates_active',
+        undefined,
+        false,
+      ) === true
+    );
+  });
 
   /**
    * Helper function to update a subtopic of a time charging plan


### PR DESCRIPTION
Wenn „Temporäre Ladeeinstellungen“ aktiviert sind:
	•	In den Ladeplänen wird ein Warnhinweis angezeigt, der den Nutzer darüber informiert, dass Änderungen am Plan nach dem Abstecken des Fahrzeugs verworfen werden.
	•	Wird in diesem Modus ein neuer Plan erstellt, erscheint zusätzlich ein Hinweis, dass der gesamte Plan nach der Ladesession (nach dem Abstecken) verworfen wird.
	•	Unteren  in Plan wird ein Button zur direkten Navigation in die Fahrzeug-Ladeprofil-Einstellungen eingeblendet, damit Änderungen dort dauerhaft verändert werden können.

<img width="370" height="910" alt="Bildschirmfoto 2026-02-17 um 15 45 13" src="https://github.com/user-attachments/assets/ff26f14a-11ab-4d09-88f1-4b8a1a77fef2" />

<img width="378" height="929" alt="Bildschirmfoto 2026-02-17 um 15 45 21" src="https://github.com/user-attachments/assets/e3402afb-6723-4103-8500-a95ca73e963d" />

<img width="371" height="956" alt="Bildschirmfoto 2026-02-17 um 15 45 47" src="https://github.com/user-attachments/assets/73ba828f-5acb-4588-ab9e-857b5ba817e5" />

<img width="374" height="972" alt="Bildschirmfoto 2026-02-17 um 15 45 54" src="https://github.com/user-attachments/assets/a678393d-d74e-48e3-bf44-31517a8e0f11" />

<img width="395" height="671" alt="Bildschirmfoto 2026-02-17 um 15 53 59" src="https://github.com/user-attachments/assets/f827dc82-14ba-4c7b-a2ba-655e50c7de03" />
