### PR TITLE
fix: EVSE-Register-Einheit beim Stromvergleich korrigieren

### DIFF
--- a/packages/modules/common/evse.py
+++ b/packages/modules/common/evse.py
@@ -61,9 +61,10 @@ class Evse:
                              str(state)+", Soll-Stromstärke: "+str(self.evse_current))
         plugged = state.plugged
         charging = self.evse_current > 0 if state.charge_enabled else False
-        if self.evse_current > 32:
-            self.evse_current = self.evse_current / 100
-        return plugged, charging, self.evse_current
+        # self.evse_current bleibt als Rohwert im Register-Format erhalten,
+        # damit der Vergleich in set_current() korrekt funktioniert.
+        set_current_amps = self.evse_current / 100 if self._precise_current else float(self.evse_current)
+        return plugged, charging, set_current_amps
 
     def get_firmware_version(self) -> int:
         return self.version


### PR DESCRIPTION
## Problem

In get_plug_charge_state() wird self.evse_current aus dem Modbus-Register gelesen und bei aktiviertem Precise-Current-Modus (Firmware >= 17) in Ampere umgerechnet, indem der Wert durch 100 geteilt wird. Das geschieht über den Heuristik-Check if self.evse_current > 32, der den Wert direkt in self.evse_current schreibt.

In set_current() hingegen wird der zu schreibende Strom als Rohwert im Register-Format gespeichert (ormatted_current = round(current*100)), und dann mit self.evse_current verglichen:

 
```
if self.evse_current != formatted_current:
    self.client.write_register(1000, formatted_current, unit=self.id)
```
 

Da get_plug_charge_state() self.evse_current bereits in Ampere umgewandelt hat (z.B. 16.0), aber ormatted_current im Register-Format vorliegt (z.B. 1600), **schlägt der Vergleich immer fehl**. Dadurch wird die EVSE alle paar Sekunden neu beschrieben, auch wenn sich der Sollstrom nicht geändert hat.

## Ursache

Die Konvertierung von Register-Einheiten nach Ampere darf self.evse_current nicht überschreiben – dieser Wert wird als Zustand für den nachfolgenden Vergleich in set_current() benötigt.

## Fix

self.evse_current bleibt unverändert als Rohwert im Register-Format. Für den Rückgabewert wird eine separate lokale Variable set_current_amps verwendet, die korrekt anhand von self._precise_current umrechnet:

 
```
set_current_amps = self.evse_current / 100 if self._precise_current else float(self.evse_current)
return plugged, charging, set_current_amps
```
 

Außerdem entfällt die fehleranfällige Heuristik > 32 – stattdessen wird das bereits bekannte Flag self._precise_current verwendet.