### PR TITLE
Remove charge limit from settings dialog

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ChargePointEcoSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointEcoSettings.vue
@@ -39,40 +39,6 @@
       </q-btn-group>
     </div>
   </div>
-
-  <div class="text-subtitle2 q-mt-sm q-mr-sm">Begrenzung</div>
-  <div class="row items-center justify-center q-ma-none q-pa-none no-wrap">
-    <q-btn-group class="col">
-      <q-btn
-        v-for="mode in limitModes"
-        :key="mode.value"
-        :color="limitMode.value === mode.value ? 'primary' : 'grey'"
-        :label="mode.label"
-        size="sm"
-        class="col"
-        @click="limitMode.value = mode.value"
-      />
-    </q-btn-group>
-  </div>
-  <SliderStandard
-    v-if="limitMode.value === 'soc'"
-    title="SoC-Limit für das Fahrzeug"
-    :min="5"
-    :max="100"
-    :step="5"
-    unit="%"
-    v-model="limitSoC.value"
-    class="q-mt-md"
-  />
-  <SliderStandard
-    v-if="limitMode.value === 'amount'"
-    title="Energie-Limit"
-    :min="1"
-    :max="50"
-    unit="kWh"
-    v-model="limitEnergy.value"
-    class="q-mt-md"
-  />
   <div v-if="etConfigured">
     <div class="text-subtitle2 q-my-sm">
       Preisgrenze für strompreisbasiertes Laden
