### PR TITLE
fix rfid input on display

### DIFF
--- a/packages/modules/common/store/_chargepoint.py
+++ b/packages/modules/common/store/_chargepoint.py
@@ -48,7 +48,8 @@ class ChargepointValueStoreBroker(ValueStore[ChargepointState]):
         pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/charge_state", self.state.charge_state, 2)
         if self.state.plug_state is not None:
             pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/plug_state", self.state.plug_state, 2)
-        pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/rfid", self.state.rfid)
+        if self.state.rfid is not None:
+            pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/rfid", self.state.rfid)
         if self.state.rfid_timestamp is not None:
             pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/rfid_timestamp", self.state.rfid_timestamp)
         pub_to_broker("openWB/set/chargepoint/" + str(self.num) + "/get/serial_number", self.state.serial_number)


### PR DESCRIPTION
Secondary 
- [x] Tag am Display eingeben
- [x]  RFID an Duo scannen, vor dem Anstecken, LP freischalten
- [x]  RFID an Duo scannen, nach dem Anstecken, LP freischalten & Fahrzeug zuordnen
- [x]  RFID scannen, 5 Min kein Auto anstecken
- [ ]  RFID scannen, danach Tag am Display eingeben

MQTT-Ladepunkt
- [ ] Tag am Display eingeben, LP freischalten
- [ ] RFID scannen, Fahrzeug zuordnen
- [ ]  RFID scannen, 5 Min kein Auto anstecken
- [ ]  RFID scannen, danach Tag am Display eingeben

Pro
- [ ] RFID scannen, Fahrzeug zuordnen
- [ ]  RFID scannen, 5 Min kein Auto anstecken
- [ ]  RFID scannen, danach Tag am Display eingeben