### PR TITLE
Koala - Add padding to slider - prevent overflow when label at 100%

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/RangeSliderStandard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/RangeSliderStandard.vue
@@ -68,5 +68,6 @@ const maxChanged = computed(() =>
 }
 :deep(.q-range) {
   padding-bottom: 24px;
+  padding-right: 8px;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/RangeSliderStandard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/RangeSliderStandard.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="text-subtitle2">{{ title }}</div>
-    <div class="row items-center justify-between q-ml-sm">
+    <div class="row items-center q-mx-sm">
       <q-range
         v-model="delayedValue"
         :min="props.min"
@@ -12,8 +12,9 @@
         :right-label-color="maxChanged ? 'negative' : 'primary'"
         label
         label-always
+        switch-label-side
         color="primary"
-        class="col"
+        class="col q-pb-xl"
         track-size="0.5em"
         thumb-size="1.7em"
         @touchstart.stop
@@ -58,16 +59,3 @@ const maxChanged = computed(() =>
   delayedValue.value.max !== props.modelValue.max
 )
 </script>
-<style scoped lang="scss">
-:deep(.q-slider__pin) {
-  top: 100%;
-  transform: scaleY(-1);
-}
-:deep(.q-slider__text-container) {
-  transform: scaleY(-1) !important;
-}
-:deep(.q-range) {
-  padding-bottom: 24px;
-  padding-right: 8px;
-}
-</style>


### PR DESCRIPTION
<img width="497" height="363" alt="Bildschirmfoto 2026-03-24 um 10 22 27" src="https://github.com/user-attachments/assets/30a45970-4a1c-4433-a9dd-8ead1b47e3aa" />

<img width="484" height="321" alt="Bildschirmfoto 2026-03-24 um 10 23 22" src="https://github.com/user-attachments/assets/8a5d3adb-8082-4f87-9cc4-d835047999b9" />
