### PR TITLE
fix: add minimum energy deviation to PeakFilter for qcells inverter

### DIFF
--- a/packages/modules/common/utils/peak_filter.py
+++ b/packages/modules/common/utils/peak_filter.py
@@ -9,10 +9,17 @@ log = logging.getLogger(__name__)
 
 
 class PeakFilter:
-    def __init__(self, component_type: ComponentType, component_id: int, fault_state: FaultState):
+    def __init__(
+        self,
+        component_type: ComponentType,
+        component_id: int,
+        fault_state: FaultState,
+        minimum_energy_deviation_wh: float = 0,
+    ):
         self.component_type = component_type
         self.component_id = component_id
         self.fault_state = fault_state
+        self.minimum_energy_deviation_wh = max(0, minimum_energy_deviation_wh)
         self.imported = None
         self.exported = None
 
@@ -56,7 +63,8 @@ class PeakFilter:
             # Die erlaubte Abweichung ist doppelt so groß wie die mögliche
             # Energiemenge pro Intervall bei maximaler Leistung
             control_interval = data.data.general_data.data.control_interval
-            allowed_deviation = 2 * (control_interval / 3600) * max_power
+            dynamic_allowed_deviation = 2 * (control_interval / 3600) * max_power
+            allowed_deviation = max(dynamic_allowed_deviation, self.minimum_energy_deviation_wh)
 
             imp = self.check_total_energy(imported, self.imported, allowed_deviation)
             self.imported = imported

--- a/packages/modules/common/utils/test_peak_filter.py
+++ b/packages/modules/common/utils/test_peak_filter.py
@@ -89,3 +89,23 @@ def test_check_values_valid(params):
         imp, exp = pf.check_values(params.power, params.imported, params.exported)
         assert imp == params.expected_imported
         assert exp == params.expected_exported
+
+
+def test_minimum_energy_deviation_accepts_resolution_step():
+    fs = DummyFaultState()
+    pf = PeakFilter(ComponentType.INVERTER, 1, fs, minimum_energy_deviation_wh=100)
+    pf.exported = 1000
+
+    _, exp = pf.check_values(1500, None, 1100)
+
+    assert exp == 1100
+
+
+def test_minimum_energy_deviation_still_filters_above_step():
+    fs = DummyFaultState()
+    pf = PeakFilter(ComponentType.INVERTER, 1, fs, minimum_energy_deviation_wh=100)
+    pf.exported = 1000
+
+    _, exp = pf.check_values(1500, None, 1150)
+
+    assert exp is None

--- a/packages/modules/devices/qcells/qcells/inverter.py
+++ b/packages/modules/devices/qcells/qcells/inverter.py
@@ -28,7 +28,12 @@ class QCellsInverter(AbstractInverter):
         self.client: ModbusTcpClient_ = self.kwargs['client']
         self.store = get_inverter_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
-        self.peak_filter = PeakFilter(ComponentType.INVERTER, self.component_config.id, self.fault_state)
+        self.peak_filter = PeakFilter(
+            ComponentType.INVERTER,
+            self.component_config.id,
+            self.fault_state,
+            minimum_energy_deviation_wh=100,
+        )
 
     def update(self) -> None:
         power_string1 = (self.client.read_input_registers(


### PR DESCRIPTION
Problem: PeakFilter berechnet die maximal erlaubte Energieabweichung anhand der Leistung des Wechselrichters. Es gibt aber Wechselrichter, die die Daten nicht sofort senden sondern in einer Mindestschrittweite. Für diese wirft der Peakfilter somit Fehler/Warnungen, sobald der Wechselrichter an die entsprechende Mindestschrittweite gezählt hat und diese Änderung nun an die openWB sendet.

- PeakFilter unterstützt jetzt einen optionalen Mindestwert für die erlaubte Energieabweichung.
- Für den QCells-Inverter wird 100Wh gesetzt, damit gültige Registersprünge nicht mehr fälschlich gefiltert werden.