@@ -166,21 +132,6 @@ const props = defineProps<{
 
 const mqttStore = useMqttStore();
 
-const limitModes = computed(() => {
-  let modes = [
-    { value: 'none', label: 'keine', color: 'primary' },
-    { value: 'soc', label: 'EV-SoC', color: 'primary' },
-    { value: 'amount', label: 'Energie', color: 'primary' },
-  ];
-  if (vehicleSocType.value === undefined) {
-    modes = modes.filter((mode) => mode.value !== 'soc');
-  }
-  return modes;
-});
-
-const vehicleSocType = computed(() =>
-  mqttStore.chargePointConnectedVehicleSocType(props.chargePointId),
-)?.value;
 
 const phaseOptions = [
   { value: 1, label: '1' },
@@ -206,20 +157,6 @@ const dcPower = computed(() =>
 
 const numPhases = computed(() =>
   mqttStore.chargePointConnectedVehicleEcoChargePhases(props.chargePointId),
-);
-
-const limitMode = computed(() =>
-  mqttStore.chargePointConnectedVehicleEcoChargeLimit(props.chargePointId),
-);
-
-const limitSoC = computed(() =>
-  mqttStore.chargePointConnectedVehicleEcoChargeLimitSoC(props.chargePointId),
-);
-
-const limitEnergy = computed(() =>
-  mqttStore.chargePointConnectedVehicleEcoChargeLimitEnergy(
-    props.chargePointId,
-  ),
 );
 
 const etConfigured = computed(() => mqttStore.etProviderConfigured);

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointInstantSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointInstantSettings.vue
@@ -34,39 +34,6 @@
       </q-btn-group>
     </div>
   </div>
-  <div class="text-subtitle2 q-mt-sm q-mr-sm">Begrenzung</div>
-  <div class="row items-center justify-center q-ma-none q-pa-none no-wrap">
-    <q-btn-group class="col">
-      <q-btn
-        v-for="mode in limitModes"
-        :key="mode.value"
-        :color="limitMode.value === mode.value ? 'primary' : 'grey'"
-        :label="mode.label"
-        size="sm"
-        class="col"
-        @click="limitMode.value = mode.value"
-      />
-    </q-btn-group>
-  </div>
-  <SliderStandard
-    v-if="limitMode.value === 'soc'"
-    title="SoC-Limit für das Fahrzeug"
-    :min="5"
-    :max="100"
-    :step="5"
-    unit="%"
-    v-model="limitSoC.value"
-    class="q-mt-md"
-  />
-  <SliderStandard
-    v-if="limitMode.value === 'amount'"
-    title="Energie-Limit"
-    :min="1"
-    :max="50"
-    unit="kWh"
-    v-model="limitEnergy.value"
-    class="q-mt-md"
-  />
 </template>
 
 <script setup lang="ts">
@@ -79,22 +46,6 @@ const props = defineProps<{
 }>();
 
 const mqttStore = useMqttStore();
-
-const limitModes = computed(() => {
-  let modes = [
-    { value: 'none', label: 'keine', color: 'primary' },
-    { value: 'soc', label: 'EV-SoC', color: 'primary' },
-    { value: 'amount', label: 'Energie', color: 'primary' },
-  ];
-  if (vehicleSocType.value === undefined) {
-    modes = modes.filter((mode) => mode.value !== 'soc');
-  }
-  return modes;
-});
-
-const vehicleSocType = computed(() =>
-  mqttStore.chargePointConnectedVehicleSocType(props.chargePointId),
-)?.value;
 
 const phaseOptions = [
   { value: 1, label: '1' },
@@ -123,22 +74,6 @@ const instantChargeCurrentDc = computed(() => {
 
 const numPhases = computed(() =>
   mqttStore.chargePointConnectedVehicleInstantChargePhases(props.chargePointId),
-);
-
-const limitMode = computed(() =>
-  mqttStore.chargePointConnectedVehicleInstantChargeLimit(props.chargePointId),
-);
-
-const limitSoC = computed(() =>
-  mqttStore.chargePointConnectedVehicleInstantChargeLimitSoC(
-    props.chargePointId,
-  ),
-);
-
-const limitEnergy = computed(() =>
-  mqttStore.chargePointConnectedVehicleInstantChargeLimitEnergy(
-    props.chargePointId,
-  ),
 );
 </script>
 

--- a/packages/modules/web_themes/koala/source/src/components/ChargePointPvSettings.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChargePointPvSettings.vue
@@ -39,40 +39,6 @@
       </q-btn-group>
     </div>
   </div>
-
-  <div class="text-subtitle2 q-mt-sm q-mr-sm">Begrenzung</div>
-  <div class="row items-center justify-center q-ma-none q-pa-none no-wrap">
-    <q-btn-group class="col">
-      <q-btn
-        v-for="mode in limitModes"
-        :key="mode.value"
-        :color="limitMode.value === mode.value ? 'primary' : 'grey'"
-        :label="mode.label"
-        size="sm"
-        class="col"
-        @click="limitMode.value = mode.value"
-      />
-    </q-btn-group>
-  </div>
-  <SliderStandard
-    v-if="limitMode.value === 'soc'"
-    title="SoC-Limit für das Fahrzeug"
-    :min="5"
-    :max="100"
-    :step="5"
-    unit="%"
-    v-model="limitSoC.value"
-    class="q-mt-md"
-  />
-  <SliderStandard
-    v-if="limitMode.value === 'amount'"
-    title="Energie-Limit"
-    :min="1"
-    :max="50"
-    unit="kWh"
-    v-model="limitEnergy.value"
-    class="q-mt-md"
-  />
   <div v-if="vehicleSocType !== undefined">
     <SliderStandard
       title="Mindest-SoC für das Fahrzeug"
@@ -146,18 +112,6 @@ const props = defineProps<{
 
 const mqttStore = useMqttStore();
 
-const limitModes = computed(() => {
-  let modes = [
-    { value: 'none', label: 'keine', color: 'primary' },
-    { value: 'soc', label: 'EV-SoC', color: 'primary' },
-    { value: 'amount', label: 'Energie', color: 'primary' },
-  ];
-  if (vehicleSocType.value === undefined) {
-    modes = modes.filter((mode) => mode.value !== 'soc');
-  }
-  return modes;
-});
-
 const vehicleSocType = computed(() =>
   mqttStore.chargePointConnectedVehicleSocType(props.chargePointId),
 )?.value;
@@ -211,18 +165,6 @@ const pvMinSocCurrent = computed(() =>
   mqttStore.chargePointConnectedVehiclePvChargeMinSocCurrent(
     props.chargePointId,
   ),
-);
-
-const limitMode = computed(() =>
-  mqttStore.chargePointConnectedVehiclePvChargeLimit(props.chargePointId),
-);
-
-const limitSoC = computed(() =>
-  mqttStore.chargePointConnectedVehiclePvChargeLimitSoC(props.chargePointId),
-);
-
-const limitEnergy = computed(() =>
-  mqttStore.chargePointConnectedVehiclePvChargeLimitEnergy(props.chargePointId),
 );
 
 const feedInLimit = computed(() =>


### PR DESCRIPTION
Ladelimit Einstellungen aus dem Einstellungsdialog entfernen, da der Schieberegler in der Ladepunkt-Karte jetzt direkt den Ladelimit-Dialog öffnet