### PR TITLE
fix: EVSE-Ruecklesen vor Phasenumschaltung

### DIFF
--- a/packages/modules/internal_chargepoint_handler/chargepoint_module.py
+++ b/packages/modules/internal_chargepoint_handler/chargepoint_module.py
@@ -143,9 +143,19 @@ class ChargepointModule(AbstractChargepoint):
 
     def perform_phase_switch(self, phases_to_use: int) -> None:
         gpio_cp, gpio_relay = self._client.get_pins_phase_switch(phases_to_use)
-        with SingleComponentUpdateContext(self.fault_state, update_always=False):
-            self._client.evse_client.set_current(0)
-        time.sleep(5)
+        evse = self._client.evse_client
+        with SingleComponentUpdateContext(self.fault_state, update_always=False, reraise=True):
+            evse.set_current(0)
+            for _ in range(20):  # poll up to 10s (20 × 0.5s) for EVSE to confirm 0 A
+                _, _, evse_current = evse.get_plug_charge_state()
+                if evse_current == 0:
+                    break
+                time.sleep(0.5)
+                evse.set_current(0)
+            else:
+                log.error("CP%d: EVSE did not reach 0 A within 10s — aborting phase switch.",
+                          self.local_charge_point_num)
+                return
         GPIO.output(gpio_cp, GPIO.HIGH)  # CP off
         GPIO.output(gpio_relay, GPIO.HIGH)  # 3 on/off
         time.sleep(5)

--- a/packages/modules/internal_chargepoint_handler/chargepoint_module.py
+++ b/packages/modules/internal_chargepoint_handler/chargepoint_module.py
@@ -153,9 +153,7 @@ class ChargepointModule(AbstractChargepoint):
                 time.sleep(0.5)
                 evse.set_current(0)
             else:
-                log.error("CP%d: EVSE did not reach 0 A within 10s — aborting phase switch.",
-                          self.local_charge_point_num)
-                return
+                raise Exception("Ladung konnte nicht gestoppt werden - Phasenumschaltung abgebrochen.")
         GPIO.output(gpio_cp, GPIO.HIGH)  # CP off
         GPIO.output(gpio_relay, GPIO.HIGH)  # 3 on/off
         time.sleep(5)


### PR DESCRIPTION
## Problem

Beim Phasenwechsel wird aktuell `set_current(0)` an die EVSE gesendet und dann blind 5 Sekunden gewartet, bevor die Relais geschaltet werden. Wenn der EVSE-Schreibvorgang fehlschlägt (Modbus-Timeout, Bus-Konflikt, `evse_client is None`), wird die Exception von `SingleComponentUpdateContext` stillschweigend geschluckt und die Relais werden unter Last geschaltet.

**Folgen:** Lichtbogenschäden an den Relaiskontakten (nur für stromloses Schalten ausgelegt), mögliches Verschweißen der Kontakte, im schlimmsten Fall Brandgefahr bei 32 A.
Ladeabruch da das Fahrzeug einen Fehler erkennt.

## Lösung

- **`reraise=True`** auf `SingleComponentUpdateContext`: Ein fehlgeschlagener `set_current(0)`-Aufruf wird nicht mehr geschluckt, sondern als Exception weitergegeben — die Relais werden nicht geschaltet.
- **Aktive Rücklesung** statt blindem Sleep: EVSE-Register wird bis zu 20× im Abstand von 0,5 s abgefragt (max. 10 s). Bei jeder Iteration wird `set_current(0)` erneut gesendet.
- **Abbruch bei Timeout:** Wenn die EVSE nach 10 s keinen Strom von 0 A bestätigt, wird die Phasenumschaltung mit `log.error` abgebrochen. Die Relais werden nicht betätigt.

## Geänderte Datei

- `packages/modules/internal_chargepoint_handler/chargepoint_module.py` — `perform_phase_switch()`

## Test

- Normalbetrieb: EVSE bestätigt 0 A nach 1–2 Abfragen → Phasenwechsel erfolgt wie bisher
- Modbus-Fehler bei `set_current(0)`: Exception wird geworfen → Relais bleiben unangetastet
- EVSE antwortet, aber Strom bleibt > 0: Nach 10 s Timeout → Abbruch mit Fehlermeldung im Log
