### PR TITLE
Tasmota: add types

### DIFF
--- a/packages/modules/devices/tasmota/tasmota/bat.py
+++ b/packages/modules/devices/tasmota/tasmota/bat.py
@@ -48,24 +48,31 @@ class TasmotaBat(AbstractBat):
             imported = float(response['StatusSNS']['ENERGY']['Total']*1000)
             imported, _ = self.peak_filter.check_values(power, imported, None)
             _, exported = self.sim_counter.sim_count(power)
-
-            bat_state = BatState(
-                power=power,
-                currents=currents,
-                imported=imported,
-                exported=exported
-            )
-        else:
+        elif 'Itron' in response['StatusSNS']:
             power = float(response['StatusSNS']['Itron']['Power'])
             imported = float(response['StatusSNS']['Itron']['E_in']*1000)
             exported = float(response['StatusSNS']['Itron']['E_out']*1000)
             imported, exported = self.peak_filter.check_values(power, imported, exported)
+        elif 'MT681' in response['StatusSNS']:
+            power = float(response['StatusSNS']['MT681']['Watt_summe'])
+            imported = float(response['StatusSNS']['MT681']['Total_in']*1000)
+            exported = float(response['StatusSNS']['MT681']['Total_out']*1000)
+            imported, exported = self.peak_filter.check_values(power, imported, exported)
+        elif 'eBZ' in response['StatusSNS']:
+            power = float(response['StatusSNS']['eBZ']['Power'])
+            imported = float(response['StatusSNS']['eBZ']['E_in']*1000)
+            exported = float(response['StatusSNS']['eBZ']['E_out']*1000)
+            imported, exported = self.peak_filter.check_values(power, imported, exported)
+        else:
+            raise ValueError("Nicht unterstützter Tasmota Zählertyp. Bitte an den Support wenden.")
 
-            bat_state = BatState(
-                power=power,
-                imported=imported,
-                exported=exported
-            )
+        bat_state = BatState(
+            power=power,
+            imported=imported,
+            exported=exported
+        )
+        if 'currents' in locals():
+            bat_state.currents = currents
 
         self.store.set(bat_state)
 

--- a/packages/modules/devices/tasmota/tasmota/bat.py
+++ b/packages/modules/devices/tasmota/tasmota/bat.py
@@ -45,7 +45,7 @@ class TasmotaBat(AbstractBat):
             currents = [0.0, 0.0, 0.0]
 
             power = float(response['StatusSNS']['ENERGY']['Power'])
-            currents[self.__phase-1] = (response['StatusSNS']['ENERGY']['Current']), 0.0, 0.0
+            currents[self.__phase-1] = float(response['StatusSNS']['ENERGY']['Current'])
             imported = float(response['StatusSNS']['ENERGY']['Total']*1000)
             imported, _ = self.peak_filter.check_values(power, imported, None)
             _, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/tasmota/tasmota/bat.py
+++ b/packages/modules/devices/tasmota/tasmota/bat.py
@@ -40,6 +40,7 @@ class TasmotaBat(AbstractBat):
         url = "http://" + self.__ip_address + "/cm?cmnd=Status%208"
         response = req.get_http_session().get(url, timeout=5).json()
 
+        currents = None
         if 'ENERGY' in response['StatusSNS']:
             currents = [0.0, 0.0, 0.0]
 
@@ -69,10 +70,9 @@ class TasmotaBat(AbstractBat):
         bat_state = BatState(
             power=power,
             imported=imported,
-            exported=exported
+            exported=exported,
+            currents=currents
         )
-        if 'currents' in locals():
-            bat_state.currents = currents
 
         self.store.set(bat_state)
 

--- a/packages/modules/devices/tasmota/tasmota/counter.py
+++ b/packages/modules/devices/tasmota/tasmota/counter.py
@@ -40,6 +40,10 @@ class TasmotaCounter(AbstractCounter):
         url = "http://" + self.__ip_address + "/cm?cmnd=Status%208"
         response = req.get_http_session().get(url, timeout=5).json()
 
