### PR TITLE
eebus: fix failsafe

### DIFF
--- a/packages/helpermodules/subdata.py
+++ b/packages/helpermodules/subdata.py
@@ -988,7 +988,8 @@ class SubData:
                 index = get_index(msg.topic)
                 if decode_payload(msg.payload) == "":
                     if "io"+index in var:
-                        if var[f"io{index}"].config.configuration.host == "localhost":
+                        if (var[f"io{index}"].config.type == "add_on" and
+                                var[f"io{index}"].config.configuration.host == "localhost"):
                             var.pop("iolocal")
                         var.pop("io"+index)
                     else:

--- a/packages/modules/common/version_by_telnet.py
+++ b/packages/modules/common/version_by_telnet.py
@@ -1,7 +1,11 @@
+import socket
 import telnetlib
 
 
 def get_version_by_telnet(expected_bytearray: str, ip_address: str, port: int = 8898):
+    if ip_address is None:
+        # None liefert einen ValueError genauso wie wenn telnet nicht aktiv ist.
+        raise socket.timeout("Die IP-Adresse ist nicht erreichbar. Bitte überprüfe die Einstellungen.")
     # telnetlib ist ab Python 3.11 deprecated
     with telnetlib.Telnet(ip_address, port, 2) as client:
         answer = client.read_until(bytearray(expected_bytearray, 'utf-8'), 2)

--- a/packages/modules/io_actions/controllable_consumers/dimming/api_eebus.py
+++ b/packages/modules/io_actions/controllable_consumers/dimming/api_eebus.py
@@ -52,12 +52,12 @@ class DimmingEebus(AbstractIoAction):
 
         with ModifyLoglevelContext(control_command_log, logging.DEBUG):
             if check_fault_state_io_device(self.config.configuration.io_device) or self.dimming_active():
+                if check_fault_state_io_device(self.config.configuration.io_device):
+                    control_command_log.info(
+                        "Fehler des IO-Geräts: Dimmen aktiviert für Failsafe-Modus.")
                 if self.timestamp is None:
                     Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", create_timestamp())
-                    if check_fault_state_io_device(self.config.configuration.io_device):
-                        control_command_log.info(
-                            "Fehler des IO-Geräts: Dimmen aktiviert für Failsafe-Modus.")
-                    else:
+                    if check_fault_state_io_device(self.config.configuration.io_device) is False:
                         control_command_log.info(f"Dimmen aktiviert. Übermittelter LPC-Wert: {lpc_value/1000}kWh. "
                                                  "Leistungswerte vor Ausführung des Steuerbefehls:")
 

--- a/packages/modules/io_actions/controllable_consumers/dimming/api_eebus.py
+++ b/packages/modules/io_actions/controllable_consumers/dimming/api_eebus.py
@@ -36,23 +36,28 @@ class DimmingEebus(AbstractIoAction):
         super().__init__()
 
     def setup(self) -> None:
-        lpc_value = data.data.io_states[f"io_states{self.config.configuration.io_device}"
-                                        ].data.get.analog_input[AnalogInputMapping.LPC_VALUE.name]
+
         surplus = calc_dimming_surplus()
-        self.import_power_left = lpc_value + surplus
-        self.import_power_left -= self.config.configuration.fixed_import_power
+        if check_fault_state_io_device(self.config.configuration.io_device):
+            self.import_power_left = surplus
+        else:
+            lpc_value = data.data.io_states[f"io_states{self.config.configuration.io_device}"
+                                            ].data.get.analog_input[AnalogInputMapping.LPC_VALUE.name]
+            self.import_power_left = lpc_value + surplus
+            self.import_power_left -= self.config.configuration.fixed_import_power
         log.debug(
             f"Dimmen: Überschuss von {surplus}W berücksichtigt, verbleibende Dimm-Leistung: {self.import_power_left}W")
 
         with ModifyLoglevelContext(control_command_log, logging.DEBUG):
-            if self.dimming_active() or check_fault_state_io_device(self.config.configuration.io_device):
+            if check_fault_state_io_device(self.config.configuration.io_device) or self.dimming_active():
                 if self.timestamp is None:
                     Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", create_timestamp())
                     if check_fault_state_io_device(self.config.configuration.io_device):
                         control_command_log.info(
                             "Fehler des IO-Geräts: Dimmen aktiviert für Failsafe-Modus.")
