### PR TITLE
Koala - Add slot to pass battery SoC to child - SliderDouble

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/BatteryCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BatteryCard.vue
@@ -68,7 +68,9 @@
     </q-card-section>
     <q-separator inset class="q-mt-sm" />
     <q-card-section>
-      <SliderDouble :current-value="soc" :readonly="true" limit-mode="none" />
+      <SliderDouble :current-value="soc" :readonly="true" limit-mode="none">
+        <template #value> {{ soc }}% </template>
+      </SliderDouble>
     </q-card-section>
   </q-card>
   <BatterySettingsDialog :battery-id="props.batteryId" ref="dialog" />

--- a/packages/modules/web_themes/koala/source/src/components/SliderDouble.vue
+++ b/packages/modules/web_themes/koala/source/src/components/SliderDouble.vue
@@ -37,15 +37,19 @@
       <div class="col">
         <div>{{ props.limitMode == 'amount' ? 'Geladen' : 'Ladestand' }}</div>
         <div>
-          {{
-            props.limitMode === 'amount'
-              ? formatEnergy(props.currentValue)
-              : !props.vehicleSocType
-                ? 'Kein SoC-Modul konfiguriert'
-                : props.currentValue + '%'
-          }}
+          <slot name="value">
+            {{
+              props.limitMode === 'amount'
+                ? formatEnergy(props.currentValue)
+                : !props.vehicleSocType
+                  ? 'Kein SoC-Modul konfiguriert'
+                  : props.currentValue + '%'
+            }}
+          </slot>
           <q-icon
-            v-if="props.vehicleSocType === 'manual' && props.limitMode !== 'amount'"
+            v-if="
+              props.vehicleSocType === 'manual' && props.limitMode !== 'amount'
+            "
             name="edit"
             size="xs"
             class="q-ml-xs cursor-pointer"
@@ -54,7 +58,11 @@
             <q-tooltip>Ladestand eingeben</q-tooltip>
           </q-icon>
           <q-icon
-            v-else-if="props.vehicleSocType && props.vehicleSocType !== 'manual' && props.limitMode !== 'amount'"
+            v-else-if="
+              props.vehicleSocType &&
+              props.vehicleSocType !== 'manual' &&
+              props.limitMode !== 'amount'
+            "
             name="refresh"
             size="xs"
             class="q-ml-xs cursor-pointer"


### PR DESCRIPTION
Im BatteryCard wurde der SoC-Wert fälschlicherweise durch den Text „Kein SoC-Modul konfiguriert“ überschrieben.
Grund dafür ist, dass die Logik im SliderDouble auf das Vorhandensein eines vehicleSocType prüft – was im Batterie-Kontext nicht zutrifft.

Es wurde ein benannter Slot (value) im SliderDouble eingeführt, über den der anzeigte Wert bei Bedarf vom Parent überschrieben werden kann.
Der BatteryCard nutzt diesen Slot, um den SoC-Wert direkt darzustellen.

Alternativ wäre es möglich gewesen, die bestehende Logik im SliderDouble über eine zusätzliche Prop (z. B. batteryCard) anzupassen.
Dies hätte jedoch die Komponente weiter an spezifische Anwendungsfälle gekoppelt.

Der Slot-Ansatz wurde gewählt, da er:
	•	die bestehende Standardlogik unverändert lässt
	•	keine zusätzliche Kopplung durch neue Props einführt
	•	eine flexible und saubere Erweiterung ermöglicht