+        voltages = None
+        currents = None
+        powers = None
+        power_factors = None
         if 'ENERGY' in response['StatusSNS']:
             voltages = [0.0, 0.0, 0.0]
             powers = [0.0, 0.0, 0.0]
@@ -84,16 +88,12 @@ class TasmotaCounter(AbstractCounter):
         counter_state = CounterState(
             power=power,
             imported=imported,
-            exported=exported
+            exported=exported,
+            voltages=voltages,
+            currents=currents,
+            powers=powers,
+            power_factors=power_factors
         )
-        if 'voltages' in locals():
-            counter_state.voltages = voltages
-        if 'currents' in locals():
-            counter_state.currents = currents
-        if 'powers' in locals():
-            counter_state.powers = powers
-        if 'power_factors' in locals():
-            counter_state.power_factors = power_factors
 
         self.store.set(counter_state)
 

--- a/packages/modules/devices/tasmota/tasmota/counter.py
+++ b/packages/modules/devices/tasmota/tasmota/counter.py
@@ -64,6 +64,20 @@ class TasmotaCounter(AbstractCounter):
             imported = float(response['StatusSNS']['MT681']['Total_in']*1000)
             exported = float(response['StatusSNS']['MT681']['Total_out']*1000)
             imported, exported = self.peak_filter.check_values(power, imported, exported)
+        elif 'eBZ' in response['StatusSNS']:
+            powers = [0.0, 0.0, 0.0]
+            power = float(response['StatusSNS']['eBZ']['Power'])
+            imported = float(response['StatusSNS']['eBZ']['E_in']*1000)
+            exported = float(response['StatusSNS']['eBZ']['E_out']*1000)
+            imported, exported = self.peak_filter.check_values(power, imported, exported)
+            if (
+                '36_7_0' in response['StatusSNS']['eBZ'] and
+                '56_7_0' in response['StatusSNS']['eBZ'] and
+                '76_7_0' in response['StatusSNS']['eBZ']
+            ):
+                powers = [float(response['StatusSNS']['eBZ']['36_7_0']),
+                          float(response['StatusSNS']['eBZ']['56_7_0']),
+                          float(response['StatusSNS']['eBZ']['76_7_0'])]
         else:
             raise ValueError("Nicht unterstützter Tasmota Zählertyp. Bitte an den Support wenden.")
 

--- a/packages/modules/devices/tasmota/tasmota/inverter.py
+++ b/packages/modules/devices/tasmota/tasmota/inverter.py
@@ -47,20 +47,27 @@ class TasmotaInverter(AbstractInverter):
             currents[self.__phase-1] = (response['StatusSNS']['ENERGY']['Current']), 0.0, 0.0
             self.peak_filter.check_values(power)
             _, exported = self.sim_counter.sim_count(power)
-
-            inverter_state = InverterState(
-                power=power,
-                currents=currents,
-                exported=exported
-            )
-        else:
+        elif 'Itron' in response['StatusSNS']:
             power = float(response['StatusSNS']['Itron']['Power']) * -1
             exported = float(response['StatusSNS']['Itron']['E_out']*1000)
             _, exported = self.peak_filter.check_values(power, None, exported)
-            inverter_state = InverterState(
-                power=power,
-                exported=exported
-            )
+        elif 'MT681' in response['StatusSNS']:
+            power = float(response['StatusSNS']['MT681']['Watt_summe'])
+            exported = float(response['StatusSNS']['MT681']['Total_out']*1000)
+            _, exported = self.peak_filter.check_values(power, None, exported)
+        elif 'eBZ' in response['StatusSNS']:
+            power = float(response['StatusSNS']['eBZ']['Power'])
+            exported = float(response['StatusSNS']['eBZ']['E_out']*1000)
+            _, exported = self.peak_filter.check_values(power, None, exported)
+        else:
+            raise ValueError("Nicht unterstützter Tasmota Zählertyp. Bitte an den Support wenden.")
+
+        inverter_state = InverterState(
+            power=power,
+            exported=exported
+        )
+        if 'currents' in locals():
+            inverter_state.currents = currents
 
         self.store.set(inverter_state)
 

