### PR TITLE
fix rfid duo

### DIFF
--- a/packages/control/chargepoint/rfd_test.py
+++ b/packages/control/chargepoint/rfd_test.py
@@ -4,12 +4,16 @@ from unittest.mock import Mock
 import pytest
 from control import data
 from control.chargepoint.chargepoint import Chargepoint
+from control.chargepoint.chargepoint_template import CpTemplate
+from control.ev.ev import Ev
 
 
 @pytest.fixture()
 def mock_data() -> None:
     data.data_init(Mock())
     data.data.cp_data["cp1"] = Chargepoint(1, None)
+    data.data.cp_data["cp1"].template = CpTemplate()
+    data.data.cp_data["cp1"].chargepoint_module = Mock()
     data.data.cp_data["cp1"].data.get.rfid = "1234"
 
 
@@ -39,6 +43,9 @@ def test_link_rfid_to_cp(partner_id: Optional[int],
     cp.data.set.plug_time = cp0_plug_time
     data.data.cp_data["cp1"].data.get.plug_state = cp1_plug_state
     data.data.cp_data["cp1"].data.set.plug_time = cp1_plug_time
+    data.data.cp_data["cp1"].data.config.ev = 1
+    data.data.ev_data["ev1"] = Ev(1)
+
     mock_find_duo_partner = Mock(return_value=partner_id)
     monkeypatch.setattr(Chargepoint, "find_duo_partner", mock_find_duo_partner)
 

--- a/packages/control/chargepoint/rfid.py
+++ b/packages/control/chargepoint/rfid.py
@@ -24,9 +24,20 @@ class ChargepointRfidMixin:
              ((cp2_data.data.get.plug_state and self.data.get.plug_state and
                (cp2_data.data.set.plug_time - self.data.set.plug_time) < 0) or
               # kein EV am anderen Duo-Ladepunkt
-              cp2_data.data.get.plug_state is False)) or
-                # keine Duo
-                cp2_data is None):
+              cp2_data.data.get.plug_state is False))):
+            self.data.set.rfid = rfid
+            self.chargepoint_module.clear_rfid()
+            # Tag kann nur an einem Duo-Ladepunkt zugewiesen werden
+            if cp2_data.template.data.disable_after_unplug:
+                cp2_data.data.set.manual_lock = True
+            if data.data.ev_data[f"ev{cp2_data.data.config.ev}"].charge_template.data.load_default:
+                cp2_data.data.config.ev = 0
+            cp2_data.data.get.rfid = None
+            Pub().pub(f"openWB/set/chargepoint/{cp2_num}/get/rfid", None)
+            cp2_data.data.get.rfid_timestamp = None
+            Pub().pub(f"openWB/set/chargepoint/{cp2_num}/get/rfid_timestamp", None)
+            cp2_data.chargepoint_module.clear_rfid()
+        elif cp2_data is None:
             self.data.set.rfid = rfid
             self.chargepoint_module.clear_rfid()
 
@@ -63,7 +74,7 @@ class ChargepointRfidMixin:
                                 self.data.get.rfid_timestamp = None
                                 if self.template.data.disable_after_unplug:
                                     self.data.set.manual_lock = True
-                                if self.data.set.charging_ev_data.charge_template.data.load_default:
+                                if data.data.ev_data[f"ev{self.data.config.ev}"].charge_template.data.load_default:
                                     self.data.config.ev = 0
                                 Pub().pub(f"openWB/set/chargepoint/{self.num}/get/rfid_timestamp", None)
                                 msg = ("Es ist in den letzten 5 Minuten kein EV angesteckt worden, dem "
@@ -87,6 +98,7 @@ class ChargepointRfidMixin:
             if self.data.config.type == "external_openwb" or self.data.config.type == "internal_openwb":
                 for cp2 in data.data.cp_data.values():
                     if (cp2.num != self.num and
+                        (cp2.data.config.type == "external_openwb" or cp2.data.config.type == "internal_openwb") and
                             self.data.config.configuration["ip_address"] == cp2.data.config.configuration[
                                 "ip_address"]):
                         return cp2.num


### PR DESCRIPTION
Standard:
- [x] Scannen vor Anstecken
- [x] Scannen nach Anstecken
- [x] kein Anstecken nach Scannen -> wieder auf Standard-Fahrzeug wechseln, RFID  und Zeitstempel zurücksetzen

Duo:
- [x] Scannen vor Anstecken:  Lp 1: Anstecken, LP 2: wieder auf Standard-Fahrzeug wechseln, RFID  und Zeitstempel zurücksetzen
- [x] Scannen nach Anstecken: LP 1:  Anstecken, LP 2: wieder auf Standard-Fahrzeug wechseln, RFID  und Zeitstempel zurücksetzen
- [x] Scannen nach Anstecken LP 1: Anstecken, LP 2: wieder auf Standard-Fahrzeug wechseln, RFID  und Zeitstempel zurücksetzen, LP 2 scannen und Anstecken
- [ ] LP 1& 2: kein Anstecken nach Scannen -> wieder auf Standard-Fahrzeug wechseln, RFID  und Zeitstempel zurücksetzen
- [x] Scannen vor Anstecken: Lp 2: Anstecken, LP 1: wieder auf Standard-Fahrzeug wechseln, RFID  und Zeitstempel zurücksetzen
- [x] Scannen nach Anstecken: LP 2:  Anstecken, LP 1: wieder auf Standard-Fahrzeug wechseln, RFID  und Zeitstempel zurücksetzen
- [ ] Scannen nach Anstecken: LP 2: Anstecken, LP 1: wieder auf Standard-Fahrzeug wechseln, RFID  und Zeitstempel zurücksetzen, LP 1 scannen und Anstecken
