### PR TITLE
Solis Hybridwechselrichter S-Serie

### DIFF
--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -30,6 +30,7 @@ class SolisBat(AbstractBat):
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
         self.version: SolisVersion = self.kwargs['version']
+        self.sim_counter = SimCounter(self.component_config.id)
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
@@ -39,7 +40,7 @@ class SolisBat(AbstractBat):
 
         power = self.client.read_input_registers(33149, ModbusDataType.INT_32, unit=unit)
         soc = self.client.read_input_registers(33139, ModbusDataType.UINT_16, unit=unit)
-        bat_current = self.__tcp_client.read_input_registers(33134, ModbusDataType.INT_16, unit=unit) * -0.1
+        bat_current = self.client.read_input_registers(33134, ModbusDataType.INT_16, unit=unit) * -0.1
 
         currents = [bat_current / 3] * 3
 
@@ -58,26 +59,26 @@ class SolisBat(AbstractBat):
         unit = self.component_config.configuration.modbus_id
 
         if power_limit is None:
-            self.__tcp_client.write_register(43135, 0, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.client.write_register(43135, 0, data_type=ModbusDataType.UINT_16, unit=unit)
             log.debug("Keine Batteriesteuerung, Selbstregelung durch Wechselrichter")
         elif power_limit == 0:
-            self.__tcp_client.write_register(43135, 1, data_type=ModbusDataType.UINT_16, unit=unit)
-            self.__tcp_client.write_register(43136, 0, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.client.write_register(43135, 1, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.client.write_register(43136, 0, data_type=ModbusDataType.UINT_16, unit=unit)
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht geladen/entladen")
         elif power_limit < 0:
-            self.__tcp_client.write_register(43135, 2, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.client.write_register(43135, 2, data_type=ModbusDataType.UINT_16, unit=unit)
             power_value = int(power_limit / 10)
-            self.__tcp_client.write_register(43129, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.client.write_register(43129, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
         elif power_limit > 0:
-            self.__tcp_client.write_register(43135, 1, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.client.write_register(43135, 1, data_type=ModbusDataType.UINT_16, unit=unit)
             power_value = int(power_limit / 10)
-            self.__tcp_client.write_register(43136, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.client.write_register(43136, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W geladen")
 
     def power_limit_controllable(self) -> bool:
         # Nur die S-Serie sollte die Speichersteuerung können
-        return self.solis_version == SolisVersion.hybrid_s
+        return self.version == SolisVersion.hybrid_s
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolisBatSetup)

--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -7,6 +7,7 @@ from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
+from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.solis.solis.config import SolisBatSetup
 from modules.common.utils.peak_filter import PeakFilter
@@ -35,19 +36,44 @@ class SolisBat(AbstractBat):
 
         power = self.client.read_input_registers(33149, ModbusDataType.INT_32, unit=unit)
         soc = self.client.read_input_registers(33139, ModbusDataType.UINT_16, unit=unit)
-        # Geladen in kWh
-        imported = self.client.read_input_registers(33161, ModbusDataType.UINT_32, unit=unit) * 1000
-        # Entladen in kWh
-        exported = self.client.read_input_registers(33165, ModbusDataType.UINT_32, unit=unit) * 1000
+        bat_current = self.__tcp_client.read_input_registers(33134, ModbusDataType.INT_16, unit=unit) * -0.1
 
-        imported, exported = self.peak_filter.check_values(power, imported, exported)
+        currents = [bat_current / 3] * 3
+
+        self.peak_filter.check_values(power)
+        imported, exported = self.sim_counter.sim_count(power)
         bat_state = BatState(
             power=power,
             soc=soc,
+            currents=currents,
             imported=imported,
             exported=exported
         )
         self.store.set(bat_state)
+
+    def set_power_limit(self, power_limit: Optional[int]) -> None:
+        unit = self.component_config.configuration.modbus_id
+
+        if power_limit is None:
+            self.__tcp_client.write_register(43135, 0, data_type=ModbusDataType.UINT_16, unit=unit)
+            log.debug("Keine Batteriesteuerung, Selbstregelung durch Wechselrichter")
+        elif power_limit == 0:
+            self.__tcp_client.write_register(43135, 1, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.__tcp_client.write_register(43136, 0, data_type=ModbusDataType.UINT_16, unit=unit)
+            log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht geladen/entladen")
+        elif power_limit < 0:
+            self.__tcp_client.write_register(43135, 2, data_type=ModbusDataType.UINT_16, unit=unit)
+            power_value = int(power_limit / 10)
+            self.__tcp_client.write_register(43129, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
+            log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
+        elif power_limit > 0:
+            self.__tcp_client.write_register(43135, 1, data_type=ModbusDataType.UINT_16, unit=unit)
+            power_value = int(power_limit / 10)
+            self.__tcp_client.write_register(43136, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
+            log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W geladen")
+
+    def power_limit_controllable(self) -> bool:
+        return True
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolisBatSetup)

--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import logging
-from typing import TypedDict, Any
+from typing import TypedDict, Any, Optional
 
 from modules.common.abstract_device import AbstractBat
 from modules.common.component_state import BatState
@@ -10,6 +10,7 @@ from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_bat_value_store
 from modules.devices.solis.solis.config import SolisBatSetup
+from modules.devices.solis.solis.version import SolisVersion
 from modules.common.utils.peak_filter import PeakFilter
 from modules.common.component_type import ComponentType
 
@@ -18,6 +19,7 @@ log = logging.getLogger(__name__)
 
 class KwargsDict(TypedDict):
     client: ModbusTcpClient_
+    version: SolisVersion
 
 
 class SolisBat(AbstractBat):
@@ -27,6 +29,7 @@ class SolisBat(AbstractBat):
 
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
+        self.version: SolisVersion = self.kwargs['version']
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
@@ -73,7 +76,8 @@ class SolisBat(AbstractBat):
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W geladen")
 
     def power_limit_controllable(self) -> bool:
-        return True
+        # Nur die S-Serie sollte die Speichersteuerung können
+        return self.solis_version == SolisVersion.hybrid_s
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolisBatSetup)

--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -68,7 +68,7 @@ class SolisBat(AbstractBat):
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht geladen/entladen")
         elif power_limit < 0:
             self.client.write_register(43135, 2, data_type=ModbusDataType.UINT_16, unit=unit)
-            power_value = int(power_limit / 10)
+            power_value = int(abs(power_limit) / 10)
             self.client.write_register(43129, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
         elif power_limit > 0:

--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -43,7 +43,8 @@ class SolisBat(AbstractBat):
 
         currents = [bat_current / 3] * 3
 
-        imported, exported = self.peak_filter.check_values(power, imported, exported)
+        self.peak_filter.check_values(power)
+        imported, exported = self.sim_counter.sim_count(power)
         bat_state = BatState(
             power=power,
             soc=soc,

--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 class KwargsDict(TypedDict):
     client: ModbusTcpClient_
-    version: SolisVersion
+    device_id: int
 
 
 class SolisBat(AbstractBat):
@@ -29,8 +29,7 @@ class SolisBat(AbstractBat):
 
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
-        self.version: SolisVersion = self.kwargs['version']
-        self.sim_counter = SimCounter(self.component_config.id)
+        self.sim_counter = SimCounter(self.kwargs['device_id'], self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
@@ -78,7 +77,7 @@ class SolisBat(AbstractBat):
 
     def power_limit_controllable(self) -> bool:
         # Nur die S-Serie sollte die Speichersteuerung können
-        return self.version == SolisVersion.hybrid_s
+        return SolisVersion(self.component_config.configuration.version) == SolisVersion.hybrid_s
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolisBatSetup)

--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 class KwargsDict(TypedDict):
     client: ModbusTcpClient_
     device_id: int
+    version: SolisVersion
 
 
 class SolisBat(AbstractBat):
@@ -29,6 +30,7 @@ class SolisBat(AbstractBat):
 
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
+        self.version: SolisVersion = self.kwargs['version']
         self.sim_counter = SimCounter(self.kwargs['device_id'], self.component_config.id, prefix="speicher")
         self.store = get_bat_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
@@ -77,7 +79,7 @@ class SolisBat(AbstractBat):
 
     def power_limit_controllable(self) -> bool:
         # Nur die S-Serie sollte die Speichersteuerung können
-        return SolisVersion(self.component_config.configuration.version) == SolisVersion.hybrid_s
+        return self.version == SolisVersion.hybrid_s
 
 
 component_descriptor = ComponentDescriptor(configuration_factory=SolisBatSetup)

--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -43,8 +43,7 @@ class SolisBat(AbstractBat):
 
         currents = [bat_current / 3] * 3
 
-        self.peak_filter.check_values(power)
-        imported, exported = self.sim_counter.sim_count(power)
+        imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(
             power=power,
             soc=soc,

--- a/packages/modules/devices/solis/solis/counter.py
+++ b/packages/modules/devices/solis/solis/counter.py
@@ -13,7 +13,6 @@ from modules.common.component_type import ComponentType
 
 class KwargsDict(TypedDict):
     client: ModbusTcpClient_
-    version: SolisVersion
 
 
 class SolisCounter:
@@ -23,18 +22,16 @@ class SolisCounter:
 
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
-        self.version: SolisVersion = self.kwargs['version']
         self.store = get_counter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
-        self.version = self.kwargs['version']
-        self.client = self.kwargs['client']
         self.peak_filter = PeakFilter(ComponentType.COUNTER, self.component_config.id, self.fault_state)
 
     def update(self):
         unit = self.component_config.configuration.modbus_id
+        version = SolisVersion(self.component_config.configuration.version)
 
         register_offset = 30000
-        if self.version == SolisVersion.inverter:
+        if version == SolisVersion.inverter:
             register_offset = -1
 
         power = self.client.read_input_registers(3263 + register_offset, ModbusDataType.INT_32, unit=unit) * -1

--- a/packages/modules/devices/solis/solis/counter.py
+++ b/packages/modules/devices/solis/solis/counter.py
@@ -13,6 +13,7 @@ from modules.common.component_type import ComponentType
 
 class KwargsDict(TypedDict):
     client: ModbusTcpClient_
+    version: SolisVersion
 
 
 class SolisCounter:
@@ -22,16 +23,16 @@ class SolisCounter:
 
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
+        self.version: SolisVersion = self.kwargs['version']
         self.store = get_counter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.peak_filter = PeakFilter(ComponentType.COUNTER, self.component_config.id, self.fault_state)
 
     def update(self):
         unit = self.component_config.configuration.modbus_id
-        version = SolisVersion(self.component_config.configuration.version)
 
         register_offset = 30000
-        if version == SolisVersion.inverter:
+        if self.version == SolisVersion.inverter:
             register_offset = -1
 
         power = self.client.read_input_registers(3263 + register_offset, ModbusDataType.INT_32, unit=unit) * -1

--- a/packages/modules/devices/solis/solis/device.py
+++ b/packages/modules/devices/solis/solis/device.py
@@ -10,7 +10,6 @@ from modules.devices.solis.solis.bat import SolisBat
 from modules.devices.solis.solis.counter import SolisCounter
 from modules.devices.solis.solis.inverter import SolisInverter
 from modules.devices.solis.solis.config import Solis, SolisBatSetup, SolisCounterSetup, SolisInverterSetup
-from modules.devices.solis.solis.version import SolisVersion
 
 log = logging.getLogger(__name__)
 
@@ -20,17 +19,15 @@ def create_device(device_config: Solis):
 
     def create_bat_component(component_config: SolisBatSetup):
         nonlocal client
-        return SolisBat(component_config, client=client)
-
+        return SolisBat(component_config, client=client, device_id=device_config.id)
+ 
     def create_counter_component(component_config: SolisCounterSetup):
         nonlocal client
-        return SolisCounter(component_config, version=SolisVersion(device_config.configuration.version), client=client)
-
+        return SolisCounter(component_config, client=client)
+ 
     def create_inverter_component(component_config: SolisInverterSetup):
         nonlocal client
-        return SolisInverter(component_config,
-                             version=SolisVersion(device_config.configuration.version),
-                             client=client)
+        return SolisInverter(component_config, client=client, device_id=device_config.id)
 
     def update_components(components: Iterable[Union[SolisBat, SolisCounter, SolisInverter]]):
         nonlocal client

--- a/packages/modules/devices/solis/solis/device.py
+++ b/packages/modules/devices/solis/solis/device.py
@@ -23,11 +23,11 @@ def create_device(device_config: Solis):
 
     def create_counter_component(component_config: SolisCounterSetup):
         nonlocal client
-        return SolisCounter(component_config, client=client)
+        return SolisCounter(component_config, client=client, version=device_config.configuration.version)
 
     def create_inverter_component(component_config: SolisInverterSetup):
         nonlocal client
-        return SolisInverter(component_config, client=client, device_id=device_config.id)
+        return SolisInverter(component_config, client=client, device_id=device_config.id, version=device_config.configuration.version)
 
     def update_components(components: Iterable[Union[SolisBat, SolisCounter, SolisInverter]]):
         nonlocal client

--- a/packages/modules/devices/solis/solis/device.py
+++ b/packages/modules/devices/solis/solis/device.py
@@ -19,7 +19,10 @@ def create_device(device_config: Solis):
 
     def create_bat_component(component_config: SolisBatSetup):
         nonlocal client
-        return SolisBat(component_config, client=client, device_id=device_config.id)
+        return SolisBat(component_config,
+                        client=client,
+                        device_id=device_config.id,
+                        version=device_config.configuration.version)
 
     def create_counter_component(component_config: SolisCounterSetup):
         nonlocal client

--- a/packages/modules/devices/solis/solis/device.py
+++ b/packages/modules/devices/solis/solis/device.py
@@ -27,7 +27,10 @@ def create_device(device_config: Solis):
 
     def create_inverter_component(component_config: SolisInverterSetup):
         nonlocal client
-        return SolisInverter(component_config, client=client, device_id=device_config.id, version=device_config.configuration.version)
+        return SolisInverter(component_config,
+                             client=client,
+                             device_id=device_config.id,
+                             version=device_config.configuration.version)
 
     def update_components(components: Iterable[Union[SolisBat, SolisCounter, SolisInverter]]):
         nonlocal client

--- a/packages/modules/devices/solis/solis/device.py
+++ b/packages/modules/devices/solis/solis/device.py
@@ -20,11 +20,11 @@ def create_device(device_config: Solis):
     def create_bat_component(component_config: SolisBatSetup):
         nonlocal client
         return SolisBat(component_config, client=client, device_id=device_config.id)
- 
+
     def create_counter_component(component_config: SolisCounterSetup):
         nonlocal client
         return SolisCounter(component_config, client=client)
- 
+
     def create_inverter_component(component_config: SolisInverterSetup):
         nonlocal client
         return SolisInverter(component_config, client=client, device_id=device_config.id)

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -26,6 +26,7 @@ class SolisInverter:
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
         self.version: SolisVersion = self.kwargs['version']
+        self.sim_counter = SimCounter(self.component_config.id)
         self.store = get_inverter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.peak_filter = PeakFilter(ComponentType.INVERTER, self.component_config.id, self.fault_state)
@@ -35,10 +36,10 @@ class SolisInverter:
 
         if self.version == SolisVersion.inverter:
             power = self.client.read_input_registers(3004, ModbusDataType.UINT_32, unit=unit) * -1
-            currents = self.__tcp_client.read_input_registers(3037, [ModbusDataType.UINT_16]*3, unit=unit)
+            currents = self.client.read_input_registers(3037, [ModbusDataType.UINT_16]*3, unit=unit)
         elif self.version in (SolisVersion.hybrid, SolisVersion.hybrid_s):
             power = self.client.read_input_registers(33057, ModbusDataType.UINT_32, unit=unit) * -1
-            currents = self.__tcp_client.read_input_registers(33076, [ModbusDataType.UINT_16]*3, unit=unit)
+            currents = self.client.read_input_registers(33076, [ModbusDataType.UINT_16]*3, unit=unit)
 
         currents = [value * -0.1 for value in currents]
 

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -5,6 +5,7 @@ from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
 from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.modbus import ModbusDataType, ModbusTcpClient_
+from modules.common.simcount import SimCounter
 from modules.common.store import get_inverter_value_store
 from modules.devices.solis.solis.config import SolisInverterSetup
 from modules.devices.solis.solis.version import SolisVersion

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -34,14 +34,19 @@ class SolisInverter:
 
         if self.version == SolisVersion.inverter:
             power = self.client.read_input_registers(3004, ModbusDataType.UINT_32, unit=unit) * -1
-            exported = self.client.read_input_registers(3008, ModbusDataType.UINT_32, unit=unit) * 1000
-        elif self.version == SolisVersion.hybrid:
+            currents = self.__tcp_client.read_input_registers(3037, [ModbusDataType.UINT_16]*3, unit=unit)
+        elif self.version in (SolisVersion.hybrid, SolisVersion.hybrid_s):
             power = self.client.read_input_registers(33057, ModbusDataType.UINT_32, unit=unit) * -1
-            exported = self.client.read_input_registers(33029, ModbusDataType.UINT_32, unit=unit) * 1000
+            currents = self.__tcp_client.read_input_registers(33076, [ModbusDataType.UINT_16]*3, unit=unit)
 
-        _, exported = self.peak_filter.check_values(power, None, exported)
+        currents = [value * -0.1 for value in currents]
+
+        self.peak_filter.check_values(power)
+        imported, exported = self.sim_counter.sim_count(power)
         inverter_state = InverterState(
             power=power,
+            currents=currents,
+            imported=imported,
             exported=exported
         )
         self.store.set(inverter_state)

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -35,18 +35,22 @@ class SolisInverter:
         unit = self.component_config.configuration.modbus_id
 
         if self.version == SolisVersion.inverter:
-            power = self.client.read_input_registers(3004, ModbusDataType.UINT_32, unit=unit) * -1
-            currents = self.client.read_input_registers(3037, [ModbusDataType.UINT_16]*3, unit=unit)
+            # Für Stringwechselrichter -1 bei Modbus Registers
+            power = self.client.read_input_registers(3004, ModbusDataType.INT_32, unit=unit) * -1
+            dc_power = self.client.read_input_registers(3006, ModbusDataType.UINT_32, unit=unit) * -1
+            currents = self.client.read_input_registers(3036, [ModbusDataType.UINT_16]*3, unit=unit)
         elif self.version in (SolisVersion.hybrid, SolisVersion.hybrid_s):
-            power = self.client.read_input_registers(33057, ModbusDataType.UINT_32, unit=unit) * -1
+            power = self.client.read_input_registers(33079, ModbusDataType.INT_32, unit=unit) * -1
+            dc_power = self.client.read_input_registers(33057, ModbusDataType.UINT_32, unit=unit) * -1
             currents = self.client.read_input_registers(33076, [ModbusDataType.UINT_16]*3, unit=unit)
 
         currents = [value * -0.1 for value in currents]
 
         self.peak_filter.check_values(power)
-        imported, exported = self.sim_counter.sim_count(power)
+        imported, exported = self.sim_counter.sim_count(power, dc_power)
         inverter_state = InverterState(
             power=power,
+            dc_power=dc_power,
             currents=currents,
             imported=imported,
             exported=exported

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -46,7 +46,8 @@ class SolisInverter:
 
         currents = [value * -0.1 for value in currents]
 
-        imported, exported = self.peak_filter.check_values(power, imported, exported)
+        self.peak_filter.check_values(power)
+        imported, exported = self.sim_counter.sim_count(power)
         inverter_state = InverterState(
             power=power,
             dc_power=dc_power,

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -15,7 +15,7 @@ from modules.common.component_type import ComponentType
 
 class KwargsDict(TypedDict):
     client: ModbusTcpClient_
-    version: SolisVersion
+    device_id: int
 
 
 class SolisInverter:
@@ -25,21 +25,21 @@ class SolisInverter:
 
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
-        self.version: SolisVersion = self.kwargs['version']
-        self.sim_counter = SimCounter(self.component_config.id)
+        self.sim_counter = SimCounter(self.kwargs['device_id'], self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
         self.peak_filter = PeakFilter(ComponentType.INVERTER, self.component_config.id, self.fault_state)
 
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
+        version = SolisVersion(self.component_config.configuration.version)
 
-        if self.version == SolisVersion.inverter:
+        if version == SolisVersion.inverter:
             # Für Stringwechselrichter -1 bei Modbus Registers
             power = self.client.read_input_registers(3004, ModbusDataType.INT_32, unit=unit) * -1
             dc_power = self.client.read_input_registers(3006, ModbusDataType.UINT_32, unit=unit) * -1
             currents = self.client.read_input_registers(3036, [ModbusDataType.UINT_16]*3, unit=unit)
-        elif self.version in (SolisVersion.hybrid, SolisVersion.hybrid_s):
+        elif version in (SolisVersion.hybrid, SolisVersion.hybrid_s):
             power = self.client.read_input_registers(33079, ModbusDataType.INT_32, unit=unit) * -1
             dc_power = self.client.read_input_registers(33057, ModbusDataType.UINT_32, unit=unit) * -1
             currents = self.client.read_input_registers(33076, [ModbusDataType.UINT_16]*3, unit=unit)
@@ -47,7 +47,7 @@ class SolisInverter:
         currents = [value * -0.1 for value in currents]
 
         self.peak_filter.check_values(power)
-        imported, exported = self.sim_counter.sim_count(power, dc_power)
+        imported, exported = self.sim_counter.sim_count(power)
         inverter_state = InverterState(
             power=power,
             dc_power=dc_power,

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -16,6 +16,7 @@ from modules.common.component_type import ComponentType
 class KwargsDict(TypedDict):
     client: ModbusTcpClient_
     device_id: int
+    version: SolisVersion
 
 
 class SolisInverter:
@@ -25,6 +26,7 @@ class SolisInverter:
 
     def initialize(self) -> None:
         self.client: ModbusTcpClient_ = self.kwargs['client']
+        self.version: SolisVersion = self.kwargs['version']
         self.sim_counter = SimCounter(self.kwargs['device_id'], self.component_config.id, prefix="pv")
         self.store = get_inverter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
@@ -32,14 +34,13 @@ class SolisInverter:
 
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
-        version = SolisVersion(self.component_config.configuration.version)
 
-        if version == SolisVersion.inverter:
+        if self.version == SolisVersion.inverter:
             # Für Stringwechselrichter -1 bei Modbus Registers
             power = self.client.read_input_registers(3004, ModbusDataType.INT_32, unit=unit) * -1
             dc_power = self.client.read_input_registers(3006, ModbusDataType.UINT_32, unit=unit) * -1
             currents = self.client.read_input_registers(3036, [ModbusDataType.UINT_16]*3, unit=unit)
-        elif version in (SolisVersion.hybrid, SolisVersion.hybrid_s):
+        elif self.version in (SolisVersion.hybrid, SolisVersion.hybrid_s):
             power = self.client.read_input_registers(33079, ModbusDataType.INT_32, unit=unit) * -1
             dc_power = self.client.read_input_registers(33057, ModbusDataType.UINT_32, unit=unit) * -1
             currents = self.client.read_input_registers(33076, [ModbusDataType.UINT_16]*3, unit=unit)

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -46,8 +46,7 @@ class SolisInverter:
 
         currents = [value * -0.1 for value in currents]
 
-        self.peak_filter.check_values(power)
-        imported, exported = self.sim_counter.sim_count(power)
+        imported, exported = self.peak_filter.check_values(power, imported, exported)
         inverter_state = InverterState(
             power=power,
             dc_power=dc_power,

--- a/packages/modules/devices/solis/solis/version.py
+++ b/packages/modules/devices/solis/solis/version.py
@@ -4,3 +4,4 @@ from enum import Enum
 class SolisVersion(Enum):
     inverter = "inverter"
     hybrid = "hybrid"
+    hybrid-s = "hybrid-s"

--- a/packages/modules/devices/solis/solis/version.py
+++ b/packages/modules/devices/solis/solis/version.py
@@ -4,4 +4,4 @@ from enum import Enum
 class SolisVersion(Enum):
     inverter = "inverter"
     hybrid = "hybrid"
-    hybrid-s = "hybrid-s"
+    hybrid_s = "hybrid_s"


### PR DESCRIPTION
UI PR: https://github.com/openWB/openwb-ui-settings/pull/947

https://forum.openwb.de/viewtopic.php?t=12065

Solis Hybrid S-Serie herausgetrennt und alle Counter auf simcounter umgestellt, da in der Doku für alle Register nur eine Auflösung von 1kWh angegeben sind

Speichersteuerung für S-Serie hinzugefügt, aber mangels Hardware nicht getestet

Doku für S-Serie Register: https://github.com/peufeu2/GrugBus/blob/main/grugbus/devices/Solis_S5_EH1P_6K_2020.csv

