### PR TITLE
Convert range slider label to dynamic text

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/BatterySettingsDialog.vue
+++ b/packages/modules/web_themes/koala/source/src/components/BatterySettingsDialog.vue
@@ -28,7 +28,7 @@
         <BatteryModeButtons />
           <RangeSliderStandard  v-if="batteryMode === 'min_soc_bat_mode'" class="q-pt-md"
             v-model="batteryRange"
-            title="SoC-Grenzen des Speichers % :"
+            title="SoC-Grenzen des Speichers:"
             :min="0"
             :max="100"
             :step="1"

--- a/packages/modules/web_themes/koala/source/src/components/RangeSliderStandard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/RangeSliderStandard.vue
@@ -1,6 +1,17 @@
 <template>
   <div>
-    <div class="text-subtitle2">{{ title }}</div>
+    <div class="row items-center justify-between text-subtitle2">
+      <div>{{ title }}</div>
+      <div class="text-right">
+        <span :class="{ 'text-negative': minChanged }">
+          {{ delayedValue.min }}%
+        </span>
+        –
+        <span :class="{ 'text-negative': maxChanged }">
+          {{ delayedValue.max }}%
+        </span>
+      </div>
+    </div>
     <div class="row items-center q-mx-sm">
       <q-range
         v-model="delayedValue"
@@ -8,11 +19,6 @@
         :max="props.max"
         :step="props.step"
         :markers="props.markers"
-        :left-label-color="minChanged ? 'negative' : 'primary'"
-        :right-label-color="maxChanged ? 'negative' : 'primary'"
-        label
-        label-always
-        switch-label-side
         color="primary"
         class="col q-pb-xl"
         track-size="0.5em"
@@ -31,19 +37,19 @@ import { RangeValue } from '../stores/mqtt-store-model';
 
 const props = withDefaults(
   defineProps<{
-    title?: string
-    modelValue: RangeValue
-    min: number
-    max: number
-    step?: number
-    markers?: boolean | number
+    title?: string;
+    modelValue: RangeValue;
+    min: number;
+    max: number;
+    step?: number;
+    markers?: boolean | number;
   }>(),
   {
     title: '',
     step: 1,
     markers: false,
-  }
-)
+  },
+);
 
 const emit = defineEmits<{
   'update:model-value': [value: RangeValue];
@@ -51,11 +57,11 @@ const emit = defineEmits<{
 
 const { delayedValue } = useDelayModel<RangeValue>(props, emit);
 
-const minChanged = computed(() =>
-  delayedValue.value.min !== props.modelValue.min
-)
+const minChanged = computed(
+  () => delayedValue.value.min !== props.modelValue.min,
+);
 
-const maxChanged = computed(() =>
-  delayedValue.value.max !== props.modelValue.max
-)
+const maxChanged = computed(
+  () => delayedValue.value.max !== props.modelValue.max,
+);
 </script>


### PR DESCRIPTION
Wenn die Werte nah beieinander liegen, überlappen sich die Slider-Labels.
Daher wird stattdessen ein dynamischer Text verwendet.

<img width="496" height="350" alt="Bildschirmfoto 2026-04-07 um 14 33 58" src="https://github.com/user-attachments/assets/8f8271d5-bdbe-468e-bd68-36e3be4238b4" />

<img width="501" height="365" alt="Bildschirmfoto 2026-04-07 um 13 58 06" src="https://github.com/user-attachments/assets/224b8a5b-44f0-455f-9cff-e3d215658714" />