-                    control_command_log.info(f"Dimmen aktiviert. Übermittelter LPC-Wert: {lpc_value/1000}kWh. "
-                                             "Leistungswerte vor Ausführung des Steuerbefehls:")
+                    else:
+                        control_command_log.info(f"Dimmen aktiviert. Übermittelter LPC-Wert: {lpc_value/1000}kWh. "
+                                                 "Leistungswerte vor Ausführung des Steuerbefehls:")
 
                 evu_counter = data.data.counter_data[data.data.counter_all_data.get_evu_counter_str()]
                 msg = f"EVU-Zähler: {evu_counter.data.get.powers}W, {evu_counter.data.get.power}W"

--- a/packages/modules/io_actions/controllable_consumers/dimming/api_eebus.py
+++ b/packages/modules/io_actions/controllable_consumers/dimming/api_eebus.py
@@ -43,10 +43,12 @@ class DimmingEebus(AbstractIoAction):
         else:
             lpc_value = data.data.io_states[f"io_states{self.config.configuration.io_device}"
                                             ].data.get.analog_input[AnalogInputMapping.LPC_VALUE.name]
-            self.import_power_left = lpc_value + surplus
-            self.import_power_left -= self.config.configuration.fixed_import_power
-        log.debug(
-            f"Dimmen: Überschuss von {surplus}W berücksichtigt, verbleibende Dimm-Leistung: {self.import_power_left}W")
+            if surplus > 0:
+                self.import_power_left = lpc_value + surplus
+            else:
+                self.import_power_left = lpc_value
+            self.import_power_left = max(0, self.import_power_left - self.config.configuration.fixed_import_power)
+        log.debug(f"Dimmen: {self.import_power_left}W inkl. Überschuss")
 
         with ModifyLoglevelContext(control_command_log, logging.DEBUG):
             if check_fault_state_io_device(self.config.configuration.io_device) or self.dimming_active():

--- a/packages/modules/io_actions/controllable_consumers/dimming/api_io.py
+++ b/packages/modules/io_actions/controllable_consumers/dimming/api_io.py
@@ -52,7 +52,7 @@ class DimmingIo(AbstractIoAction):
             f"Dimmen: Überschuss von {surplus}W berücksichtigt, verbleibende Dimm-Leistung: {self.import_power_left}W")
 
         with ModifyLoglevelContext(control_command_log, logging.DEBUG):
-            if self.dimming_active() or check_fault_state_io_device(self.config.configuration.io_device):
+            if check_fault_state_io_device(self.config.configuration.io_device) or self.dimming_active():
                 if self.timestamp is None:
                     Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", create_timestamp())
                     if check_fault_state_io_device(self.config.configuration.io_device):

--- a/packages/modules/io_actions/generator_systems/stepwise_control/api_eebus.py
+++ b/packages/modules/io_actions/generator_systems/stepwise_control/api_eebus.py
@@ -44,49 +44,50 @@ class StepwiseControlEebus(AbstractIoAction):
 
     def setup(self) -> None:
         with ModifyLoglevelContext(control_command_log, logging.DEBUG):
-            self.lpp_value = data.data.io_states[f"io_states{self.config.configuration.io_device}"
-                                                 ].data.get.analog_input[AnalogInputMapping.LPP_VALUE.name]
-            lpp_value_prev = data.data.io_states[f"io_states{self.config.configuration.io_device}"
-                                                 ].data.get.analog_input_prev[AnalogInputMapping.LPP_VALUE.name]
-            self.lpp_active = data.data.io_states[f"io_states{self.config.configuration.io_device}"
-                                                  ].data.get.digital_input[DigitalInputMapping.LPP_ACTIVE.name]
-            lpp_active_prev = data.data.io_states[f"io_states{self.config.configuration.io_device}"
-                                                  ].data.get.digital_input_prev[DigitalInputMapping.LPP_ACTIVE.name]
-            changed = True if self.lpp_value != lpp_value_prev or self.lpp_active != lpp_active_prev else False
-
-            max_output_inverter = 0
-            for inverter in self.config.configuration.devices:
-                max_output_inverter += data.data.pv_data[f"pv{inverter['id']}"].data.config.max_ac_out
-
-            if self.lpp_active or check_fault_state_io_device(self.config.configuration.io_device):
-                try:
-                    self.step = self.lpp_value / max_output_inverter
-                except ZeroDivisionError:
-                    msg = ("Bitte unter Konfiguration -> Lastmanagement die maximale Ausgangsleistung"
-                           " des Wechselrichters angeben.")
-                    log.exception(msg)
-                    control_command_log.info(msg)
-                    self.step = 0
-                for s in [0, 0.25, 0.5, 0.75, 1.0]:
-                    if self.step <= s:
-                        self.step = s
-                        break
-                if check_fault_state_io_device(self.config.configuration.io_device):
-                    control_command_log.info("Fehler des IO-Geräts: EZA-Begrenzung kann nicht erfasst werden.")
-                if changed:
-                    Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", create_timestamp())
-                    control_command_log.info(f"EEBus-Steuerung: LPP-Wert {self.lpp_value} / "
-                                             f"max. PV-Leistung {max_output_inverter} = {self.step}")
-                    control_command_log.info(f"EZA-Begrenzung mit Wert {self.step*100}% aktiviert.")
-                    for device in self.config.configuration.devices:
-                        control_command_log.info(
-                            f"Erzeugungsanlage {get_component_name_by_id(device)} "
-                            f"auf {self.step*100}% begrenzt."
-                        )
+            if check_fault_state_io_device(self.config.configuration.io_device):
+                control_command_log.info("Fehler des IO-Geräts: EZA-Begrenzung kann nicht erfasst werden.")
             else:
-                if changed:
-                    Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", None)
-                    control_command_log.info("EZA-Begrenzung aufgehoben.")
+                self.lpp_value = data.data.io_states[f"io_states{self.config.configuration.io_device}"
+                                                     ].data.get.analog_input[AnalogInputMapping.LPP_VALUE.name]
+                lpp_value_prev = data.data.io_states[f"io_states{self.config.configuration.io_device}"
+                                                     ].data.get.analog_input_prev[AnalogInputMapping.LPP_VALUE.name]
+                self.lpp_active = data.data.io_states[f"io_states{self.config.configuration.io_device}"
+                                                      ].data.get.digital_input[DigitalInputMapping.LPP_ACTIVE.name]
+                lpp_active_prev = data.data.io_states[f"io_states{self.config.configuration.io_device}"
+                                                      ].data.get.digital_input_prev[DigitalInputMapping.LPP_ACTIVE.name]
+                changed = True if self.lpp_value != lpp_value_prev or self.lpp_active != lpp_active_prev else False
+
+                max_output_inverter = 0
+                for inverter in self.config.configuration.devices:
+                    max_output_inverter += data.data.pv_data[f"pv{inverter['id']}"].data.config.max_ac_out
+
+                if self.lpp_active:
+                    try:
+                        self.step = self.lpp_value / max_output_inverter
+                    except ZeroDivisionError:
+                        msg = ("Bitte unter Konfiguration -> Lastmanagement die maximale Ausgangsleistung"
+                               " des Wechselrichters angeben.")
+                        log.exception(msg)
+                        control_command_log.info(msg)
+                        self.step = 0
+                    for s in [0, 0.25, 0.5, 0.75, 1.0]:
+                        if self.step <= s:
+                            self.step = s
+                            break
+                    if changed:
+                        Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", create_timestamp())
+                        control_command_log.info(f"EEBus-Steuerung: LPP-Wert {self.lpp_value} / "
+                                                 f"max. PV-Leistung {max_output_inverter} = {self.step}")
+                        control_command_log.info(f"EZA-Begrenzung mit Wert {self.step*100}% aktiviert.")
+                        for device in self.config.configuration.devices:
+                            control_command_log.info(
+                                f"Erzeugungsanlage {get_component_name_by_id(device)} "
+                                f"auf {self.step*100}% begrenzt."
+                            )
+                else:
+                    if changed:
+                        Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", None)
+                        control_command_log.info("EZA-Begrenzung aufgehoben.")
 
     def control_stepwise(self) -> Tuple[Optional[float], LoadmanagementLimit]:
         if check_fault_state_io_device(self.config.configuration.io_device):

--- a/packages/modules/io_actions/generator_systems/stepwise_control/api_eebus.py
+++ b/packages/modules/io_actions/generator_systems/stepwise_control/api_eebus.py
@@ -81,7 +81,7 @@ class StepwiseControlEebus(AbstractIoAction):
                         control_command_log.info(f"EZA-Begrenzung mit Wert {self.step*100}% aktiviert.")
                         for device in self.config.configuration.devices:
                             control_command_log.info(
-                                f"Erzeugungsanlage {get_component_name_by_id(device)} "
+                                f"Erzeugungsanlage {get_component_name_by_id(device['id'])} "
                                 f"auf {self.step*100}% begrenzt."
                             )
                 else:

--- a/packages/modules/io_actions/generator_systems/stepwise_control/api_io.py
+++ b/packages/modules/io_actions/generator_systems/stepwise_control/api_io.py
@@ -47,41 +47,43 @@ class StepwiseControlIo(AbstractIoAction):
 
     def setup(self) -> None:
         with ModifyLoglevelContext(control_command_log, logging.DEBUG):
