### PR TITLE
Fix: evse_current in Evse.__init__ initialisieren

### DIFF
--- a/packages/modules/common/evse.py
+++ b/packages/modules/common/evse.py
@@ -46,6 +46,7 @@ class Evse:
                 if self.is_precise_current_active() is False:
                     self.activate_precise_current()
                 self._precise_current = self.is_precise_current_active()
+        self.evse_current = 0
 
     def get_plug_charge_state(self) -> Tuple[bool, bool, float]:
         time.sleep(0.1)


### PR DESCRIPTION
## Problem

Das Attribut `self.evse_current` wird in `Evse.__init__` nicht initialisiert. Es wird erst beim ersten Aufruf von `get_plug_charge_state()` gesetzt (Zeile 55).

`set_current()` liest `self.evse_current` jedoch direkt in seiner Guard-Bedingung:

`if self.evse_current != formatted_current:`


Wird `set_current()` aufgerufen, **bevor** `get_plug_charge_state()` mindestens einmal gelaufen ist, kommt es zu einem `AttributeError`.

## Auswirkung

Der Ladevorgang kann nicht gestartet werden, wenn die Steuerungsschleife `set_current()` vor dem ersten State-Polling aufruft. Das ist z.B. möglich, wenn direkt nach der Initialisierung ein Strom gesetzt werden soll.

## Lösung

`self.evse_current = 0` wird am Ende von `__init__` gesetzt. Der Wert 0 sorgt dafür, dass der erste `set_current()`-Aufruf immer einen Modbus-Write auslöst (es sei denn, der Sollstrom ist ebenfalls 0 — in dem Fall ist kein Write nötig).