--- a/packages/modules/devices/tasmota/tasmota/inverter.py
+++ b/packages/modules/devices/tasmota/tasmota/inverter.py
@@ -40,9 +40,8 @@ class TasmotaInverter(AbstractInverter):
         url = "http://" + self.__ip_address + "/cm?cmnd=Status%208"
         response = req.get_http_session().get(url, timeout=5).json()
 
+        currents = None
         if 'ENERGY' in response['StatusSNS']:
-            currents = [0.0, 0.0, 0.0]
-
             power = float(response['StatusSNS']['ENERGY']['Power']) * -1
             currents[self.__phase-1] = (response['StatusSNS']['ENERGY']['Current']), 0.0, 0.0
             self.peak_filter.check_values(power)
@@ -52,11 +51,11 @@ class TasmotaInverter(AbstractInverter):
             exported = float(response['StatusSNS']['Itron']['E_out']*1000)
             _, exported = self.peak_filter.check_values(power, None, exported)
         elif 'MT681' in response['StatusSNS']:
-            power = float(response['StatusSNS']['MT681']['Watt_summe'])
+            power = float(response['StatusSNS']['MT681']['Watt_summe']) * -1
             exported = float(response['StatusSNS']['MT681']['Total_out']*1000)
             _, exported = self.peak_filter.check_values(power, None, exported)
         elif 'eBZ' in response['StatusSNS']:
-            power = float(response['StatusSNS']['eBZ']['Power'])
+            power = float(response['StatusSNS']['eBZ']['Power']) * -1
             exported = float(response['StatusSNS']['eBZ']['E_out']*1000)
             _, exported = self.peak_filter.check_values(power, None, exported)
         else:
@@ -64,10 +63,9 @@ class TasmotaInverter(AbstractInverter):
 
         inverter_state = InverterState(
             power=power,
-            exported=exported
+            exported=exported,
+            currents=currents
         )
-        if 'currents' in locals():
-            inverter_state.currents = currents
 
         self.store.set(inverter_state)
 

--- a/packages/modules/devices/tasmota/tasmota/inverter.py
+++ b/packages/modules/devices/tasmota/tasmota/inverter.py
@@ -44,7 +44,7 @@ class TasmotaInverter(AbstractInverter):
         if 'ENERGY' in response['StatusSNS']:
             currents = [0.0, 0.0, 0.0]
             power = float(response['StatusSNS']['ENERGY']['Power']) * -1
-            currents[self.__phase-1] = (response['StatusSNS']['ENERGY']['Current']), 0.0, 0.0
+            currents[self.__phase-1] = float(response['StatusSNS']['ENERGY']['Current'])
             self.peak_filter.check_values(power)
             _, exported = self.sim_counter.sim_count(power)
         elif 'Itron' in response['StatusSNS']:

--- a/packages/modules/devices/tasmota/tasmota/inverter.py
+++ b/packages/modules/devices/tasmota/tasmota/inverter.py
@@ -42,6 +42,7 @@ class TasmotaInverter(AbstractInverter):
 
         currents = None
         if 'ENERGY' in response['StatusSNS']:
+            currents = [0.0, 0.0, 0.0]
             power = float(response['StatusSNS']['ENERGY']['Power']) * -1
             currents[self.__phase-1] = (response['StatusSNS']['ENERGY']['Current']), 0.0, 0.0
             self.peak_filter.check_values(power)


### PR DESCRIPTION
- Vorhandene Typen auch für Speicher- und Wechselrichter-Zähler implementieren
- Neuen Tasmota Typ c2dc44 hinzugefügt