### PR TITLE
Sungrow fix simcounter

### DIFF
--- a/packages/modules/devices/sungrow/sungrow_sg/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow_sg/inverter.py
@@ -44,7 +44,7 @@ class SungrowSGInverter(AbstractInverter):
         currents = [value * -0.1 for value in currents]
 
         self.peak_filter.check_values(power)
-        imported, exported = self.sim_counter.sim_count(power, dc_power)
+        imported, exported = self.sim_counter.sim_count(power)
         inverter_state = InverterState(
             power=power,
             dc_power=dc_power,

--- a/packages/modules/devices/sungrow/sungrow_sh/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow_sh/inverter.py
@@ -44,7 +44,7 @@ class SungrowSHInverter(AbstractInverter):
         currents = [value * -0.1 for value in currents]
 
         self.peak_filter.check_values(power)
-        imported, exported = self.sim_counter.sim_count(power, dc_power)
+        imported, exported = self.sim_counter.sim_count(power)
         inverter_state = InverterState(
             power=power,
             dc_power=dc_power,


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?p=142364#p142364

Es gab schonmal einen Fall per PN der an mich herangetragen wurde, wo der simcounter nicht richtig gezählt hat. In einer früheren Version war die dc_power auch im simcounter enthalten, ich glaube @ndrsnhs hatte das eingebaut. Mir war der Grund dafür nicht klar. Im anderen Fall habe ich denjenigen den Code ändern lassen und die dc_power im simcounter entfernen lassen und es lief.
Vermutlich hier das gleiche Thema.