-            digital_input = (
-                data.data.io_states[
-                    f"io_states{self.config.configuration.io_device}"
-                ].data.get.digital_input
-            )
-            digital_input_prev = data.data.io_states[
-                f"io_states{self.config.configuration.io_device}"].data.get.digital_input_prev
-            changed = len([
-                input_name for input_name in self.__unique_inputs
-                if digital_input[input_name] != digital_input_prev[input_name]
-            ]) > 0
-
             if check_fault_state_io_device(self.config.configuration.io_device):
                 control_command_log.info("Fehler des IO-Geräts: EZA-Begrenzung kann nicht erfasst werden.")
-            for pattern in self.config.configuration.input_pattern:
-                for action_input, value in pattern["matrix"].items():
-                    if digital_input[action_input] != value:
-                        break
-                else:
-                    # Alle digitalen Eingänge entsprechen dem Pattern
-                    if pattern["value"] != 1:
-                        if changed:
-                            Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", create_timestamp())
-                            control_command_log.info(f"EZA-Begrenzung mit Wert {int(pattern['value']*100)}% aktiviert.")
-                            for device in self.config.configuration.devices:
-                                if device["type"] == "inverter":
-                                    control_command_log.info(
-                                        f"Erzeugungsanlage {get_component_name_by_id(device['id'])} "
-                                        f"auf {int(pattern['value']*100)}% begrenzt."
-                                    )
-                        break
             else:
-                if changed:
-                    Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", None)
-                    control_command_log.info("EZA-Begrenzung aufgehoben.")
+                digital_input = (
+                    data.data.io_states[
+                        f"io_states{self.config.configuration.io_device}"
+                    ].data.get.digital_input
+                )
+                digital_input_prev = data.data.io_states[
+                    f"io_states{self.config.configuration.io_device}"].data.get.digital_input_prev
+                changed = len([
+                    input_name for input_name in self.__unique_inputs
+                    if digital_input[input_name] != digital_input_prev[input_name]
+                ]) > 0
+
+                for pattern in self.config.configuration.input_pattern:
+                    for action_input, value in pattern["matrix"].items():
+                        if digital_input[action_input] != value:
+                            break
+                    else:
+                        # Alle digitalen Eingänge entsprechen dem Pattern
+                        if pattern["value"] != 1:
+                            if changed:
+                                Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", create_timestamp())
+                                control_command_log.info(
+                                    f"EZA-Begrenzung mit Wert {int(pattern['value']*100)}% aktiviert.")
+                                for device in self.config.configuration.devices:
+                                    if device["type"] == "inverter":
+                                        control_command_log.info(
+                                            f"Erzeugungsanlage {get_component_name_by_id(device['id'])} "
+                                            f"auf {int(pattern['value']*100)}% begrenzt."
+                                        )
+                            break
+                else:
+                    if changed:
+                        Pub().pub(f"openWB/set/io/action/{self.config.id}/timestamp", None)
+                        control_command_log.info("EZA-Begrenzung aufgehoben.")
 
     def control_stepwise(self) -> Tuple[Optional[float], LoadmanagementLimit]:
         if check_fault_state_io_device(self.config.configuration.io_device):


### PR DESCRIPTION
- Bei der Dimmung wird im Failsafe-Mode die Leistung zur Verfügung gestellt, die auch bei Aktivierung durch den Netzbetreiber zur Verfügung stehen würde.
Der Nutzer bekommt eine Meldung am Ladepunkt, dass seine Ladung gestoppt/reduziert wurde, weil das IO-Gerät im Fehlerzustand ist.
- Fehler beim Löschen des IO-Gerätes behoben
- Fehlermeldung verbessert, wenn als IP none eingetragen ist

Dimmen per EMS über EEBus
- [x]  Aktion aktiv
- [x]  Aktion inaktiv
- [x]  Gerät Fehler ab Einrichtung
- [x] Gerät Fehler im Betrieb

Dimmen per EMS über IO
- [x]  Aktion aktiv
- [x]  Aktion inaktiv
- [x]  Gerät Fehler ab Einrichtung
- [x] Gerät Fehler im Betrieb

Erzeuger über EEBus

- [x]  Aktion aktiv
- [x]  Aktion inaktiv
- [x]  Gerät Fehler ab Einrichtung
- [x] Gerät Fehler im Betrieb

Erzeuger über IO

- [ ]  Aktion aktiv
- [x]  Aktion inaktiv
- [x]  Gerät Fehler ab Einrichtung
- [x] Gerät Fehler im Betrieb
