### PR TITLE
fix(colors-display): touch-action:manipulation fuer Lademodus-Buttons…

### DIFF
--- a/packages/modules/display_themes/colors/source/src/components/shared/RadioBarInput.vue
+++ b/packages/modules/display_themes/colors/source/src/components/shared/RadioBarInput.vue
@@ -70,6 +70,7 @@ export type InfoItemValues = {
 	opacity: 1;
 	font-size: var(--font-chargebutton);
 	width: 75px;
+	touch-action: manipulation;
 }
 .btn-outline-secondary.active {
 	background-color: var(--color-bg);


### PR DESCRIPTION
Auf Touchscreens warten Browser ca. 300 ms auf Buttons, um Doppeltipp- Zoom-Gesten zu erkennen. Dadurch scheint beim ersten Antippen eines Lademodus-Buttons nichts zu passieren; die Aktion wird erst beim zweiten Antippen ausgeloest.

Das Hinzufuegen von Touch-action: manipulation zur CSS-Regel .radiobutton weist den Browser an, die Doppeltipp-Gestenerkennung zu uebergehen und Click-Events sofort auszuloesen.

Das cards-Theme (Inkline) setzt diese Eigenschaft bereits global fuer alle button-Elemente in seiner Basis-CSS. Das colors-Theme fehlte dies.

Die Aenderung betrifft zwei Dateien:
- RadioBarInput.vue  (Quellcode)
- index-w83z-Df1.css (vorkompiliertes Asset, wirkt ohne Neubau sofort)

Behebt: Internes Display (Raspberry Pi Touchscreen) erforderte zwei Antipps, um den Lademodus zu wechseln.