### PR TITLE
active bat control: improve log messages

### DIFF
--- a/packages/control/bat_all.py
+++ b/packages/control/bat_all.py
@@ -118,7 +118,7 @@ class Set:
     regulate_up: bool = field(default=False, metadata={"topic": "set/regulate_up"})
     hysteresis_discharge: bool = field(default=False, metadata={"topic": "set/hysteresis_discharge"})
     current_state: str = field(default=CurrentState.STARTUP.value, metadata={"topic": "set/current_state"})
-    set_limit: bool = field(default=False, metadata={"topic": "set/set_limit"})
+    set_limit: bool = False
 
 
 def set_factory() -> Set:
@@ -237,20 +237,21 @@ class BatAll:
         bat_ready_to_charge = 0
         max_discharge_power_total = 0
         bat_ready_to_discharge = 0
-        for bat_component in controllable_bat_components:
-            bat_component_data = data.data.bat_data[f"bat{bat_component.component_config.id}"].data
-            if bat_component_data.get.soc < self.data.config.bat_control_max_soc:
-                max_charge_power_total += bat_component_data.get.max_charge_power
-                bat_ready_to_charge += 1
-            if bat_component_data.get.soc > self.data.config.bat_control_min_soc:
-                max_discharge_power_total += bat_component_data.get.max_discharge_power
-                bat_ready_to_discharge += 1
-        log.debug((f"Aktive Speichersteuerung: {power}W auf "
-                   f"{len(controllable_bat_components)} regelbare Speicher verteilen."))
-        log.debug((f"Ladung: {bat_ready_to_charge} Speicher unterhalb des maximalen SoC mit "
-                   f"{max_charge_power_total}W regelbarer Lade-Leistung"))
-        log.debug((f"Entladung: {bat_ready_to_discharge} Speicher oberhalb des minimalen SoC mit "
-                   f"{max_discharge_power_total}W regelbarer Entlade-Leistung"))
+        if power is not None:
+            for bat_component in controllable_bat_components:
+                bat_component_data = data.data.bat_data[f"bat{bat_component.component_config.id}"].data
+                if bat_component_data.get.soc < self.data.config.bat_control_max_soc:
+                    max_charge_power_total += bat_component_data.get.max_charge_power
+                    bat_ready_to_charge += 1
+                if bat_component_data.get.soc > self.data.config.bat_control_min_soc:
+                    max_discharge_power_total += bat_component_data.get.max_discharge_power
+                    bat_ready_to_discharge += 1
+            log.debug((f"Aktive Speichersteuerung: {power}W auf "
+                       f"{len(controllable_bat_components)} regelbare Speicher verteilen."))
+            log.debug((f"Ladung: {bat_ready_to_charge} Speicher unterhalb des maximalen SoC mit "
+                       f"{max_charge_power_total}W regelbarer Lade-Leistung"))
+            log.debug((f"Entladung: {bat_ready_to_discharge} Speicher oberhalb des minimalen SoC mit "
+                       f"{max_discharge_power_total}W regelbarer Entlade-Leistung"))
 
         # Leistung an einzelne Speicher übergeben
         for bat_component in controllable_bat_components:
@@ -259,13 +260,13 @@ class BatAll:
             if power is None:
                 power_limit = None
                 bat_component_data.get.state_str = "Keine Steuerung"
-                log.debug(("Aktive Speichersteuerung: Eigenregelung - Speicher "
-                          f"(ID: {bat_component.component_config.id}) auf Eigenregelung gesetzt."))
+                log.debug(("Speichersteuerung: Eigenregelung - Speicher "
+                          f"(ID: {bat_component.component_config.id}) regelt selbst."))
             elif power == 0:
                 power_limit = 0
                 bat_component_data.get.state_str = "Entladesperre"
                 log.debug((f"Aktive Speichersteuerung: Kein Laden/Entladen - "
-                           f"Speicher (ID: {bat_component.component_config.id}) auf 0W gesetzt."))
+                           f"0W für Speicher (ID: {bat_component.component_config.id})."))
             elif power < 0:
                 # Eigenregelung aller Speicher, da Entladung nicht möglich
                 if max_discharge_power_total == 0:
@@ -273,7 +274,7 @@ class BatAll:
                     bat_component_data.get.state_str = ("Keine Steuerung - alle Speicher "
                                                         "befinden sich unterhalb minimal SoC")
                     log.debug(("Aktive Speichersteuerung: Entladung - alle Speicher befinden sich unterhalb minimal "
-                               f"SoC. Speicher (ID: {bat_component.component_config.id}) auf Eigenregelung gesetzt."))
+                               f"SoC. Eigenregelung des Speichers (ID: {bat_component.component_config.id})"))
                 else:
                     # unterhalb des minimal SoC greift die Eigenregelung
                     # das verhindert Tiefenentladung
@@ -283,7 +284,7 @@ class BatAll:
                                                             "befindet sich unterhalb minimal SoC")
                         log.debug(("Aktive Speichersteuerung: Entladung - "
                                    f"Speicher (ID: {bat_component.component_config.id}) "
-                                   "befindet sich unterhalb minimal SoC - auf Eigenregelung gesetzt."))
+                                   "befindet sich unterhalb minimal SoC - Eigenregelung des Speichers."))
                     # setze Entladeleistung als Bruchteil der möglichen Entladeleistung
                     else:
                         factor = min(power / max_discharge_power_total, 1)
@@ -291,8 +292,8 @@ class BatAll:
                         bat_component_data.get.state_str = f"Entladung mit {round(power_limit / 1000, 3)} kW"
                         log.debug(("Aktive Speichersteuerung: Entladung - "
                                    f"Speicher (ID: {bat_component.component_config.id}) "
-                                   f"entlädt mit {power_limit} ({factor} x "
-                                   f"{bat_component_data.get.max_discharge_power})"))
+                                   f"entladen mit {power_limit} ({factor} x "
+                                   f"{bat_component_data.get.max_discharge_power}) W"))
             else:
                 # oberhalb des max_soc soll Speicher nicht entladen wenn andere Speicher laden
                 if bat_component_data.get.soc >= self.data.config.bat_control_max_soc:
@@ -308,9 +309,8 @@ class BatAll:
                     bat_component_data.get.state_str = f"Ladung mit {round(power_limit / 1000, 3)} kW "
                     log.debug(("Aktive Speichersteuerung: Ladung - "
                                f"Speicher (ID: {bat_component.component_config.id}) "
-                               f"lädt mit {power_limit} ({factor} x {bat_component_data.get.max_charge_power})"))
+                               f"laden mit {power_limit} ({factor} x {bat_component_data.get.max_charge_power}) W"))
             data.data.bat_data[f"bat{bat_component.component_config.id}"].data.set.power_limit = power_limit
-            log.debug(f"Power Limit {power_limit}W an Speicher übergeben!")
 
     def setup_bat(self):
         """ prüft, ob mind ein Speicher vorhanden ist und berechnet die Summen-Topics.

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -687,6 +687,8 @@ class SetData:
                 self._validate_value(msg, int, [(0, 100)])
             elif "openWB/set/bat/set/charging_power_left" in msg.topic:
                 self._validate_value(msg, float)
+            elif "openWB/set/bat/set/current_state" in msg.topic:
+                self._validate_value(msg, str)
             elif "openWB/set/bat/get/soc" in msg.topic:
                 self._validate_value(msg, float, [(0, 100)])
             elif ("openWB/set/bat/get/power" in msg.topic or


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?p=141992#p141992
Die Threads, die die Modbus-Register beschreiben, werden nicht mehr ausgeführt. Die Logmeldungen, während der Zustand der aktiven Speichersteuerung festgestellt wird, lesen sich allerdings so, als würde da aktiv in den Speicher geschrieben werden.

Metadaten von set_limit entfernt, da es keinen Eintrag in setdata gab und der Wert daher nicht im Broker gelandet ist.

MQTT-Speicher:
- [x] Speichersteuerung aktiv: sendet Topic
- [x] Speichersteuerung deaktiviert: sendet kein Topic
- [x] Speichersteuerung deaktiviert, Neustart: sendet kein Topic
- [x] Zustimmung zur Speichersteuerung verweigert, Speichersteuerung aktiv: sendet kein Topic