### PR TITLE
Kritisch: Relaisschleife nach Phasenumschaltung

### DIFF
--- a/packages/modules/internal_chargepoint_handler/chargepoint_module.py
+++ b/packages/modules/internal_chargepoint_handler/chargepoint_module.py
@@ -153,6 +153,7 @@ class ChargepointModule(AbstractChargepoint):
         time.sleep(5)
         GPIO.output(gpio_cp, GPIO.LOW)  # CP on
         time.sleep(1)
+        self.old_phases_in_use = phases_to_use
 
     def perform_cp_interruption(self, duration: int) -> None:
         gpio_cp = self._client.get_pins_cp_interruption()


### PR DESCRIPTION
## Problem

Bei der internen openWB mit Phasenumschaltung kann es zu wiederholten Relais-Schaltungen (Relais-Schleife) kommen, wenn das Fahrzeug nach einer Phasenumschaltung nicht lädt.

### Reproduktion

1. Fahrzeug lädt im **PV-Modus auf 3 Phasen** (z.B. ~11A)
2. Fahrzeug stoppt die Ladung (fahrzeugseitig, z.B. Fehler oder voller Akku), oder manuell
3. Benutzer wechselt auf **Sofortladen 1-phasig**

oder: 

1. PV laden 3p, warten bis abends automatisch auf 1p umgeschaltet wird und das Auto nicht schnell genug weiter lädt. Passiert regelmäßig.  

### Was passiert (ohne Fix)

- Der Hauptprozess erkennt `phases_to_use=1` vs. `phases_in_use=3` → löst Phasenumschaltung aus
- `perform_phase_switch()` schaltet die Relais korrekt (CP aus → Relais umschalten → CP an) — **2 Relais-Schaltungen**
- Da das Fahrzeug nicht lädt, misst der Zähler 0A auf allen Phasen
- `phases_in_use` fällt auf den Fallback `old_phases_in_use` zurück — der steht noch auf **3** (vom vorherigen PV-Laden)
- Der Hauptprozess sieht erneut `phases_to_use=1` vs. `phases_in_use=3` → löst **erneut** eine Phasenumschaltung aus
- Dieser Zyklus wiederholt sich alle ~2 Minuten (`keep_charge_active_duration` + 20s Hauptschleife), bis `failed_phase_switches` das Maximum erreicht
- **Ergebnis:** 3×2 = 6 unnötige Relais-Schaltungen. Das Fahrzeug kann dadurch in einen Fehlerzustand geraten.

### Ursache

In `get_values()` (Zeile ~98) wird `phases_in_use` über die Zählerströme ermittelt:
`python
phases_in_use = sum(1 for current in counter_state.currents if current > 3)
if phases_in_use == 0:
    phases_in_use = self.old_phases_in_use  # Fallback bei 0A
`
Wenn das Fahrzeug nicht lädt (alle Ströme = 0), greift der Fallback auf `old_phases_in_use`. Dieser Wert wird aber in `perform_phase_switch()` **nicht aktualisiert**, sodass er den alten Wert (3) behält.

### Lösung

Am Ende von `perform_phase_switch()` wird `old_phases_in_use` auf den neuen Sollwert gesetzt:
`python
self.old_phases_in_use = phases_to_use
`
Damit gibt der Fallback den **angeforderten** Zustand zurück statt den veralteten. Die State-Machine in `chargepoint.py` sieht dann keinen Mismatch mehr und löst keine weitere Umschaltung aus.

Dieses Muster wird beim Booten bereits verwendet (Zeile 64-65):
`python
self.perform_phase_switch(1)
self.old_phases_in_use = 1
`
Es fehlte nur innerhalb der Methode selbst.