### PR TITLE
Fix: correct download times for EKZ prices

### DIFF
--- a/packages/modules/electricity_pricing/flexible_tariffs/ekz/config.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/ekz/config.py
@@ -2,7 +2,7 @@ class EkzTariffConfiguration:
     def __init__(self):
         self.country = "ch"
         self.unit = "Rp"
-        self.update_hours = [18,19]
+        self.update_hours = [18, 19]
 
 
 class EkzTariff:

--- a/packages/modules/electricity_pricing/flexible_tariffs/ekz/config.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/ekz/config.py
@@ -2,6 +2,7 @@ class EkzTariffConfiguration:
     def __init__(self):
         self.country = "ch"
         self.unit = "Rp"
+        self.update_hours = [18,19]
 
 
 class EkzTariff:


### PR DESCRIPTION
- Preise für den Provider EKZ werden jeweils um 18 Uhr publiziert. Diese Änderung konfiguriert Downloads für 18 und 19 Uhr, damit auch bei leichten Verspätungen die Daten für den nächsten Tag geladen werden.