### PR TITLE
Upgrade pymodbus 2.5.2 to 3.x (Python 3.12+ compatibility)

### DIFF
--- a/docs/samples/sample_modbus/sample_modbus/bat.py
+++ b/docs/samples/sample_modbus/sample_modbus/bat.py
@@ -53,7 +53,7 @@ class SampleBat(AbstractBat):
         # read_input_registers_bulk benötigit als Parameter das Startregister, die Anzahl der Register,
         # Register-Mapping und die Modbus-ID
         resp = self.client.read_input_registers_bulk(
-            Register.CURRENT_L1, 70, mapping=self.REG_MAPPING, unit=self.id)
+            Register.CURRENT_L1, 70, mapping=self.REG_MAPPING, device_id=self.id)
         imported, exported = self.peak_filter.check_values(resp[Register.POWER],
                                                            resp[Register.IMPORTED],
                                                            resp[Register.EXPORTED])
@@ -66,8 +66,8 @@ class SampleBat(AbstractBat):
         self.store.set(bat_state)
 
         # Einzelregister lesen (dauert länger, bei sehr weit >100 auseinanderliegenden Registern sinnvoll)
-        power = self.client.read_holding_registers(reg, ModbusDataType.INT_32, unit=unit)
-        soc = self.client.read_holding_registers(reg, ModbusDataType.INT_32, unit=unit)
+        power = self.client.read_holding_registers(reg, ModbusDataType.INT_32, device_id=unit)
+        soc = self.client.read_holding_registers(reg, ModbusDataType.INT_32, device_id=unit)
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/docs/samples/sample_modbus/sample_modbus/counter.py
+++ b/docs/samples/sample_modbus/sample_modbus/counter.py
@@ -57,7 +57,7 @@ class SampleCounter(AbstractCounter):
         # read_input_registers_bulk benötigit als Parameter das Startregister, die Anzahl der Register,
         # Register-Mapping und die Modbus-ID
         resp = self.client.read_input_registers_bulk(
-            Register.VOLTAGE_L1, 76, mapping=self.REG_MAPPING, unit=self.id)
+            Register.VOLTAGE_L1, 76, mapping=self.REG_MAPPING, device_id=self.id)
         imported, exported = self.peak_filter.check_values(sum(resp[Register.POWER_L1]),
                                                            resp[Register.IMPORTED],
                                                            resp[Register.EXPORTED])
@@ -74,7 +74,7 @@ class SampleCounter(AbstractCounter):
         self.store.set(counter_state)
 
         # Einzelregister lesen (dauert länger, bei sehr weit >100 auseinanderliegenden Registern sinnvoll)
-        power = self.client.read_holding_registers(reg, ModbusDataType.INT_32, unit=unit)
+        power = self.client.read_holding_registers(reg, ModbusDataType.INT_32, device_id=unit)
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/docs/samples/sample_modbus/sample_modbus/inverter.py
+++ b/docs/samples/sample_modbus/sample_modbus/inverter.py
@@ -51,7 +51,7 @@ class SampleInverter(AbstractInverter):
         # read_input_registers_bulk benötigit als Parameter das Startregister, die Anzahl der Register,
         # Register-Mapping und die Modbus-ID
         resp = self.client.read_input_registers_bulk(
-            Register.CURRENT_L1, 70, mapping=self.REG_MAPPING, unit=self.id)
+            Register.CURRENT_L1, 70, mapping=self.REG_MAPPING, device_id=self.id)
         _, exported = self.peak_filter.check_values(resp[Register.POWER], None, resp[Register.EXPORTED])
         inverter_state = InverterState(
             power=resp[Register.POWER],
@@ -62,7 +62,7 @@ class SampleInverter(AbstractInverter):
         self.store.set(inverter_state)
 
         # Einzelregister lesen (dauert länger, bei sehr weit >100 auseinanderliegenden Registern sinnvoll)
-        power = self.client.read_holding_registers(reg, ModbusDataType.INT_32, unit=unit)
+        power = self.client.read_holding_registers(reg, ModbusDataType.INT_32, device_id=unit)
         self.peak_filter.check_values(power)
         exported = self.sim_counter.sim_count(power)[1]
 

--- a/packages/modbus_control_tester.py
+++ b/packages/modbus_control_tester.py
@@ -4,7 +4,7 @@ from enum import Enum
 import logging
 import struct
 from typing import Optional
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import time
 from modules.common import modbus
 from modules.common.modbus import ModbusDataType
@@ -54,7 +54,7 @@ REGISTERS = (
 
 
 def heartbeat_read():
-    read_client.read_input_registers(10104, modbus.ModbusDataType.INT_16, unit=slave_id)
+    read_client.read_input_registers(10104, modbus.ModbusDataType.INT_16, device_id=slave_id)
 
 
 def read_reg(register: int,
@@ -66,28 +66,28 @@ def read_reg(register: int,
         if action == Actions.READ_NUMBER:
             if read_mode == ReadMode.READ_INPUT_REG:
                 if length > 1:
-                    resp = read_client.read_input_registers(register, [data_type]*length, unit=slave_id)
+                    resp = read_client.read_input_registers(register, [data_type]*length, device_id=slave_id)
                 else:
-                    resp = read_client.read_input_registers(register, data_type, unit=slave_id)
+                    resp = read_client.read_input_registers(register, data_type, device_id=slave_id)
             elif read_mode == ReadMode.READ_HOLDING_REG:
                 if length > 1:
-                    resp = read_client.read_holding_registers(register, [data_type]*length, unit=slave_id)
+                    resp = read_client.read_holding_registers(register, [data_type]*length, device_id=slave_id)
                 else:
-                    resp = read_client.read_holding_registers(register, data_type, unit=slave_id)
+                    resp = read_client.read_holding_registers(register, data_type, device_id=slave_id)
             return resp
         elif action == Actions.READ_STR:
             if read_mode == ReadMode.READ_INPUT_REG:
-                resp = read_client.read_input_registers(register, [modbus.ModbusDataType.INT_16]*length, unit=slave_id)
+                resp = read_client.read_input_registers(register, [modbus.ModbusDataType.INT_16]*length, device_id=slave_id)
             elif read_mode == ReadMode.READ_HOLDING_REG:
                 resp = read_client.read_holding_registers(
-                    register, [modbus.ModbusDataType.INT_16]*length, unit=slave_id)
+                    register, [modbus.ModbusDataType.INT_16]*length, device_id=slave_id)
             string = ""
             for word in resp:
                 string += struct.pack(">h", word).decode("utf-8")
             return resp
         elif action == Actions.WRITE_VALUE:
             client = ModbusTcpClient(host, port=port)
-            client.write_registers(register, write_value, unit=slave_id)
+            client.write_registers(register, write_value, device_id=slave_id)
             return None
     except Exception:
         log.exception("Fehler")

--- a/packages/modules/chargepoints/openwb_series2_satellit/chargepoint_module.py
+++ b/packages/modules/chargepoints/openwb_series2_satellit/chargepoint_module.py
@@ -148,16 +148,16 @@ class ChargepointModule(AbstractChargepoint):
                             time.sleep(5)
                             if phases_to_use == 1:
                                 self._client.client.delegate.write_register(
-                                    0x0001, 256, unit=self.ID_PHASE_SWITCH_UNIT)
+                                    0x0001, 256, device_id=self.ID_PHASE_SWITCH_UNIT)
                                 time.sleep(1)
                                 self._client.client.delegate.write_register(
-                                    0x0001, 512, unit=self.ID_PHASE_SWITCH_UNIT)
+                                    0x0001, 512, device_id=self.ID_PHASE_SWITCH_UNIT)
                             else:
                                 self._client.client.delegate.write_register(
-                                    0x0002, 512, unit=self.ID_PHASE_SWITCH_UNIT)
+                                    0x0002, 512, device_id=self.ID_PHASE_SWITCH_UNIT)
                                 time.sleep(1)
                                 self._client.client.delegate.write_register(
-                                    0x0002, 256, unit=self.ID_PHASE_SWITCH_UNIT)
+                                    0x0002, 256, device_id=self.ID_PHASE_SWITCH_UNIT)
                     except AttributeError:
                         self._create_client()
                         self._validate_version()

--- a/packages/modules/common/b23.py
+++ b/packages/modules/common/b23.py
@@ -46,7 +46,7 @@ class B23(AbstractCounter):
         # Modbus mapping version: 0x8910, 1 Register, only 2 bytes
         data_type = ModbusDataType.UINT_32
         time.sleep(0.1)
-        value = self.client.read_holding_registers(0x8900, data_type, unit=self.id)
+        value = self.client.read_holding_registers(0x8900, data_type, device_id=self.id)
         return str(self.check_nan(value, value, data_type))
 
     def get_currents(self) -> List[float]:
@@ -55,14 +55,14 @@ class B23(AbstractCounter):
         data_type = ModbusDataType.UINT_32
         time.sleep(0.1)
         return [self.check_nan(val, val / 100, data_type)
-                for val in self.client.read_holding_registers(0x5B0C, [data_type]*3, unit=self.id)]
+                for val in self.client.read_holding_registers(0x5B0C, [data_type]*3, device_id=self.id)]
 
     def get_frequency(self) -> float:
         """Returns frequency in Hz.
         """
         data_type = ModbusDataType.UINT_16
         time.sleep(0.1)
-        raw_value = self.client.read_holding_registers(0x5B2C, data_type, unit=self.id)
+        raw_value = self.client.read_holding_registers(0x5B2C, data_type, device_id=self.id)
         return self.check_nan(raw_value, raw_value / 100, data_type)
 
     def get_imported(self) -> float:
@@ -70,12 +70,12 @@ class B23(AbstractCounter):
         """
         data_type = ModbusDataType.UINT_64
         time.sleep(0.1)
-        raw_value = self.client.read_holding_registers(0x5000, data_type, unit=self.id)
+        raw_value = self.client.read_holding_registers(0x5000, data_type, device_id=self.id)
         return self.check_nan(raw_value, raw_value * 10, data_type)
 
     def get_exported(self) -> float:
         time.sleep(0.1)
-        return self.client.read_holding_registers(0x5004, ModbusDataType.UINT_64, unit=self.id) * 10
+        return self.client.read_holding_registers(0x5004, ModbusDataType.UINT_64, device_id=self.id) * 10
 
     def get_power(self) -> Tuple[List[float], float]:
         """Returns power per phase and total power.
@@ -84,7 +84,7 @@ class B23(AbstractCounter):
         time.sleep(0.1)
         # reading of total power and power per phase in one call
         powers = [self.check_nan(val, val / 100, data_type)
-                  for val in self.client.read_holding_registers(0x5B14, [data_type]*4, unit=self.id)]
+                  for val in self.client.read_holding_registers(0x5B14, [data_type]*4, device_id=self.id)]
         return powers[1:4], powers[0]
 
     def get_power_factors(self) -> List[float]:
@@ -95,7 +95,7 @@ class B23(AbstractCounter):
         data_type = ModbusDataType.INT_16
         time.sleep(0.1)
         return [self.check_nan(val, val / 1000, data_type)
-                for val in self.client.read_holding_registers(0x5B3B, [data_type]*3, unit=self.id)]
+                for val in self.client.read_holding_registers(0x5B3B, [data_type]*3, device_id=self.id)]
 
     def get_voltages(self) -> List[float]:
         """Returns voltages for all 3 phases.
@@ -103,7 +103,7 @@ class B23(AbstractCounter):
         data_type = ModbusDataType.UINT_32
         time.sleep(0.1)
         values = [self.check_nan(val, val / 10, data_type)
-                  for val in self.client.read_holding_registers(0x5B00, [data_type]*3, unit=self.id)]
+                  for val in self.client.read_holding_registers(0x5B00, [data_type]*3, device_id=self.id)]
         return values
 
     def get_counter_state(self) -> CounterState:

--- a/packages/modules/common/evse.py
+++ b/packages/modules/common/evse.py
@@ -35,9 +35,9 @@ class Evse:
         self.id = modbus_id
         with client:
             time.sleep(0.1)
-            self.version = self.client.read_holding_registers(1005, ModbusDataType.UINT_16, unit=self.id)
+            self.version = self.client.read_holding_registers(1005, ModbusDataType.UINT_16, device_id=self.id)
             time.sleep(0.1)
-            self.max_current = self.client.read_holding_registers(2007, ModbusDataType.UINT_16, unit=self.id)
+            self.max_current = self.client.read_holding_registers(2007, ModbusDataType.UINT_16, device_id=self.id)
             with ModifyLoglevelContext(log, logging.DEBUG):
                 log.debug(f"Firmware-Version der EVSE: {self.version}")
             if self.version < 17:
@@ -50,7 +50,7 @@ class Evse:
     def get_plug_charge_state(self) -> Tuple[bool, bool, float]:
         time.sleep(0.1)
         raw_set_current, _, state_number = self.client.read_holding_registers(
-            1000, [ModbusDataType.UINT_16]*3, unit=self.id)
+            1000, [ModbusDataType.UINT_16]*3, device_id=self.id)
         # remove leading zeros
         self.evse_current = int(raw_set_current)
         log.debug("Gesetzte Stromstärke EVSE: "+str(self.evse_current) +
@@ -78,7 +78,7 @@ class Evse:
 
     def is_precise_current_active(self) -> bool:
         time.sleep(0.1)
-        value = self.client.read_holding_registers(2005, ModbusDataType.UINT_16, unit=self.id)
+        value = self.client.read_holding_registers(2005, ModbusDataType.UINT_16, device_id=self.id)
         with ModifyLoglevelContext(log, logging.DEBUG):
             if value & self.PRECISE_CURRENT_BIT:
                 log.debug("Angabe der Ströme in 0,01A-Schritten ist aktiviert.")
@@ -89,23 +89,23 @@ class Evse:
 
     def activate_precise_current(self) -> None:
         time.sleep(0.1)
-        value = self.client.read_holding_registers(2005, ModbusDataType.UINT_16, unit=self.id)
+        value = self.client.read_holding_registers(2005, ModbusDataType.UINT_16, device_id=self.id)
         if value & self.PRECISE_CURRENT_BIT:
             return
         else:
             with ModifyLoglevelContext(log, logging.DEBUG):
                 log.debug("Bit zur Angabe der Ströme in 0,1A-Schritten wird gesetzt.")
-            self.client.write_register(2005, value ^ self.PRECISE_CURRENT_BIT, unit=self.id)
+            self.client.write_register(2005, value ^ self.PRECISE_CURRENT_BIT, device_id=self.id)
             # Zeit zum Verarbeiten geben
             time.sleep(1)
 
     def deactivate_precise_current(self) -> None:
         time.sleep(0.1)
-        value = self.client.read_holding_registers(2005, ModbusDataType.UINT_16, unit=self.id)
+        value = self.client.read_holding_registers(2005, ModbusDataType.UINT_16, device_id=self.id)
         if value & self.PRECISE_CURRENT_BIT:
             with ModifyLoglevelContext(log, logging.DEBUG):
                 log.debug("Bit zur Angabe der Ströme in 0,1A-Schritten wird zurueckgesetzt.")
-            self.client.write_register(2005, value ^ self.PRECISE_CURRENT_BIT, unit=self.id)
+            self.client.write_register(2005, value ^ self.PRECISE_CURRENT_BIT, device_id=self.id)
         else:
             return
 
@@ -118,4 +118,4 @@ class Evse:
                 current = 16
         formatted_current = round(current*100) if self._precise_current else round(current)
         if self.evse_current != formatted_current:
-            self.client.write_register(1000, formatted_current, unit=self.id)
+            self.client.write_register(1000, formatted_current, device_id=self.id)

--- a/packages/modules/common/lovato.py
+++ b/packages/modules/common/lovato.py
@@ -17,21 +17,21 @@ class Lovato(AbstractCounter):
 
     def get_voltages(self) -> List[float]:
         return [val / 100 for val in self.client.read_input_registers(
-            0x0001, [ModbusDataType.INT_32]*3, unit=self.id)]
+            0x0001, [ModbusDataType.INT_32]*3, device_id=self.id)]
 
     def get_power(self) -> Tuple[List[float], float]:
         powers = [val / 100 for val in self.client.read_input_registers(
-            0x0013, [ModbusDataType.INT_32]*3, unit=self.id
+            0x0013, [ModbusDataType.INT_32]*3, device_id=self.id
         )]
         power = sum(powers)
         return powers, power
 
     def get_power_factors(self) -> List[float]:
         return [val / 10000 for val in self.client.read_input_registers(
-            0x0025, [ModbusDataType.INT_32]*3, unit=self.id)]
+            0x0025, [ModbusDataType.INT_32]*3, device_id=self.id)]
 
     def get_frequency(self) -> float:
-        frequency = self.client.read_input_registers(0x0031, ModbusDataType.INT_32, unit=self.id) / 100
+        frequency = self.client.read_input_registers(0x0031, ModbusDataType.INT_32, device_id=self.id) / 100
         if frequency > 100:
             # needed if external measurement clamps connected
             frequency = frequency / 10
@@ -39,7 +39,7 @@ class Lovato(AbstractCounter):
 
     def get_currents(self) -> List[float]:
         return [val / 10000 for val in self.client.read_input_registers(
-            0x0007, [ModbusDataType.INT_32]*3, unit=self.id)]
+            0x0007, [ModbusDataType.INT_32]*3, device_id=self.id)]
 
     def get_counter_state(self) -> CounterState:
         powers, power = self.get_power()

--- a/packages/modules/common/modbus.py
+++ b/packages/modules/common/modbus.py
@@ -11,10 +11,10 @@ import time
 from typing import Any, Callable, Iterable, Optional, Union, overload, List
 
 import pymodbus
-from pymodbus.client.sync import ModbusTcpClient, ModbusUdpClient, ModbusSerialClient
-from pymodbus.constants import Endian
-from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder
-from pymodbus.transaction import ModbusSocketFramer
+from pymodbus.client import ModbusTcpClient, ModbusUdpClient, ModbusSerialClient
+from modules.common.pymodbus_compat import Endian
+from modules.common.pymodbus_compat import BinaryPayloadBuilder, BinaryPayloadDecoder
+from pymodbus.framer import FramerType
 from urllib3.util import parse_url
 
 log = logging.getLogger(__name__)
@@ -102,8 +102,7 @@ class ModbusClient:
 
             number_of_addresses = sum(divide_rounding_up(
                 t.bits, _MODBUS_HOLDING_REGISTER_SIZE) for t in types)
-            response = read_register_method(
-                address, number_of_addresses, **kwargs)
+            response = read_register_method(`n                address, count=number_of_addresses, **kwargs)
             if response.isError():
                 raise Exception(__name__+" "+str(response))
             decoder = BinaryPayloadDecoder.fromRegisters(response.registers, byteorder, wordorder)
@@ -176,7 +175,7 @@ class ModbusClient:
 
     def read_coils(self, address: int, count: int, **kwargs):
         try:
-            response = self._delegate.read_coils(address, count, **kwargs)
+            response = self._delegate.read_coils(address, count=count, **kwargs)
             if response.isError():
                 raise Exception(__name__+" "+str(response))
             return response.bits[0] if count == 1 else response.bits[:count]
@@ -235,7 +234,7 @@ class ModbusClient:
         if self.is_socket_open() is False:
             self.connect()
         try:
-            response = read_register_method(start_address, count, **kwargs)
+            response = read_register_method(start_address, count=count, **kwargs)
             if response.isError():
                 raise Exception(__name__+" "+str(response))
             decoder = BinaryPayloadDecoder.fromRegisters(response.registers, byteorder, wordorder)
@@ -299,13 +298,13 @@ class ModbusTcpClient_(ModbusClient):
                  address: str,
                  port: int = 502,
                  sleep_after_connect: Optional[int] = 0,
-                 framer: type[ModbusSocketFramer] = ModbusSocketFramer,
+                 framer=FramerType.SOCKET,
                  **kwargs):
         parsed_url = parse_url(address)
         host = parsed_url.host
         if parsed_url.port is not None:
             port = parsed_url.port
-        super().__init__(ModbusTcpClient(host, port, framer, **kwargs), address, port, sleep_after_connect)
+        super().__init__(ModbusTcpClient(host, port=port, framer=framer, **kwargs), address, port, sleep_after_connect)
 
 
 class ModbusUdpClient_(ModbusClient):
@@ -318,7 +317,7 @@ class ModbusUdpClient_(ModbusClient):
         host = parsed_url.host
         if parsed_url.port is not None:
             port = parsed_url.port
-        super().__init__(ModbusUdpClient(host, port, **kwargs), address, port, sleep_after_connect)
+        super().__init__(ModbusUdpClient(host, port=port, **kwargs), address, port, sleep_after_connect)
 
 
 class ModbusSerialClient_(ModbusClient):
@@ -326,8 +325,8 @@ class ModbusSerialClient_(ModbusClient):
                  port: int,
                  sleep_after_connect: Optional[int] = 0,
                  **kwargs):
-        super().__init__(ModbusSerialClient(method="rtu",
-                                            port=port,
+        super().__init__(ModbusSerialClient(port,
+                                            framer=FramerType.RTU,
                                             baudrate=9600,
                                             stopbits=1,
                                             bytesize=8,

--- a/packages/modules/common/mpm3pm.py
+++ b/packages/modules/common/mpm3pm.py
@@ -17,40 +17,40 @@ class Mpm3pm(AbstractCounter):
 
     def get_voltages(self) -> List[float]:
         return [val / 10 for val in self.client.read_input_registers(
-            0x08, [ModbusDataType.UINT_32]*3, unit=self.id)]
+            0x08, [ModbusDataType.UINT_32]*3, device_id=self.id)]
 
     def get_imported(self) -> float:
         # Faktorisierung anders als in der Dokumentation angegeben
-        return self.client.read_input_registers(0x0002, ModbusDataType.UINT_32, unit=self.id) * 10
+        return self.client.read_input_registers(0x0002, ModbusDataType.UINT_32, device_id=self.id) * 10
 
     def get_power(self) -> Tuple[List[float], float]:
         powers = [val / 100 for val in self.client.read_input_registers(
-            0x14, [ModbusDataType.INT_32]*3, unit=self.id)]
-        power = self.client.read_input_registers(0x26, ModbusDataType.INT_32, unit=self.id) / 100
+            0x14, [ModbusDataType.INT_32]*3, device_id=self.id)]
+        power = self.client.read_input_registers(0x26, ModbusDataType.INT_32, device_id=self.id) / 100
         return powers, power
 
     def get_exported(self) -> float:
         # Faktorisierung anders als in der Dokumentation angegeben
-        return self.client.read_input_registers(0x0004, ModbusDataType.UINT_32, unit=self.id) * 10
+        return self.client.read_input_registers(0x0004, ModbusDataType.UINT_32, device_id=self.id) * 10
 
     def get_power_factors(self) -> List[float]:
         # Faktorisierung anders als in der Dokumentation angegeben?
         factors = [val / 10 for val in self.client.read_input_registers(
-            0x20, [ModbusDataType.UINT_32]*3, unit=self.id)]
+            0x20, [ModbusDataType.UINT_32]*3, device_id=self.id)]
         # check if the absolute value of an entry in factors is greater 1
         if any([abs(factor) > 1 for factor in factors]):
             factors = [factor / 100 for factor in factors]
         return factors
 
     def get_frequency(self) -> float:
-        return self.client.read_input_registers(0x2c, ModbusDataType.UINT_32, unit=self.id) / 100
+        return self.client.read_input_registers(0x2c, ModbusDataType.UINT_32, device_id=self.id) / 100
 
     def get_currents(self) -> List[float]:
         return [val / 100 for val in self.client.read_input_registers(
-            0x0E, [ModbusDataType.UINT_32]*3, unit=self.id)]
+            0x0E, [ModbusDataType.UINT_32]*3, device_id=self.id)]
 
     def get_serial_number(self) -> str:
-        return str(self.client.read_input_registers(0x33, ModbusDataType.UINT_32, unit=self.id))
+        return str(self.client.read_input_registers(0x33, ModbusDataType.UINT_32, device_id=self.id))
 
     def get_counter_state(self) -> CounterState:
         powers, power = self.get_power()

--- a/packages/modules/common/pymodbus_compat.py
+++ b/packages/modules/common/pymodbus_compat.py
@@ -1,0 +1,118 @@
+import struct
+
+
+class Endian:
+    Big = "big"
+    Little = "little"
+
+
+class BinaryPayloadDecoder:
+    def __init__(self, payload, byteorder="big", wordorder="big"):
+        self._payload = payload
+        self._bo = byteorder
+        self._wo = wordorder
+        self._ptr = 0
+
+    @classmethod
+    def fromRegisters(cls, registers, byteorder="big", wordorder="big"):
+        if wordorder == "little":
+            registers = list(reversed(registers))
+        raw = b""
+        for r in registers:
+            raw += struct.pack(">H", r)
+        return cls(raw, byteorder, wordorder)
+
+    def reset(self):
+        self._ptr = 0
+
+    def skip_bytes(self, n):
+        self._ptr += n
+
+    def _decode(self, fmt):
+        sz = struct.calcsize(fmt)
+        data = self._payload[self._ptr:self._ptr + sz]
+        self._ptr += sz
+        if ">" not in fmt and "<" not in fmt:
+            fmt = ">" + fmt
+        return struct.unpack(fmt, data)[0]
+
+    def decode_8bit_uint(self):
+        return self._decode("B")
+
+    def decode_16bit_uint(self):
+        return self._decode(">H")
+
+    def decode_16bit_int(self):
+        return self._decode(">h")
+
+    def decode_32bit_uint(self):
+        return self._decode(">I")
+
+    def decode_32bit_int(self):
+        return self._decode(">i")
+
+    def decode_64bit_uint(self):
+        return self._decode(">Q")
+
+    def decode_64bit_int(self):
+        return self._decode(">q")
+
+    def decode_32bit_float(self):
+        return self._decode(">f")
+
+    def decode_64bit_float(self):
+        return self._decode(">d")
+
+
+class BinaryPayloadBuilder:
+    def __init__(self, byteorder="big", wordorder="big"):
+        self._bo = byteorder
+        self._wo = wordorder
+        self._regs = []
+
+    def reset(self):
+        self._regs = []
+
+    def _add(self, value, fmt):
+        if ">" not in fmt and "<" not in fmt:
+            fmt = ">" + fmt
+        data = struct.pack(fmt, value)
+        regs = []
+        for i in range(0, len(data), 2):
+            chunk = data[i:i+2]
+            if len(chunk) == 1:
+                chunk = b"\x00" + chunk
+            regs.append(struct.unpack(">H", chunk)[0])
+        if self._wo == "little":
+            regs.reverse()
+        self._regs.extend(regs)
+
+    def add_8bit_uint(self, v):
+        self._add(v, "B")
+
+    def add_16bit_uint(self, v):
+        self._add(v, ">H")
+
+    def add_16bit_int(self, v):
+        self._add(v, ">h")
+
+    def add_32bit_uint(self, v):
+        self._add(v, ">I")
+
+    def add_32bit_int(self, v):
+        self._add(v, ">i")
+
+    def add_64bit_uint(self, v):
+        self._add(v, ">Q")
+
+    def add_64bit_int(self, v):
+        self._add(v, ">q")
+
+    def add_32bit_float(self, v):
+        self._add(v, ">f")
+
+    def add_64bit_float(self, v):
+        self._add(v, ">d")
+
+    def to_registers(self):
+        return list(self._regs)

--- a/packages/modules/common/sdm.py
+++ b/packages/modules/common/sdm.py
@@ -20,12 +20,12 @@ class Sdm(AbstractCounter):
         self.id = modbus_id
         self.fast_mode = True
         with client:
-            self.serial_number = str(self.client.read_holding_registers(0xFC00, ModbusDataType.UINT_32, unit=self.id))
+            self.serial_number = str(self.client.read_holding_registers(0xFC00, ModbusDataType.UINT_32, device_id=self.id))
 
     def get_imported(self) -> float:
         # smarthome legacy
         time.sleep(0.1)
-        return self.client.read_input_registers(0x0048, ModbusDataType.FLOAT_32, unit=self.id) * 1000
+        return self.client.read_input_registers(0x0048, ModbusDataType.FLOAT_32, device_id=self.id) * 1000
 
 
 class SdmRegister(IntEnum):
@@ -57,14 +57,14 @@ class Sdm630_72(Sdm):
     def get_power(self) -> Tuple[List[float], float]:
         # smarthome legacy
         time.sleep(0.1)
-        powers = self.client.read_input_registers(0x0C, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+        powers = self.client.read_input_registers(0x0C, [ModbusDataType.FLOAT_32]*3, device_id=self.id)
         power = sum(powers)
         return powers, power
 
     def get_voltages(self) -> Tuple[List[float], float]:
         # client handler
         time.sleep(0.1)
-        return self.client.read_input_registers(0x00, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+        return self.client.read_input_registers(0x00, [ModbusDataType.FLOAT_32]*3, device_id=self.id)
 
     def get_counter_state(self) -> CounterState:
         # entgegen der Doku können nicht bei allen SDM72 80 Register auf einmal gelesen werden,
@@ -73,18 +73,18 @@ class Sdm630_72(Sdm):
             try:
                 time.sleep(0.1)
                 bulk_1 = self.client.read_input_registers_bulk(
-                    SdmRegister.VOLTAGE_L1, 18, mapping=self.REG_MAPPING_BULK_1, unit=self.id)
+                    SdmRegister.VOLTAGE_L1, 18, mapping=self.REG_MAPPING_BULK_1, device_id=self.id)
                 time.sleep(0.1)
                 power_factors = self.client.read_input_registers(
-                    SdmRegister.POWER_FACTOR_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+                    SdmRegister.POWER_FACTOR_L1, [ModbusDataType.FLOAT_32]*3, device_id=self.id)
                 time.sleep(0.1)
                 bulk_2 = self.client.read_input_registers_bulk(
-                    SdmRegister.FREQUENCY, 6, mapping=self.REG_MAPPING_BULK_2, unit=self.id)
+                    SdmRegister.FREQUENCY, 6, mapping=self.REG_MAPPING_BULK_2, device_id=self.id)
                 resp = {**bulk_1, **bulk_2}
             except Exception:
                 log.exception("Fehler beim Auslesen des Zählers")
                 self.client.read_input_registers(
-                    SdmRegister.VOLTAGE_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+                    SdmRegister.VOLTAGE_L1, [ModbusDataType.FLOAT_32]*3, device_id=self.id)
                 self.fast_mode = False
         if self.fast_mode is False:
             # im gleichen Durchlauf noch im slow mode versuchen, sonst schlägt der Hardware-Check fehl
@@ -92,23 +92,23 @@ class Sdm630_72(Sdm):
             resp = {}
             time.sleep(0.1)
             resp[SdmRegister.VOLTAGE_L1] = self.client.read_input_registers(
-                SdmRegister.VOLTAGE_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+                SdmRegister.VOLTAGE_L1, [ModbusDataType.FLOAT_32]*3, device_id=self.id)
             time.sleep(0.1)
             resp[SdmRegister.CURRENT_L1] = self.client.read_input_registers(
-                SdmRegister.CURRENT_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+                SdmRegister.CURRENT_L1, [ModbusDataType.FLOAT_32]*3, device_id=self.id)
             time.sleep(0.1)
             resp[SdmRegister.POWER_L1] = self.client.read_input_registers(
-                SdmRegister.POWER_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+                SdmRegister.POWER_L1, [ModbusDataType.FLOAT_32]*3, device_id=self.id)
             time.sleep(0.1)
             power_factors = self.client.read_input_registers(
-                SdmRegister.POWER_FACTOR_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
+                SdmRegister.POWER_FACTOR_L1, [ModbusDataType.FLOAT_32]*3, device_id=self.id)
             time.sleep(0.1)
             # frequency noch mit auslesen klappt nicht
             resp[SdmRegister.IMPORTED], resp[SdmRegister.EXPORTED] = self.client.read_input_registers(
-                SdmRegister.IMPORTED, [ModbusDataType.FLOAT_32]*2, unit=self.id)
+                SdmRegister.IMPORTED, [ModbusDataType.FLOAT_32]*2, device_id=self.id)
             time.sleep(0.1)
             resp[SdmRegister.FREQUENCY] = self.client.read_input_registers(
-                SdmRegister.FREQUENCY, ModbusDataType.FLOAT_32, unit=self.id)
+                SdmRegister.FREQUENCY, ModbusDataType.FLOAT_32, device_id=self.id)
 
         frequency = resp[SdmRegister.FREQUENCY]
         if frequency > 100:
@@ -147,19 +147,19 @@ class Sdm120(Sdm):
     def get_power(self) -> Tuple[List[float], float]:
         # smarthome legacy
         time.sleep(0.1)
-        power = self.client.read_input_registers(0x0C, ModbusDataType.FLOAT_32, unit=self.id)
+        power = self.client.read_input_registers(0x0C, ModbusDataType.FLOAT_32, device_id=self.id)
         return [power, 0, 0], power
 
     def get_counter_state(self) -> CounterState:
         # beim SDM120 steht nichts von Bulk-Reads in der Doku, daher auch auf 20 Register limitiert
         time.sleep(0.1)
         bulk_1 = self.client.read_input_registers_bulk(
-            SdmRegister.VOLTAGE_L1, 14, mapping=self.REG_MAPPING_BULK_1, unit=self.id)
+            SdmRegister.VOLTAGE_L1, 14, mapping=self.REG_MAPPING_BULK_1, device_id=self.id)
         time.sleep(0.1)
-        power_factor = self.client.read_input_registers(0x1E, ModbusDataType.FLOAT_32, unit=self.id)
+        power_factor = self.client.read_input_registers(0x1E, ModbusDataType.FLOAT_32, device_id=self.id)
         time.sleep(0.1)
         bulk_2 = self.client.read_input_registers_bulk(
-            SdmRegister.FREQUENCY, 6, mapping=self.REG_MAPPING_BULK_2, unit=self.id)
+            SdmRegister.FREQUENCY, 6, mapping=self.REG_MAPPING_BULK_2, device_id=self.id)
         resp = {**bulk_1, **bulk_2}
         frequency = resp[SdmRegister.FREQUENCY]
         if frequency > 100:

--- a/packages/modules/conftest.py
+++ b/packages/modules/conftest.py
@@ -20,11 +20,17 @@ sys.modules['pycarwings3'] = type(sys)('pycarwings3')
 
 # sys.modules['telnetlib3'] = type(sys)('telnetlib3')
 
-module = type(sys)('pymodbus.client.sync')
+module = type(sys)('pymodbus.client')
 module.ModbusSerialClient = Mock()
 module.ModbusTcpClient = Mock()
 module.ModbusUdpClient = Mock()
-sys.modules['pymodbus.client.sync'] = module
+sys.modules['pymodbus.client'] = module
+
+module = type(sys)('pymodbus.framer')
+module.FramerType = Mock()
+module.FramerType.SOCKET = 'socket'
+module.FramerType.RTU = 'rtu'
+sys.modules['pymodbus.framer'] = module
 
 module = type(sys)('pymodbus.constants')
 module.Endian = Mock()
@@ -35,8 +41,6 @@ module.BinaryPayloadDecoder = Mock()
 sys.modules['pymodbus.payload'] = module
 
 module = type(sys)('pymodbus.transaction')
-module.ModbusSocketFramer = Mock()
-module.ModbusRtuFramer = Mock()
 sys.modules['pymodbus.transaction'] = module
 
 module = type(sys)('socketserver')

--- a/packages/modules/devices/algodue/algodue/bat.py
+++ b/packages/modules/devices/algodue/algodue/bat.py
@@ -36,8 +36,8 @@ class AlgodueBat(AbstractBat):
 
     def update(self):
         currents = self.__tcp_client.read_input_registers(
-            0x100E, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
-        powers = self.__tcp_client.read_input_registers(0x1020, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
+            0x100E, [ModbusDataType.FLOAT_32]*3, device_id=self.__modbus_id)
+        powers = self.__tcp_client.read_input_registers(0x1020, [ModbusDataType.FLOAT_32]*3, device_id=self.__modbus_id)
         power = sum(powers)
 
         self.peak_filter.check_values(power)

--- a/packages/modules/devices/algodue/algodue/counter.py
+++ b/packages/modules/devices/algodue/algodue/counter.py
@@ -35,15 +35,15 @@ class AlgodueCounter(AbstractCounter):
         self.peak_filter = PeakFilter(ComponentType.COUNTER, self.component_config.id, self.fault_state)
 
     def update(self):
-        frequency = self.__tcp_client.read_input_registers(0x1038, ModbusDataType.FLOAT_32, unit=self.__modbus_id)
+        frequency = self.__tcp_client.read_input_registers(0x1038, ModbusDataType.FLOAT_32, device_id=self.__modbus_id)
         currents = self.__tcp_client.read_input_registers(
-            0x100E, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
-        powers = self.__tcp_client.read_input_registers(0x1020, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
+            0x100E, [ModbusDataType.FLOAT_32]*3, device_id=self.__modbus_id)
+        powers = self.__tcp_client.read_input_registers(0x1020, [ModbusDataType.FLOAT_32]*3, device_id=self.__modbus_id)
         power = sum(powers)
         voltages = self.__tcp_client.read_input_registers(
-            0x1000, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
+            0x1000, [ModbusDataType.FLOAT_32]*3, device_id=self.__modbus_id)
         power_factors = self.__tcp_client.read_input_registers(
-            0x1018, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
+            0x1018, [ModbusDataType.FLOAT_32]*3, device_id=self.__modbus_id)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
@@ -63,8 +63,8 @@ class AlgodueCounter(AbstractCounter):
 
 component_descriptor = ComponentDescriptor(configuration_factory=AlgodueCounterSetup)
 
-# serial_chars = self.client.read_holding_registers(0x500, [ModbusDataType.UINT_8]*10, unit=self.id)
-# model_id = self.client.read_holding_registers(0x505, ModbusDataType.UINT_16, unit=self.id)
+# serial_chars = self.client.read_holding_registers(0x500, [ModbusDataType.UINT_8]*10, device_id=self.id)
+# model_id = self.client.read_holding_registers(0x505, ModbusDataType.UINT_16, device_id=self.id)
 # model_string = "unknown"
 # if model_id == 0x03:
 #     model_string = "6 A, 3 phases, 4 wires"
@@ -77,7 +77,7 @@ component_descriptor = ComponentDescriptor(configuration_factory=AlgodueCounterS
 # elif model_id == 0x12:
 #     model_string = "63 A, 3 phases, 4 wires"
 
-# type_id = self.client.read_holding_registers(0x506, ModbusDataType.UINT_16, unit=self.id)
+# type_id = self.client.read_holding_registers(0x506, ModbusDataType.UINT_16, device_id=self.id)
 # type_string = "unknown"
 # if type_id == 0x00:
 #     type_string = "NO MID, RESET"

--- a/packages/modules/devices/algodue/algodue/inverter.py
+++ b/packages/modules/devices/algodue/algodue/inverter.py
@@ -36,8 +36,8 @@ class AlgodueInverter(AbstractInverter):
 
     def update(self):
         currents = self.__tcp_client.read_input_registers(
-            0x100E, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
-        powers = self.__tcp_client.read_input_registers(0x1020, [ModbusDataType.FLOAT_32]*3, unit=self.__modbus_id)
+            0x100E, [ModbusDataType.FLOAT_32]*3, device_id=self.__modbus_id)
+        powers = self.__tcp_client.read_input_registers(0x1020, [ModbusDataType.FLOAT_32]*3, device_id=self.__modbus_id)
         power = sum(powers)
 
         self.peak_filter.check_values(power)

--- a/packages/modules/devices/alpha_ess/alpha_ess/bat.py
+++ b/packages/modules/devices/alpha_ess/alpha_ess/bat.py
@@ -39,9 +39,9 @@ class AlphaEssBat(AbstractBat):
         # keine Unterschiede zwischen den Versionen
 
         time.sleep(0.1)
-        voltage = self.__tcp_client.read_holding_registers(0x0100, ModbusDataType.INT_16, unit=self.__modbus_id)
+        voltage = self.__tcp_client.read_holding_registers(0x0100, ModbusDataType.INT_16, device_id=self.__modbus_id)
         time.sleep(0.1)
-        current = self.__tcp_client.read_holding_registers(0x0101, ModbusDataType.INT_16, unit=self.__modbus_id)
+        current = self.__tcp_client.read_holding_registers(0x0101, ModbusDataType.INT_16, device_id=self.__modbus_id)
 
         power = voltage * current * -1 / 100
         log.debug(
@@ -49,7 +49,7 @@ class AlphaEssBat(AbstractBat):
             (power, voltage, current)
         )
         time.sleep(0.1)
-        soc_reg = self.__tcp_client.read_holding_registers(0x0102, ModbusDataType.INT_16, unit=self.__modbus_id)
+        soc_reg = self.__tcp_client.read_holding_registers(0x0102, ModbusDataType.INT_16, device_id=self.__modbus_id)
         soc = int(soc_reg * 0.1)
 
         self.peak_filter.check_values(power)
@@ -69,7 +69,7 @@ class AlphaEssBat(AbstractBat):
             # Kein Powerlimit gefordert, externe Steuerung deaktivieren
             log.debug("Keine Batteriesteuerung gefordert, deaktiviere externe Steuerung.")
             if self.last_mode is not None:
-                self.__tcp_client.write_register(2127, 0, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(2127, 0, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = None
         elif power_limit <= 0:
             # AlphaESS kann die Entladung nur über den SoC verhindern (komplette Entladesperre)
@@ -77,15 +77,15 @@ class AlphaEssBat(AbstractBat):
             # Zeiten für Netzladung müssen im Wechselrichter aktiviert werden
             log.debug("Aktive Batteriesteuerung angestoßen. Setze Entladesperre.")
             if self.last_mode != 'stop':
-                self.__tcp_client.write_register(2127, 1, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(2133, 10, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(2127, 1, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(2133, 10, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'stop'
         else:
             # Aktive Ladung
             log.debug("Aktive Batteriesteuerung angestoßen. Setze aktive Ladung.")
             if self.last_mode != 'charge':
-                self.__tcp_client.write_register(2127, 1, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(2133, 100, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(2127, 1, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(2133, 100, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'charge'
 
     def power_limit_controllable(self) -> bool:

--- a/packages/modules/devices/alpha_ess/alpha_ess/counter.py
+++ b/packages/modules/devices/alpha_ess/alpha_ess/counter.py
@@ -37,12 +37,12 @@ class AlphaEssCounter(AbstractCounter):
         time.sleep(0.1)
         if self.__device_config.source == 0 and self.__device_config.version == 0:
             power, exported, imported = self.__tcp_client.read_holding_registers(
-                0x6, [modbus.ModbusDataType.INT_32] * 3, unit=self.__modbus_id)
+                0x6, [modbus.ModbusDataType.INT_32] * 3, device_id=self.__modbus_id)
             exported *= 10
             imported *= 10
             imported, exported = self.peak_filter.check_values(power, imported, exported)
             currents = [val / 230 for val in self.__tcp_client.read_holding_registers(
-                0x0000, [ModbusDataType.INT_32]*3, unit=self.__modbus_id)]
+                0x0000, [ModbusDataType.INT_32]*3, device_id=self.__modbus_id)]
             counter_state = CounterState(
                 currents=currents,
                 imported=imported,
@@ -50,18 +50,18 @@ class AlphaEssCounter(AbstractCounter):
                 power=power
             )
         else:
-            power = self.__tcp_client.read_holding_registers(0x0021, ModbusDataType.INT_32, unit=self.__modbus_id)
+            power = self.__tcp_client.read_holding_registers(0x0021, ModbusDataType.INT_32, device_id=self.__modbus_id)
             exported, imported = [
                 val * 10 for val in self.__tcp_client.read_holding_registers(
-                    0x0010, [ModbusDataType.INT_32] * 2, unit=self.__modbus_id
+                    0x0010, [ModbusDataType.INT_32] * 2, device_id=self.__modbus_id
                 )]
             imported, exported = self.peak_filter.check_values(power, imported, exported)
             frequency = self.__tcp_client.read_holding_registers(
-                0x001A, ModbusDataType.UINT_16, unit=self.__modbus_id) / 100
+                0x001A, ModbusDataType.UINT_16, device_id=self.__modbus_id) / 100
             currents = self.__tcp_client.read_holding_registers(
-                0x0017, [ModbusDataType.INT_16]*3, unit=self.__modbus_id)
+                0x0017, [ModbusDataType.INT_16]*3, device_id=self.__modbus_id)
             powers = self.__tcp_client.read_holding_registers(
-                0x001b, [ModbusDataType.INT_32]*3, unit=self.__modbus_id)
+                0x001b, [ModbusDataType.INT_32]*3, device_id=self.__modbus_id)
             currents = scale_currents(currents, powers)
             counter_state = CounterState(
                 currents=currents,

--- a/packages/modules/devices/alpha_ess/alpha_ess/inverter.py
+++ b/packages/modules/devices/alpha_ess/alpha_ess/inverter.py
@@ -56,7 +56,7 @@ class AlphaEssInverter(AbstractInverter):
 
     def __get_power(self, reg_p: int) -> Number:
         powers = [
-            self.__tcp_client.read_holding_registers(address, ModbusDataType.INT_32, unit=self.__modbus_id)
+            self.__tcp_client.read_holding_registers(address, ModbusDataType.INT_32, device_id=self.__modbus_id)
             for address in [reg_p, 0x041F, 0x0423, 0x0427]
         ]
         powers[0] = abs(powers[0])

--- a/packages/modules/devices/ampere/ampere/bat.py
+++ b/packages/modules/devices/ampere/ampere/bat.py
@@ -36,8 +36,8 @@ class AmpereBat(AbstractBat):
         self.client = self.kwargs['client']
 
     def update(self) -> None:
-        power = self.client.read_input_registers(535, ModbusDataType.INT_16, unit=self.modbus_id) * -1
-        soc = self.client.read_input_registers(1339, ModbusDataType.UINT_16, unit=self.modbus_id)
+        power = self.client.read_input_registers(535, ModbusDataType.INT_16, device_id=self.modbus_id) * -1
+        soc = self.client.read_input_registers(1339, ModbusDataType.UINT_16, device_id=self.modbus_id)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/ampere/ampere/counter.py
+++ b/packages/modules/devices/ampere/ampere/counter.py
@@ -36,8 +36,8 @@ class AmpereCounter(AbstractCounter):
         self.peak_filter = PeakFilter(ComponentType.COUNTER, self.component_config.id, self.fault_state)
 
     def update(self):
-        powers = self.client.read_input_registers(1349, [ModbusDataType.INT_16]*3, unit=self.modbus_id)
-        power = self.client.read_input_registers(1348, ModbusDataType.INT_16, unit=self.modbus_id)
+        powers = self.client.read_input_registers(1349, [ModbusDataType.INT_16]*3, device_id=self.modbus_id)
+        power = self.client.read_input_registers(1348, ModbusDataType.INT_16, device_id=self.modbus_id)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/ampere/ampere/inverter.py
+++ b/packages/modules/devices/ampere/ampere/inverter.py
@@ -36,8 +36,8 @@ class AmpereInverter(AbstractInverter):
         self.peak_filter = PeakFilter(ComponentType.INVERTER, self.component_config.id, self.fault_state)
 
     def update(self) -> None:
-        pv1_power = self.client.read_holding_registers(519, ModbusDataType.INT_16, unit=self.modbus_id) * -1
-        pv2_power = self.client.read_holding_registers(522, ModbusDataType.INT_16, unit=self.modbus_id) * -1
+        pv1_power = self.client.read_holding_registers(519, ModbusDataType.INT_16, device_id=self.modbus_id) * -1
+        pv2_power = self.client.read_holding_registers(522, ModbusDataType.INT_16, device_id=self.modbus_id) * -1
 
         power = pv1_power + pv2_power
 

--- a/packages/modules/devices/azzurro_zcs/azzurro_zcs/bat.py
+++ b/packages/modules/devices/azzurro_zcs/azzurro_zcs/bat.py
@@ -33,15 +33,15 @@ class ZCSBat(AbstractBat):
         # 0x020D Battery charge-discharge power Int16 -10-10 kW accuracy 0,01 kW pos charge, neg discharge
         # 0x020E Battery voltage Cell UInt16 0-100 V accuracy 0,1 V
         # 0x020F Battery charge-discharge current Int -100-100 A accuracy 0,01A
-        power = self.client.read_input_registers(0x020D, ModbusDataType.INT_16, unit=self.__modbus_id)
+        power = self.client.read_input_registers(0x020D, ModbusDataType.INT_16, device_id=self.__modbus_id)
         # 0x0210 SoC UInt16 0-100 %
-        soc = self.client.read_input_registers(0x0210, ModbusDataType.UINT_16, unit=self.__modbus_id)
+        soc = self.client.read_input_registers(0x0210, ModbusDataType.UINT_16, device_id=self.__modbus_id)
         # 0x0227 Total energy charging battery low UInt16 in kWh LSB
         imported = self.client.read_input_registers(
-            0x0227, ModbusDataType.UINT_16, unit=self.__modbus_id) * 100
+            0x0227, ModbusDataType.UINT_16, device_id=self.__modbus_id) * 100
         # 0x0229 Total energy discharging battery low UInt16 in kWh LSB
         exported = self.client.read_input_registers(
-            0x0229, ModbusDataType.UINT_16, unit=self.__modbus_id) * 100
+            0x0229, ModbusDataType.UINT_16, device_id=self.__modbus_id) * 100
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/azzurro_zcs/azzurro_zcs/counter.py
+++ b/packages/modules/devices/azzurro_zcs/azzurro_zcs/counter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractCounter
 from modules.common.component_state import CounterState
@@ -36,22 +36,22 @@ class ZCSCounter(AbstractCounter):
         # 0x0212 Grid Power Int16 -10-10 kW Unit 0,01kW Feed in/out power
         # 0x0214 Input/Output power Int16 -10-10kW 0,01kW Energy storage power inverter
         power = self.client.read_input_registers(0x0212, ModbusDataType.INT_16, wordorder=Endian.Little,
-                                                 unit=self.__modbus_id) * -1
+                                                 device_id=self.__modbus_id) * -1
         # 0x020C Grid frequency UInt 0-100 Hz Unit 0,01 Hz
         frequency = self.client.read_input_registers(
-            0x020C, ModbusDataType.UINT_16, unit=self.__modbus_id) / 100
+            0x020C, ModbusDataType.UINT_16, device_id=self.__modbus_id) / 100
         exported = [value * 10
                     for value in self.client.read_input_registers(
                         # 0x021E Total energy injected into the grid UInt16 Unit 1kWh high
                         # 0x021F Total energy injected into the grid UInt16 Unit 1kWh low
                         0x021E, [ModbusDataType.UINT_16] * 10,
-                        wordorder=Endian.Little, unit=self.__modbus_id)]
+                        wordorder=Endian.Little, device_id=self.__modbus_id)]
         imported = [value * 10
                     for value in self.client.read_input_registers(
                         # 0x0220 Total energy taken from the grid UInt16 Unit 1kWh high
                         # 0x0221 Total energy taken from the grid UInt16 Unit 1kWh low
                         0x0220, [ModbusDataType.UINT_16] * 10,
-                        wordorder=Endian.Little, unit=self.__modbus_id)]
+                        wordorder=Endian.Little, device_id=self.__modbus_id)]
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(

--- a/packages/modules/devices/azzurro_zcs/azzurro_zcs/inverter.py
+++ b/packages/modules/devices/azzurro_zcs/azzurro_zcs/inverter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractInverter
 from modules.common.component_state import InverterState
@@ -35,18 +35,18 @@ class ZCSInverter(AbstractInverter):
         # 0x0250 PV1 Voltage UInt16 0-1000V Unit 0,1V
         # 0x0251 PV1 current Int16 0-100A Unit 0,01A
         power_string1 = (self.client.read_input_registers(
-            0x0250, ModbusDataType.UINT_16, unit=self.__modbus_id) / 10) * \
-            (self.client.read_input_registers(0x0251, ModbusDataType.INT_16, unit=self.__modbus_id) / 10)
+            0x0250, ModbusDataType.UINT_16, device_id=self.__modbus_id) / 10) * \
+            (self.client.read_input_registers(0x0251, ModbusDataType.INT_16, device_id=self.__modbus_id) / 10)
         # 0x0255 PV2 Power UInt16 0-100 kW Unit 0,01kW
         # 0x0253 PV2 Voltage UInt16 0-1000V Unit 0,1V
         # 0x0254 PV2 current Int16 0-100A Unit 0,01A
         power_string2 = (self.client.read_input_registers(
-            0x0253, ModbusDataType.INT_16, unit=self.__modbus_id) / 10) * \
-            (self.client.read_input_registers(0x0254, ModbusDataType.INT_16, unit=self.__modbus_id) / 10)
+            0x0253, ModbusDataType.INT_16, device_id=self.__modbus_id) / 10) * \
+            (self.client.read_input_registers(0x0254, ModbusDataType.INT_16, device_id=self.__modbus_id) / 10)
         power = (power_string1 + power_string2) * -1
         # 0x0215 PV Power generation UInt16 0 -10 kW Unit 0,01kW
         exported = self.client.read_input_registers(0x0215, ModbusDataType.UINT_16, wordorder=Endian.Little,
-                                                    unit=self.__modbus_id) * 100
+                                                    device_id=self.__modbus_id) * 100
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/azzurro_zcs/azzurro_zcs_3p/pv_inverter.py
+++ b/packages/modules/devices/azzurro_zcs/azzurro_zcs_3p/pv_inverter.py
@@ -35,12 +35,12 @@ class ZCSPvInverter(AbstractInverter):
         power = exported = 0
         currents = None
         try:
-            power = self.client.read_holding_registers(0x0485, ModbusDataType.INT_16, unit=self.__modbus_id)*10
-            exported = self.client.read_holding_registers(0x0684, ModbusDataType.UINT_32, unit=self.__modbus_id)*10
+            power = self.client.read_holding_registers(0x0485, ModbusDataType.INT_16, device_id=self.__modbus_id)*10
+            exported = self.client.read_holding_registers(0x0684, ModbusDataType.UINT_32, device_id=self.__modbus_id)*10
             currents = [
-                self.client.read_holding_registers(0x48E, ModbusDataType.INT_16, unit=self.__modbus_id)*0.01,
-                self.client.read_holding_registers(0x499, ModbusDataType.INT_16, unit=self.__modbus_id)*0.01,
-                self.client.read_holding_registers(0x4A4, ModbusDataType.INT_16, unit=self.__modbus_id)*0.01
+                self.client.read_holding_registers(0x48E, ModbusDataType.INT_16, device_id=self.__modbus_id)*0.01,
+                self.client.read_holding_registers(0x499, ModbusDataType.INT_16, device_id=self.__modbus_id)*0.01,
+                self.client.read_holding_registers(0x4A4, ModbusDataType.INT_16, device_id=self.__modbus_id)*0.01
             ]
         except Exception:
             log.debug("Modbus could not be read.")

--- a/packages/modules/devices/carlo_gavazzi/carlo_gavazzi/counter.py
+++ b/packages/modules/devices/carlo_gavazzi/carlo_gavazzi/counter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from typing import Any, TypedDict
 
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.devices.carlo_gavazzi.carlo_gavazzi.config import CarloGavazziCounterSetup
 from modules.common import modbus
@@ -39,13 +39,13 @@ class CarloGavazziCounter(AbstractCounter):
     def update(self):
         with self.__tcp_client:
             voltages = [val / 10 for val in self.__tcp_client.read_input_registers(
-                0x00, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=self.__modbus_id)]
+                0x00, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, device_id=self.__modbus_id)]
             powers = [val / 10 for val in self.__tcp_client.read_input_registers(
-                0x12, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=self.__modbus_id)]
+                0x12, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, device_id=self.__modbus_id)]
             power = sum(powers)
             currents = [(val / 1000) for val in self.__tcp_client.read_input_registers(
-                0x0C, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=self.__modbus_id)]
-            frequency = self.__tcp_client.read_input_registers(0x33, ModbusDataType.INT_16, unit=self.__modbus_id) / 10
+                0x0C, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, device_id=self.__modbus_id)]
+            frequency = self.__tcp_client.read_input_registers(0x33, ModbusDataType.INT_16, device_id=self.__modbus_id) / 10
             if frequency > 100:
                 frequency = frequency / 10
 

--- a/packages/modules/devices/chint/chint/counter.py
+++ b/packages/modules/devices/chint/chint/counter.py
@@ -33,30 +33,30 @@ class CHINTCounter(AbstractCounter):
     def update(self):
         powers = voltages = currents = power_factors = None
         imported_ep = exported_ep = power = frequency = 0
-        irat = self.client.read_holding_registers(0x0006, ModbusDataType.INT_16, unit=self.__modbus_id)
-        urat = self.client.read_holding_registers(0x0007, ModbusDataType.INT_16, unit=self.__modbus_id)
+        irat = self.client.read_holding_registers(0x0006, ModbusDataType.INT_16, device_id=self.__modbus_id)
+        urat = self.client.read_holding_registers(0x0007, ModbusDataType.INT_16, device_id=self.__modbus_id)
         power_ratio = urat*0.1*irat*0.1
 
-        frequency = self.client.read_holding_registers(0x2044, ModbusDataType.FLOAT_32, unit=self.__modbus_id)/100
+        frequency = self.client.read_holding_registers(0x2044, ModbusDataType.FLOAT_32, device_id=self.__modbus_id)/100
         power = self.client.read_holding_registers(0x2012,
-                                                   ModbusDataType.FLOAT_32, unit=self.__modbus_id) * power_ratio
-        powers = [self.client.read_holding_registers(reg, ModbusDataType.FLOAT_32, unit=self.__modbus_id) * power_ratio
+                                                   ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * power_ratio
+        powers = [self.client.read_holding_registers(reg, ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * power_ratio
                   for reg in [0x2014, 0x2016, 0x2018]]
         voltage_ratio = urat*0.1*0.1
         voltages = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.__modbus_id) * voltage_ratio
+            reg, ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * voltage_ratio
             for reg in [0x2006, 0x2008, 0x200A]]
         current_ratio = irat*0.001
         currents = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.__modbus_id) * current_ratio
+            reg, ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * current_ratio
             for reg in [0x200C, 0x200E, 0x2010]]
-        power_factors = [self.client.read_holding_registers(reg, ModbusDataType.FLOAT_32, unit=self.__modbus_id) * 0.001
+        power_factors = [self.client.read_holding_registers(reg, ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * 0.001
                          for reg in [0x202C, 0x202E, 0x2030]]
         ep_ratio = irat * urat * 100
         imported_ep = self.client.read_holding_registers(0x401E,
-                                                         ModbusDataType.FLOAT_32, unit=self.__modbus_id) * ep_ratio
+                                                         ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * ep_ratio
         exported_ep = self.client.read_holding_registers(0x4028,
-                                                         ModbusDataType.FLOAT_32, unit=self.__modbus_id) * ep_ratio
+                                                         ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * ep_ratio
 
         imported_ep, exported_ep = self.peak_filter.check_values(power, imported_ep, exported_ep)
 

--- a/packages/modules/devices/deye/deye/bat.py
+++ b/packages/modules/devices/deye/deye/bat.py
@@ -33,18 +33,18 @@ class DeyeBat(AbstractBat):
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="speicher")
         self.device_type = DeviceType(self.client.read_holding_registers(
-            0, ModbusDataType.INT_16, unit=self.component_config.configuration.modbus_id))
+            0, ModbusDataType.INT_16, device_id=self.component_config.configuration.modbus_id))
 
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
         if self.device_type == DeviceType.SINGLE_PHASE_STRING or self.device_type == DeviceType.SINGLE_PHASE_HYBRID:
-            power = self.client.read_holding_registers(190, ModbusDataType.INT_16, unit=unit) * -1
-            soc = self.client.read_holding_registers(184, ModbusDataType.INT_16, unit=unit)
+            power = self.client.read_holding_registers(190, ModbusDataType.INT_16, device_id=unit) * -1
+            soc = self.client.read_holding_registers(184, ModbusDataType.INT_16, device_id=unit)
 
             if self.device_type == DeviceType.SINGLE_PHASE_HYBRID:
-                imported = self.client.read_holding_registers(72, ModbusDataType.UINT_16, unit=unit) * 100
-                exported = self.client.read_holding_registers(74, ModbusDataType.UINT_16, unit=unit) * 100
+                imported = self.client.read_holding_registers(72, ModbusDataType.UINT_16, device_id=unit) * 100
+                exported = self.client.read_holding_registers(74, ModbusDataType.UINT_16, device_id=unit) * 100
                 imported, exported = self.peak_filter.check_values(power, imported, exported)
 
             elif self.device_type == DeviceType.SINGLE_PHASE_STRING:
@@ -52,11 +52,11 @@ class DeyeBat(AbstractBat):
                 imported, exported = self.sim_counter.sim_count(power)
 
         else:  # THREE_PHASE_LV (0x0500, 0x0005), THREE_PHASE_HV (0x0006)
-            power = self.client.read_holding_registers(590, ModbusDataType.INT_16, unit=unit) * -1
+            power = self.client.read_holding_registers(590, ModbusDataType.INT_16, device_id=unit) * -1
 
             if self.device_type == DeviceType.THREE_PHASE_HV:
                 power = power * 10
-            soc = self.client.read_holding_registers(588, ModbusDataType.INT_16, unit=unit)
+            soc = self.client.read_holding_registers(588, ModbusDataType.INT_16, device_id=unit)
             self.peak_filter.check_values(power)
             imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/deye/deye/counter.py
+++ b/packages/modules/devices/deye/deye/counter.py
@@ -32,13 +32,13 @@ class DeyeCounter(AbstractCounter):
         self.peak_filter = PeakFilter(ComponentType.COUNTER, self.component_config.id, self.fault_state)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.device_type = DeviceType(self.client.read_holding_registers(
-            0, ModbusDataType.INT_16, unit=self.component_config.configuration.modbus_id))
+            0, ModbusDataType.INT_16, device_id=self.component_config.configuration.modbus_id))
 
     def update(self):
         unit = self.component_config.configuration.modbus_id
 
         if self.device_type == DeviceType.SINGLE_PHASE_STRING or self.device_type == DeviceType.SINGLE_PHASE_HYBRID:
-            frequency = self.client.read_holding_registers(79, ModbusDataType.INT_16, unit=unit) / 100
+            frequency = self.client.read_holding_registers(79, ModbusDataType.INT_16, device_id=unit) / 100
 
             if self.device_type == DeviceType.SINGLE_PHASE_HYBRID:
                 powers = [0]*3
@@ -48,18 +48,18 @@ class DeyeCounter(AbstractCounter):
 
             elif self.device_type == DeviceType.SINGLE_PHASE_STRING:
                 currents = [
-                    c / 100 for c in self.client.read_holding_registers(76, [ModbusDataType.INT_16]*3, unit=unit)]
+                    c / 100 for c in self.client.read_holding_registers(76, [ModbusDataType.INT_16]*3, device_id=unit)]
                 voltages = [
-                    v / 10 for v in self.client.read_holding_registers(70, [ModbusDataType.INT_16]*3, unit=unit)]
+                    v / 10 for v in self.client.read_holding_registers(70, [ModbusDataType.INT_16]*3, device_id=unit)]
                 powers = [currents[i] * voltages[i] for i in range(0, 3)]
                 power = sum(powers)
 
         else:  # THREE_PHASE_LV (0x0500, 0x0005), THREE_PHASE_HV (0x0006)
-            currents = [c / 100 for c in self.client.read_holding_registers(613, [ModbusDataType.INT_16]*3, unit=unit)]
-            voltages = [v / 10 for v in self.client.read_holding_registers(644, [ModbusDataType.INT_16]*3, unit=unit)]
-            powers = self.client.read_holding_registers(616, [ModbusDataType.INT_16]*3, unit=unit)
+            currents = [c / 100 for c in self.client.read_holding_registers(613, [ModbusDataType.INT_16]*3, device_id=unit)]
+            voltages = [v / 10 for v in self.client.read_holding_registers(644, [ModbusDataType.INT_16]*3, device_id=unit)]
+            powers = self.client.read_holding_registers(616, [ModbusDataType.INT_16]*3, device_id=unit)
             power = sum(powers)
-            frequency = self.client.read_holding_registers(609, ModbusDataType.INT_16, unit=unit) / 100
+            frequency = self.client.read_holding_registers(609, ModbusDataType.INT_16, device_id=unit) / 100
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/deye/deye/inverter.py
+++ b/packages/modules/devices/deye/deye/inverter.py
@@ -32,16 +32,16 @@ class DeyeInverter(AbstractInverter):
         self.peak_filter = PeakFilter(ComponentType.INVERTER, self.component_config.id, self.fault_state)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="pv")
         self.device_type = DeviceType(self.client.read_holding_registers(
-            0, ModbusDataType.INT_16, unit=self.component_config.configuration.modbus_id))
+            0, ModbusDataType.INT_16, device_id=self.component_config.configuration.modbus_id))
 
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
         if self.device_type == DeviceType.SINGLE_PHASE_STRING or self.device_type == DeviceType.SINGLE_PHASE_HYBRID:
-            power = sum(self.client.read_holding_registers(186, [ModbusDataType.INT_16]*4, unit=unit)) * -1
+            power = sum(self.client.read_holding_registers(186, [ModbusDataType.INT_16]*4, device_id=unit)) * -1
 
         else:  # THREE_PHASE_LV (0x0500, 0x0005), THREE_PHASE_HV (0x0006)
-            power = sum(self.client.read_holding_registers(672, [ModbusDataType.INT_16]*2, unit=unit)) * -1
+            power = sum(self.client.read_holding_registers(672, [ModbusDataType.INT_16]*2, device_id=unit)) * -1
 
             if self.device_type == DeviceType.THREE_PHASE_HV:
                 power = power * 10

--- a/packages/modules/devices/e3dc/e3dc/bat.py
+++ b/packages/modules/devices/e3dc/e3dc/bat.py
@@ -18,9 +18,9 @@ log = logging.getLogger(__name__)
 
 def read_bat(client: modbus.ModbusTcpClient_, modbus_id: int) -> Tuple[int, int]:
     # 40082 SoC
-    soc = client.read_holding_registers(40082, ModbusDataType.INT_16, unit=modbus_id)
+    soc = client.read_holding_registers(40082, ModbusDataType.INT_16, device_id=modbus_id)
     # 40069 Speicherleistung
-    power = client.read_holding_registers(40069, ModbusDataType.INT_32, wordorder=Endian.Little, unit=modbus_id)
+    power = client.read_holding_registers(40069, ModbusDataType.INT_32, wordorder=Endian.Little, device_id=modbus_id)
     return soc, power
 
 

--- a/packages/modules/devices/e3dc/e3dc/counter.py
+++ b/packages/modules/devices/e3dc/e3dc/counter.py
@@ -29,7 +29,7 @@ def read_counter(client: modbus.ModbusTcpClient_, modbus_id: int) -> Tuple[int, 
     # bei den meisten e3dc auf 40128
     # farm haben typ 5, normale e3dc haben nur typ 1 und keinen typ 5
     # bei farm ist typ 1 vorhanden aber liefert immer 0
-    meters = list(map(int, client.read_holding_registers(40104, [ModbusDataType.INT_16] * 28, unit=modbus_id)))
+    meters = list(map(int, client.read_holding_registers(40104, [ModbusDataType.INT_16] * 28, device_id=modbus_id)))
     log.debug("meters: %s", meters)
     try:
         powers = get_meter_phases(5, meters)

--- a/packages/modules/devices/e3dc/e3dc/external_inverter.py
+++ b/packages/modules/devices/e3dc/e3dc/external_inverter.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 def read_external_inverter(client: modbus.ModbusTcpClient_, modbus_id: int) -> int:
     pv_external = int(client.read_holding_registers(
-        40075, ModbusDataType.INT_32, wordorder=Endian.Little, unit=modbus_id))
+        40075, ModbusDataType.INT_32, wordorder=Endian.Little, device_id=modbus_id))
     return pv_external
 
 

--- a/packages/modules/devices/e3dc/e3dc/inverter.py
+++ b/packages/modules/devices/e3dc/e3dc/inverter.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 def read_inverter(client: modbus.ModbusTcpClient_, modbus_id: int) -> int:
-    pv = int(client.read_holding_registers(40067, ModbusDataType.INT_32, wordorder=Endian.Little, unit=modbus_id) * -1)
+    pv = int(client.read_holding_registers(40067, ModbusDataType.INT_32, wordorder=Endian.Little, device_id=modbus_id) * -1)
     return pv
 
 

--- a/packages/modules/devices/fox_ess/fox_ess/bat.py
+++ b/packages/modules/devices/fox_ess/fox_ess/bat.py
@@ -32,12 +32,12 @@ class FoxEssBat(AbstractBat):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        power = self.client.read_holding_registers(31036, ModbusDataType.INT_16, unit=unit) * -1
-        soc = self.client.read_holding_registers(31038, ModbusDataType.UINT_16, unit=unit)
+        power = self.client.read_holding_registers(31036, ModbusDataType.INT_16, device_id=unit) * -1
+        soc = self.client.read_holding_registers(31038, ModbusDataType.UINT_16, device_id=unit)
         # Geladen in kWh * 0,1
-        imported = self.client.read_holding_registers(32003, ModbusDataType.UINT_32, unit=unit) * 100
+        imported = self.client.read_holding_registers(32003, ModbusDataType.UINT_32, device_id=unit) * 100
         # Entladen in kWh * 0,1
-        exported = self.client.read_holding_registers(32006, ModbusDataType.UINT_32, unit=unit) * 100
+        exported = self.client.read_holding_registers(32006, ModbusDataType.UINT_32, device_id=unit) * 100
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/fox_ess/fox_ess/counter.py
+++ b/packages/modules/devices/fox_ess/fox_ess/counter.py
@@ -29,11 +29,11 @@ class FoxEssCounter(AbstractCounter):
         unit = self.component_config.configuration.modbus_id
 
         powers = [val * -1 for val in
-                  self.client.read_holding_registers(31026, [ModbusDataType.INT_16]*3, unit=unit)]
+                  self.client.read_holding_registers(31026, [ModbusDataType.INT_16]*3, device_id=unit)]
         power = sum(powers)
-        frequency = self.client.read_holding_registers(31015, ModbusDataType.UINT_16, unit=unit) / 100
-        imported = self.client.read_holding_registers(32018, ModbusDataType.UINT_32, unit=unit) * 100
-        exported = self.client.read_holding_registers(32015, ModbusDataType.UINT_32, unit=unit) * 100
+        frequency = self.client.read_holding_registers(31015, ModbusDataType.UINT_16, device_id=unit) / 100
+        imported = self.client.read_holding_registers(32018, ModbusDataType.UINT_32, device_id=unit) * 100
+        exported = self.client.read_holding_registers(32015, ModbusDataType.UINT_32, device_id=unit) * 100
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(

--- a/packages/modules/devices/fox_ess/fox_ess/inverter.py
+++ b/packages/modules/devices/fox_ess/fox_ess/inverter.py
@@ -31,10 +31,10 @@ class FoxEssInverter(AbstractInverter):
         unit = self.component_config.configuration.modbus_id
         # PV1 + PV2 Power
         power = sum([self.client.read_holding_registers(
-            reg, ModbusDataType.INT_16, unit=unit)
+            reg, ModbusDataType.INT_16, device_id=unit)
             for reg in [31002, 31005]]) * -1
         # Gesamt Produktion Wechselrichter unsigned integer in kWh * 0,1
-        exported = self.client.read_holding_registers(32000, ModbusDataType.UINT_32, unit=unit) * 100
+        exported = self.client.read_holding_registers(32000, ModbusDataType.UINT_32, device_id=unit) * 100
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/good_we/good_we/bat.py
+++ b/packages/modules/devices/good_we/good_we/bat.py
@@ -49,19 +49,19 @@ class GoodWeBat(AbstractBat):
             if battery_index == 1:
                 if self.version == GoodWeVersion.V_1_7:
                     power = self.__tcp_client.read_holding_registers(
-                        35183, ModbusDataType.INT_16, unit=self.__modbus_id)*-1
+                        35183, ModbusDataType.INT_16, device_id=self.__modbus_id)*-1
                 else:
                     power = self.__tcp_client.read_holding_registers(
-                        35182, ModbusDataType.INT_32, unit=self.__modbus_id)*-1
-                soc = self.__tcp_client.read_holding_registers(37007, ModbusDataType.UINT_16, unit=self.__modbus_id)
+                        35182, ModbusDataType.INT_32, device_id=self.__modbus_id)*-1
+                soc = self.__tcp_client.read_holding_registers(37007, ModbusDataType.UINT_16, device_id=self.__modbus_id)
                 imported = self.__tcp_client.read_holding_registers(
-                    35206, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                    35206, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
                 exported = self.__tcp_client.read_holding_registers(
-                    35209, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                    35209, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
                 imported, exported = self.peak_filter.check_values(power, imported, exported)
             else:
-                power = self.__tcp_client.read_holding_registers(35264, ModbusDataType.INT_32, unit=self.__modbus_id)*-1
-                soc = self.__tcp_client.read_holding_registers(39005, ModbusDataType.UINT_16, unit=self.__modbus_id)
+                power = self.__tcp_client.read_holding_registers(35264, ModbusDataType.INT_32, device_id=self.__modbus_id)*-1
+                soc = self.__tcp_client.read_holding_registers(39005, ModbusDataType.UINT_16, device_id=self.__modbus_id)
                 self.peak_filter.check_values(power)
                 imported, exported = self.sim_counter.sim_count(power)
 
@@ -80,31 +80,31 @@ class GoodWeBat(AbstractBat):
         if power_limit is None:
             log.debug("Keine Batteriesteuerung, Selbstregelung durch Wechselrichter")
             if self.last_mode is not None:
-                self.__tcp_client.write_register(47511, 1, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(47512, 0, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(47511, 1, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(47512, 0, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = None
         elif power_limit == 0:
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht entladen")
             if self.last_mode != 'stop':
-                self.__tcp_client.write_register(47511, 2, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(47512, 0, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(47511, 2, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(47512, 0, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'stop'
         elif power_limit < 0:
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W entladen für den Hausverbrauch")
             if self.last_mode != 'discharge':
-                self.__tcp_client.write_register(47511, 3, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(47511, 3, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'discharge'
             # Die maximale Entladeleistung begrenzen auf 5000W, maximaler Wertebereich Modbusregister.
             power_value = int(min(abs(power_limit), 10000))
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
-            self.__tcp_client.write_register(47512, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.__tcp_client.write_register(47512, power_value, data_type=ModbusDataType.UINT_16, device_id=unit)
         elif power_limit > 0:
             if self.last_mode != 'charge':
-                self.__tcp_client.write_register(47511, 2, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(47511, 2, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'charge'
             power_value = int(min(abs(power_limit), 10000))
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
-            self.__tcp_client.write_register(47512, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.__tcp_client.write_register(47512, power_value, data_type=ModbusDataType.UINT_16, device_id=unit)
 
     def power_limit_controllable(self) -> bool:
         return True

--- a/packages/modules/devices/good_we/good_we/counter.py
+++ b/packages/modules/devices/good_we/good_we/counter.py
@@ -42,28 +42,28 @@ class GoodWeCounter(AbstractCounter):
         with self.__tcp_client:
             if self.firmware < 9:
                 power = self.__tcp_client.read_holding_registers(
-                    36008, ModbusDataType.INT_16, unit=self.__modbus_id) * -1
+                    36008, ModbusDataType.INT_16, device_id=self.__modbus_id) * -1
                 powers = [
                     val * -1 for val in self.__tcp_client.read_holding_registers(
-                        36005, [ModbusDataType.INT_16]*3, unit=self.__modbus_id)]
+                        36005, [ModbusDataType.INT_16]*3, device_id=self.__modbus_id)]
             else:
                 power = self.__tcp_client.read_holding_registers(
-                    36025, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
+                    36025, ModbusDataType.INT_32, device_id=self.__modbus_id) * -1
                 powers = [
                     val * -1 for val in self.__tcp_client.read_holding_registers(
-                        36019, [ModbusDataType.INT_32]*3, unit=self.__modbus_id)]
+                        36019, [ModbusDataType.INT_32]*3, device_id=self.__modbus_id)]
 
             power_factors = [
                 val / 1000 for val in self.__tcp_client.read_holding_registers(
-                    36010, [ModbusDataType.INT_16]*3, unit=self.__modbus_id)]
+                    36010, [ModbusDataType.INT_16]*3, device_id=self.__modbus_id)]
             frequency = self.__tcp_client.read_holding_registers(
-                36014, ModbusDataType.UINT_16, unit=self.__modbus_id) / 100
+                36014, ModbusDataType.UINT_16, device_id=self.__modbus_id) / 100
 
             if self.version == GoodWeVersion.V_1_7:
                 exported = self.__tcp_client.read_holding_registers(
-                    36015, ModbusDataType.FLOAT_32, unit=self.__modbus_id)
+                    36015, ModbusDataType.FLOAT_32, device_id=self.__modbus_id)
                 imported = self.__tcp_client.read_holding_registers(
-                    36017, ModbusDataType.FLOAT_32, unit=self.__modbus_id)
+                    36017, ModbusDataType.FLOAT_32, device_id=self.__modbus_id)
                 imported, exported = self.peak_filter.check_values(power, imported, exported)
             else:
                 # v1.0 und v1.1 liefern keine Werte zurueck obwohl Register laut Doku gleich

--- a/packages/modules/devices/good_we/good_we/inverter.py
+++ b/packages/modules/devices/good_we/good_we/inverter.py
@@ -38,10 +38,10 @@ class GoodWeInverter(AbstractInverter):
     def update(self) -> None:
         with self.__tcp_client:
             power = sum([self.__tcp_client.read_holding_registers(
-                reg, ModbusDataType.INT_32, unit=self.__modbus_id)
+                reg, ModbusDataType.INT_32, device_id=self.__modbus_id)
                 for reg in [35105, 35109, 35113, 35117]]) * -1
             exported = self.__tcp_client.read_holding_registers(
-                35191, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                35191, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/growatt/growatt/bat.py
+++ b/packages/modules/devices/growatt/growatt/bat.py
@@ -35,28 +35,28 @@ class GrowattBat(AbstractBat):
     def update(self) -> None:
         if self.version == GrowattVersion.max_series:
             power_in = self.client.read_input_registers(
-                1011, ModbusDataType.UINT_32, unit=self.__modbus_id) * 0.1
+                1011, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 0.1
             power_out = self.client.read_input_registers(
-                1009, ModbusDataType.UINT_32, unit=self.__modbus_id) * -0.1
+                1009, ModbusDataType.UINT_32, device_id=self.__modbus_id) * -0.1
             power = power_in + power_out
 
-            soc = self.client.read_input_registers(1014, ModbusDataType.UINT_16, unit=self.__modbus_id)
+            soc = self.client.read_input_registers(1014, ModbusDataType.UINT_16, device_id=self.__modbus_id)
             imported = self.client.read_input_registers(
-                1058, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                1058, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
             exported = self.client.read_input_registers(
-                1054, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                1054, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
         else:
             power_in = self.client.read_input_registers(
-                3180, ModbusDataType.UINT_32, unit=self.__modbus_id) * -0.1
+                3180, ModbusDataType.UINT_32, device_id=self.__modbus_id) * -0.1
             power_out = self.client.read_input_registers(
-                3178, ModbusDataType.UINT_32, unit=self.__modbus_id) * 0.1
+                3178, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 0.1
             power = power_in + power_out
 
-            soc = self.client.read_input_registers(3171, ModbusDataType.UINT_16, unit=self.__modbus_id)
+            soc = self.client.read_input_registers(3171, ModbusDataType.UINT_16, device_id=self.__modbus_id)
             imported = self.client.read_input_registers(
-                3131, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                3131, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
             exported = self.client.read_input_registers(
-                3127, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                3127, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/growatt/growatt/counter.py
+++ b/packages/modules/devices/growatt/growatt/counter.py
@@ -34,40 +34,40 @@ class GrowattCounter(AbstractCounter):
 
     def update(self) -> None:
         if self.version == GrowattVersion.max_series:
-            power_in = self.client.read_input_registers(1021, ModbusDataType.UINT_32, unit=self.__modbus_id) * 0.1
-            power_out = self.client.read_input_registers(1029, ModbusDataType.UINT_32, unit=self.__modbus_id) * -0.1
+            power_in = self.client.read_input_registers(1021, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 0.1
+            power_out = self.client.read_input_registers(1029, ModbusDataType.UINT_32, device_id=self.__modbus_id) * -0.1
             power = power_in + power_out
 
             powers = [
                 self.client.read_input_registers(
-                    40, ModbusDataType.INT_32, unit=self.__modbus_id) / 10,
+                    40, ModbusDataType.INT_32, device_id=self.__modbus_id) / 10,
                 self.client.read_input_registers(
-                    44, ModbusDataType.INT_32, unit=self.__modbus_id) / 10,
+                    44, ModbusDataType.INT_32, device_id=self.__modbus_id) / 10,
                 self.client.read_input_registers(
-                    48, ModbusDataType.INT_32, unit=self.__modbus_id) / 10]
+                    48, ModbusDataType.INT_32, device_id=self.__modbus_id) / 10]
 
             # Einheit 0.1 kWh
-            exported = self.client.read_input_registers(1050, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
-            imported = self.client.read_input_registers(1046, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+            exported = self.client.read_input_registers(1050, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
+            imported = self.client.read_input_registers(1046, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
 
         # TL-X Dokumentation hat die gleichen Register wie die MAX Serie,
         # zusätzlich sind aber auch unten abweichende enthalten
         else:
-            power_in = self.client.read_input_registers(3041, ModbusDataType.UINT_32, unit=self.__modbus_id) * 0.1
-            power_out = self.client.read_input_registers(3043, ModbusDataType.UINT_32, unit=self.__modbus_id) * -0.1
+            power_in = self.client.read_input_registers(3041, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 0.1
+            power_out = self.client.read_input_registers(3043, ModbusDataType.UINT_32, device_id=self.__modbus_id) * -0.1
             power = power_in + power_out
 
             powers = [
                 self.client.read_input_registers(
-                    3028, ModbusDataType.INT_32, unit=self.__modbus_id) / 10,
+                    3028, ModbusDataType.INT_32, device_id=self.__modbus_id) / 10,
                 self.client.read_input_registers(
-                    3032, ModbusDataType.INT_32, unit=self.__modbus_id) / 10,
+                    3032, ModbusDataType.INT_32, device_id=self.__modbus_id) / 10,
                 self.client.read_input_registers(
-                    3036, ModbusDataType.INT_32, unit=self.__modbus_id) / 10]
+                    3036, ModbusDataType.INT_32, device_id=self.__modbus_id) / 10]
 
             # Einheit 0.1 kWh
-            exported = self.client.read_input_registers(3073, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
-            imported = self.client.read_input_registers(3069, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+            exported = self.client.read_input_registers(3073, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
+            imported = self.client.read_input_registers(3069, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(

--- a/packages/modules/devices/growatt/growatt/inverter.py
+++ b/packages/modules/devices/growatt/growatt/inverter.py
@@ -35,14 +35,14 @@ class GrowattInverter(AbstractInverter):
     def update(self) -> None:
         if self.version == GrowattVersion.max_series:
             power = self.client.read_input_registers(
-                1, ModbusDataType.UINT_32, unit=self.__modbus_id) / -10
+                1, ModbusDataType.UINT_32, device_id=self.__modbus_id) / -10
             exported = self.client.read_input_registers(
-                91, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                91, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
         else:
             power = self.client.read_input_registers(
-                3001, ModbusDataType.UINT_32, unit=self.__modbus_id) / -10
+                3001, ModbusDataType.UINT_32, device_id=self.__modbus_id) / -10
             exported = self.client.read_input_registers(
-                3053, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                3053, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/huawei/huawei/bat.py
+++ b/packages/modules/devices/huawei/huawei/bat.py
@@ -40,10 +40,10 @@ class HuaweiBat(AbstractBat):
     def update(self) -> None:
         if self.type == HuaweiType.SDongle:
             time.sleep(1)
-        power = self.client.read_holding_registers(37765, ModbusDataType.INT_32, unit=self.modbus_id)
+        power = self.client.read_holding_registers(37765, ModbusDataType.INT_32, device_id=self.modbus_id)
         if self.type == HuaweiType.SDongle:
             time.sleep(1)
-        soc = self.client.read_holding_registers(37760, ModbusDataType.INT_16, unit=self.modbus_id) / 10
+        soc = self.client.read_holding_registers(37760, ModbusDataType.INT_16, device_id=self.modbus_id) / 10
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/huawei/huawei/counter.py
+++ b/packages/modules/devices/huawei/huawei/counter.py
@@ -40,11 +40,11 @@ class HuaweiCounter(AbstractCounter):
     def update(self) -> None:
         if self.type == HuaweiType.SDongle:
             time.sleep(1)
-        currents = self.client.read_holding_registers(37107, [ModbusDataType.INT_32]*3, unit=self.modbus_id)
+        currents = self.client.read_holding_registers(37107, [ModbusDataType.INT_32]*3, device_id=self.modbus_id)
         currents = [val / -100 for val in currents]
         if self.type == HuaweiType.SDongle:
             time.sleep(1)
-        power = self.client.read_holding_registers(37113, ModbusDataType.INT_32, unit=self.modbus_id) * -1
+        power = self.client.read_holding_registers(37113, ModbusDataType.INT_32, device_id=self.modbus_id) * -1
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/huawei/huawei/inverter.py
+++ b/packages/modules/devices/huawei/huawei/inverter.py
@@ -40,7 +40,7 @@ class HuaweiInverter(AbstractInverter):
     def update(self) -> None:
         if self.type == HuaweiType.SDongle:
             time.sleep(1)
-        power = self.client.read_holding_registers(32064, ModbusDataType.INT_32, unit=self.modbus_id) * -1
+        power = self.client.read_holding_registers(32064, ModbusDataType.INT_32, device_id=self.modbus_id) * -1
 
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/huawei/huawei_emma/bat.py
+++ b/packages/modules/devices/huawei/huawei_emma/bat.py
@@ -34,8 +34,8 @@ class Huawei_EmmaBat(AbstractBat):
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
 
     def update(self) -> None:
-        power = self.client.read_holding_registers(30360, ModbusDataType.INT_32, unit=self.modbus_id)
-        soc = self.client.read_holding_registers(30368, ModbusDataType.UINT_16, unit=self.modbus_id) * 0.01
+        power = self.client.read_holding_registers(30360, ModbusDataType.INT_32, device_id=self.modbus_id)
+        soc = self.client.read_holding_registers(30368, ModbusDataType.UINT_16, device_id=self.modbus_id) * 0.01
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/huawei/huawei_emma/counter.py
+++ b/packages/modules/devices/huawei/huawei_emma/counter.py
@@ -34,9 +34,9 @@ class Huawei_EmmaCounter(AbstractCounter):
         self.peak_filter = PeakFilter(ComponentType.COUNTER, self.component_config.id, self.fault_state)
 
     def update(self) -> None:
-        currents = self.client.read_holding_registers(31651, [ModbusDataType.INT_32]*3, unit=self.modbus_id)
+        currents = self.client.read_holding_registers(31651, [ModbusDataType.INT_32]*3, device_id=self.modbus_id)
         currents = [val * 0.1 for val in currents]
-        power = self.client.read_holding_registers(31657, ModbusDataType.INT_32, unit=self.modbus_id)
+        power = self.client.read_holding_registers(31657, ModbusDataType.INT_32, device_id=self.modbus_id)
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/huawei/huawei_emma/inverter.py
+++ b/packages/modules/devices/huawei/huawei_emma/inverter.py
@@ -32,8 +32,8 @@ class Huawei_EmmaInverter(AbstractInverter):
         self.peak_filter = PeakFilter(ComponentType.INVERTER, self.component_config.id, self.fault_state)
 
     def update(self) -> None:
-        power = self.client.read_holding_registers(30354, ModbusDataType.INT_32, unit=self.modbus_id) * -1
-        exported = self.client.read_holding_registers(30348, ModbusDataType.UINT_64, unit=self.modbus_id) * 10
+        power = self.client.read_holding_registers(30354, ModbusDataType.INT_32, device_id=self.modbus_id) * -1
+        exported = self.client.read_holding_registers(30348, ModbusDataType.UINT_64, device_id=self.modbus_id) * 10
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(
             power=power,

--- a/packages/modules/devices/huawei/huawei_smartlogger/bat.py
+++ b/packages/modules/devices/huawei/huawei_smartlogger/bat.py
@@ -34,8 +34,8 @@ class Huawei_SmartloggerBat(AbstractBat):
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id
-        power = self.__tcp_client.read_holding_registers(37765, ModbusDataType.INT_32, unit=modbus_id)
-        soc = self.__tcp_client.read_holding_registers(37760, ModbusDataType.INT_16, unit=modbus_id) / 10
+        power = self.__tcp_client.read_holding_registers(37765, ModbusDataType.INT_32, device_id=modbus_id)
+        soc = self.__tcp_client.read_holding_registers(37760, ModbusDataType.INT_16, device_id=modbus_id) / 10
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/huawei/huawei_smartlogger/counter.py
+++ b/packages/modules/devices/huawei/huawei_smartlogger/counter.py
@@ -33,12 +33,12 @@ class Huawei_SmartloggerCounter(AbstractCounter):
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id
-        power = self.client.read_holding_registers(32278, ModbusDataType.INT_32, unit=modbus_id)
+        power = self.client.read_holding_registers(32278, ModbusDataType.INT_32, device_id=modbus_id)
         currents = [val / 10 for val in self.client.read_holding_registers(
-            32272, [ModbusDataType.INT_32] * 3, unit=modbus_id)]
+            32272, [ModbusDataType.INT_32] * 3, device_id=modbus_id)]
         voltages = [val / 100 for val in self.client.read_holding_registers(
-            32260, [ModbusDataType.INT_32] * 3, unit=modbus_id)]
-        powers = self.client.read_holding_registers(32335, [ModbusDataType.INT_32] * 3, unit=modbus_id)
+            32260, [ModbusDataType.INT_32] * 3, device_id=modbus_id)]
+        powers = self.client.read_holding_registers(32335, [ModbusDataType.INT_32] * 3, device_id=modbus_id)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/huawei/huawei_smartlogger/inverter.py
+++ b/packages/modules/devices/huawei/huawei_smartlogger/inverter.py
@@ -37,8 +37,8 @@ class Huawei_SmartloggerInverter(AbstractInverter):
 
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id
-        power = self.client.read_holding_registers(32080, ModbusDataType.INT_32, unit=modbus_id) * -1
-        exported = self.client.read_holding_registers(32106, ModbusDataType.INT_32, unit=modbus_id) * 10
+        power = self.client.read_holding_registers(32080, ModbusDataType.INT_32, device_id=modbus_id) * -1
+        exported = self.client.read_holding_registers(32106, ModbusDataType.INT_32, device_id=modbus_id) * 10
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/idm/idm/counter.py
+++ b/packages/modules/devices/idm/idm/counter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractCounter
 from modules.common.component_state import CounterState
@@ -37,7 +37,7 @@ class IDMCounter(AbstractCounter):
     def update(self):
         unit = self.modbus_id
         power = self.client.read_input_registers(4122, ModbusDataType.FLOAT_32,
-                                                 wordorder=Endian.Little, unit=unit) * 1000
+                                                 wordorder=Endian.Little, device_id=unit) * 1000
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/janitza/janitza/bat.py
+++ b/packages/modules/devices/janitza/janitza/bat.py
@@ -34,7 +34,7 @@ class JanitzaBat(AbstractBat):
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
 
     def update(self):
-        power = self.__tcp_client.read_holding_registers(19026, ModbusDataType.FLOAT_32, unit=self.__modbus_id) * -1
+        power = self.__tcp_client.read_holding_registers(19026, ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * -1
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/janitza/janitza/counter.py
+++ b/packages/modules/devices/janitza/janitza/counter.py
@@ -36,16 +36,16 @@ class JanitzaCounter(AbstractCounter):
 
     def update(self) -> None:
         with self.__tcp_client:
-            power = self.__tcp_client.read_holding_registers(19026, ModbusDataType.FLOAT_32, unit=self.__modbus_id)
+            power = self.__tcp_client.read_holding_registers(19026, ModbusDataType.FLOAT_32, device_id=self.__modbus_id)
             powers = self.__tcp_client.read_holding_registers(
-                19020, [ModbusDataType.FLOAT_32] * 3, unit=self.__modbus_id)
+                19020, [ModbusDataType.FLOAT_32] * 3, device_id=self.__modbus_id)
             currents = self.__tcp_client.read_holding_registers(
-                19012, [ModbusDataType.FLOAT_32] * 3, unit=self.__modbus_id)
+                19012, [ModbusDataType.FLOAT_32] * 3, device_id=self.__modbus_id)
             voltages = self.__tcp_client.read_holding_registers(
-                19000, [ModbusDataType.FLOAT_32] * 3, unit=self.__modbus_id)
+                19000, [ModbusDataType.FLOAT_32] * 3, device_id=self.__modbus_id)
             power_factors = self.__tcp_client.read_holding_registers(
-                19044, [ModbusDataType.FLOAT_32] * 3, unit=self.__modbus_id)
-            frequency = self.__tcp_client.read_holding_registers(19050, ModbusDataType.FLOAT_32, unit=self.__modbus_id)
+                19044, [ModbusDataType.FLOAT_32] * 3, device_id=self.__modbus_id)
+            frequency = self.__tcp_client.read_holding_registers(19050, ModbusDataType.FLOAT_32, device_id=self.__modbus_id)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/janitza/janitza/inverter.py
+++ b/packages/modules/devices/janitza/janitza/inverter.py
@@ -34,7 +34,7 @@ class JanitzaInverter(AbstractInverter):
         self.peak_filter = PeakFilter(ComponentType.INVERTER, self.component_config.id, self.fault_state)
 
     def update(self):
-        power = self.__tcp_client.read_holding_registers(19026, ModbusDataType.FLOAT_32, unit=self.__modbus_id) * -1
+        power = self.__tcp_client.read_holding_registers(19026, ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * -1
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/kaco/kaco_tx/scale.py
+++ b/packages/modules/devices/kaco/kaco_tx/scale.py
@@ -21,7 +21,7 @@ def scale_registers(registers: List[Number]) -> List[float]:
 def create_scaled_reader(client: ModbusTcpClient_, modbus_id: int, type: ModbusDataType):
     def scaled_reader(address: int, count: int):
         return scale_registers(
-            client.read_holding_registers(address, [type] * count + [ModbusDataType.INT_16], unit=modbus_id)
+            client.read_holding_registers(address, [type] * count + [ModbusDataType.INT_16], device_id=modbus_id)
         )
 
     return scaled_reader

--- a/packages/modules/devices/kostal/kostal_piko_ci/counter.py
+++ b/packages/modules/devices/kostal/kostal_piko_ci/counter.py
@@ -34,10 +34,10 @@ class KostalPikoCiCounter(AbstractCounter):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        power = self.client.read_holding_registers(252, ModbusDataType.FLOAT_32, unit=unit)
+        power = self.client.read_holding_registers(252, ModbusDataType.FLOAT_32, device_id=unit)
         powers = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=unit) for reg in [224, 234, 244]]
-        frequency = self.client.read_holding_registers(220, ModbusDataType.FLOAT_32, unit=unit)
+            reg, ModbusDataType.FLOAT_32, device_id=unit) for reg in [224, 234, 244]]
+        frequency = self.client.read_holding_registers(220, ModbusDataType.FLOAT_32, device_id=unit)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/kostal/kostal_piko_ci/inverter.py
+++ b/packages/modules/devices/kostal/kostal_piko_ci/inverter.py
@@ -32,10 +32,10 @@ class KostalPikoCiInverter(AbstractInverter):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        power = self.client.read_holding_registers(172, ModbusDataType.FLOAT_32, unit=unit) * -1
+        power = self.client.read_holding_registers(172, ModbusDataType.FLOAT_32, device_id=unit) * -1
         currents = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=unit) for reg in [154, 160, 166]]
-        exported = self.client.read_holding_registers(320, ModbusDataType.FLOAT_32, unit=unit)
+            reg, ModbusDataType.FLOAT_32, device_id=unit) for reg in [154, 160, 166]]
+        exported = self.client.read_holding_registers(320, ModbusDataType.FLOAT_32, device_id=unit)
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(
             power=power,

--- a/packages/modules/devices/kostal/kostal_plenticore/bat.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/bat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import logging
 from typing import TypedDict, Any, Optional
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractBat
 from modules.common.component_state import BatState
@@ -41,12 +41,12 @@ class KostalPlenticoreBat(AbstractBat):
 
     def update(self) -> None:
         power = self.client.read_holding_registers(
-            582, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=self.endianess) * -1
+            582, ModbusDataType.INT_16, device_id=self.modbus_id, wordorder=self.endianess) * -1
         soc = self.client.read_holding_registers(
-            514, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=self.endianess)
+            514, ModbusDataType.INT_16, device_id=self.modbus_id, wordorder=self.endianess)
         if power < 0:
             power = self.client.read_holding_registers(
-                106, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) * -1
+                106, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess) * -1
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
@@ -73,21 +73,21 @@ class KostalPlenticoreBat(AbstractBat):
             # wiederholt auf Stop setzen damit sich Register nicht zurücksetzt
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht entladen")
             self.client.write_register(1034, 0.0, data_type=ModbusDataType.FLOAT_32,
-                                       wordorder=self.endianess, unit=unit)
+                                       wordorder=self.endianess, device_id=unit)
         elif power_limit < 0:
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W entladen für den Hausverbrauch")
             # Die maximale Entladeleistung begrenzen auf 7000W
             power_value = float(min(abs(power_limit), 7000))
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
             self.client.write_register(1034, power_value, data_type=ModbusDataType.FLOAT_32,
-                                       wordorder=self.endianess, unit=unit)
+                                       wordorder=self.endianess, device_id=unit)
         elif power_limit > 0:
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W geladen")
             # Die maximale Ladeleistung begrenzen auf 7000W
             power_value = float(min(abs(power_limit), 7000)) * -1
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W geladen")
             self.client.write_register(1034, power_value, data_type=ModbusDataType.FLOAT_32,
-                                       wordorder=self.endianess, unit=unit)
+                                       wordorder=self.endianess, device_id=unit)
 
     def power_limit_controllable(self) -> bool:
         return True

--- a/packages/modules/devices/kostal/kostal_plenticore/counter.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/counter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractCounter
 from modules.common.component_state import CounterState
@@ -38,17 +38,17 @@ class KostalPlenticoreCounter(AbstractCounter):
 
     def update(self) -> None:
         power = self.client.read_holding_registers(
-            252, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess)
+            252, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess)
         power_factor = self.client.read_holding_registers(
-            150, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess)
+            150, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess)
         currents = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) for reg in [222, 232, 242]]
+            reg, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess) for reg in [222, 232, 242]]
         voltages = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) for reg in [230, 240, 250]]
+            reg, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess) for reg in [230, 240, 250]]
         powers = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) for reg in [224, 234, 244]]
+            reg, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess) for reg in [224, 234, 244]]
         frequency = self.client.read_holding_registers(
-            220, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess)
+            220, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/kostal/kostal_plenticore/device.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/device.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import logging
 from typing import Iterable, Union
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
@@ -54,7 +54,7 @@ def create_device(device_config: KostalPlenticore):
         nonlocal client, endianess
         client = ModbusTcpClient_(device_config.configuration.ip_address, device_config.configuration.port)
         endianess = Endian.Big if client.read_holding_registers(
-            5, ModbusDataType.UINT_16, unit=device_config.configuration.modbus_id) else Endian.Little
+            5, ModbusDataType.UINT_16, device_id=device_config.configuration.modbus_id) else Endian.Little
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/kostal/kostal_plenticore/inverter.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/inverter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractInverter
 from modules.common.component_state import InverterState
@@ -42,13 +42,13 @@ class KostalPlenticoreInverter(AbstractInverter):
 
     def update(self) -> None:
         power = self.client.read_holding_registers(
-            575, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=self.endianess) * -1
+            575, ModbusDataType.INT_16, device_id=self.modbus_id, wordorder=self.endianess) * -1
         exported = self.client.read_holding_registers(
-            320, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess)
+            320, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess)
         # Try to read dc_power, if it fails just skip it and set to None
         try:
             dc_power = self.client.read_holding_registers(
-                1066, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) * -1
+                1066, ModbusDataType.FLOAT_32, device_id=self.modbus_id, wordorder=self.endianess) * -1
             self.fault_state.no_error()
         except Exception:
             dc_power = None

--- a/packages/modules/devices/kostal/kostal_sem/counter.py
+++ b/packages/modules/devices/kostal/kostal_sem/counter.py
@@ -32,23 +32,23 @@ class KostalSemCounter(AbstractCounter):
     def update(self):
         with self.__tcp_client:
             voltages = [self.__tcp_client.read_holding_registers(
-                reg, ModbusDataType.UINT_32, unit=self.__modbus_id) * 0.001 for reg in [62, 102, 142]]
+                reg, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 0.001 for reg in [62, 102, 142]]
             currents = [self.__tcp_client.read_holding_registers(
-                reg, ModbusDataType.UINT_32, unit=self.__modbus_id) * 0.001 for reg in [60, 100, 140]]
+                reg, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 0.001 for reg in [60, 100, 140]]
             power_factors = [self.__tcp_client.read_holding_registers(
-                reg, ModbusDataType.INT_32, unit=self.__modbus_id) * 0.001 for reg in [64, 104, 144]]
+                reg, ModbusDataType.INT_32, device_id=self.__modbus_id) * 0.001 for reg in [64, 104, 144]]
             imported, exported = [val * 0.1 for val in self.__tcp_client.read_holding_registers(
-                512, [ModbusDataType.UINT_64]*2, unit=self.__modbus_id)]
+                512, [ModbusDataType.UINT_64]*2, device_id=self.__modbus_id)]
             frequency = self.__tcp_client.read_holding_registers(
-                26, ModbusDataType.UINT_32, unit=self.__modbus_id) * 0.001
+                26, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 0.001
 
             powers = []
             for reg in [40, 80, 120]:
                 powers_temp = self.__tcp_client.read_holding_registers(
-                    reg, [ModbusDataType.UINT_32]*2, unit=self.__modbus_id)
+                    reg, [ModbusDataType.UINT_32]*2, device_id=self.__modbus_id)
                 powers.append((powers_temp[0] if powers_temp[0] >= powers_temp[1] else -powers_temp[1]) * 0.1)
 
-            power_temp = self.__tcp_client.read_holding_registers(0, [ModbusDataType.UINT_32]*2, unit=self.__modbus_id)
+            power_temp = self.__tcp_client.read_holding_registers(0, [ModbusDataType.UINT_32]*2, device_id=self.__modbus_id)
             power = (power_temp[0] if power_temp[0] >= power_temp[1] else -power_temp[1]) * 0.1
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(

--- a/packages/modules/devices/marstek/venus_c_e/bat.py
+++ b/packages/modules/devices/marstek/venus_c_e/bat.py
@@ -31,11 +31,11 @@ class VenusCEBat(AbstractBat):
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
 
     def _read_reg(self, addr: int, type_: ModbusDataType) -> Union[int, float]:
-        return self.client.read_holding_registers(addr, type_, unit=self.component_config.configuration.modbus_id)
+        return self.client.read_holding_registers(addr, type_, device_id=self.component_config.configuration.modbus_id)
 
     def _write_reg(self, addr: int, val: int) -> None:
         # Marstek Venus does not work with write_registers!
-        self.client._delegate.write_register(addr, val, unit=self.component_config.configuration.modbus_id)
+        self.client._delegate.write_register(addr, val, device_id=self.component_config.configuration.modbus_id)
 
     def update(self) -> None:
         power = -self._read_reg(32202, ModbusDataType.INT_32)

--- a/packages/modules/devices/mtec/mtec/bat.py
+++ b/packages/modules/devices/mtec/mtec/bat.py
@@ -39,12 +39,12 @@ class MTecBat(AbstractBat):
         generation = self.component_config.configuration.generation
 
         if generation == 2:
-            power = self.client.read_holding_registers(40258, ModbusDataType.INT_32, unit=unit) * -1
+            power = self.client.read_holding_registers(40258, ModbusDataType.INT_32, device_id=unit) * -1
             # soc unit 0.01%
-            soc = self.client.read_holding_registers(43000, ModbusDataType.UINT_16, unit=unit) / 100
+            soc = self.client.read_holding_registers(43000, ModbusDataType.UINT_16, device_id=unit) / 100
         else:
-            power = self.client.read_holding_registers(30258, ModbusDataType.INT_32, unit=unit) * -1
-            soc = self.client.read_holding_registers(33000, ModbusDataType.UINT_16, unit=unit) / 100
+            power = self.client.read_holding_registers(30258, ModbusDataType.INT_32, device_id=unit) * -1
+            soc = self.client.read_holding_registers(33000, ModbusDataType.UINT_16, device_id=unit) / 100
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/mtec/mtec/counter.py
+++ b/packages/modules/devices/mtec/mtec/counter.py
@@ -34,8 +34,8 @@ class MTecCounter(AbstractCounter):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        power = self.client.read_holding_registers(11000, ModbusDataType.INT_32, unit=unit) * -1
-        powers = self.client.read_holding_registers(10994, [ModbusDataType.INT_32]*3, unit=unit)
+        power = self.client.read_holding_registers(11000, ModbusDataType.INT_32, device_id=unit) * -1
+        powers = self.client.read_holding_registers(10994, [ModbusDataType.INT_32]*3, device_id=unit)
         powers = [value * -1 for value in powers]
 
         self.peak_filter.check_values(power)

--- a/packages/modules/devices/mtec/mtec/inverter.py
+++ b/packages/modules/devices/mtec/mtec/inverter.py
@@ -34,7 +34,7 @@ class MTecInverter(AbstractInverter):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        power = self.client.read_holding_registers(11028, ModbusDataType.UINT_32, unit=unit) * -1
+        power = self.client.read_holding_registers(11028, ModbusDataType.UINT_32, device_id=unit) * -1
 
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/nibe/nibe/counter.py
+++ b/packages/modules/devices/nibe/nibe/counter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractCounter
 from modules.common.component_state import CounterState
@@ -34,7 +34,7 @@ class NibeCounter(AbstractCounter):
 
     def update(self):
         unit = self.component_config.configuration.modbus_id
-        power = self.client.read_input_registers(2166, ModbusDataType.UINT_32, wordorder=Endian.Little, unit=unit)
+        power = self.client.read_input_registers(2166, ModbusDataType.UINT_32, wordorder=Endian.Little, device_id=unit)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/orno/orno/counter.py
+++ b/packages/modules/devices/orno/orno/counter.py
@@ -29,9 +29,9 @@ class OrnoCounter(AbstractCounter):
 
     def update(self):
         power = self.client.read_holding_registers(
-            0x141, ModbusDataType.INT_32, unit=self.component_config.configuration.modbus_id)
+            0x141, ModbusDataType.INT_32, device_id=self.component_config.configuration.modbus_id)
         imported = self.client.read_holding_registers(
-            0xA001, ModbusDataType.INT_32, unit=self.component_config.configuration.modbus_id) * 10
+            0xA001, ModbusDataType.INT_32, device_id=self.component_config.configuration.modbus_id) * 10
         imported, _ = self.peak_filter.check_values(power, imported, None)
         counter_state = CounterState(
             imported=imported,

--- a/packages/modules/devices/orno/orno/device.py
+++ b/packages/modules/devices/orno/orno/device.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import logging
-from pymodbus.transaction import ModbusRtuFramer
+from pymodbus.framer import FramerType
 from typing import Iterable
 
 from modules.common.abstract_device import DeviceDescriptor
@@ -29,7 +29,7 @@ def create_device(device_config: Orno):
     def initializer():
         nonlocal client
         client = ModbusTcpClient_(device_config.configuration.ip_address,
-                                  device_config.configuration.port, framer=ModbusRtuFramer)
+                                  device_config.configuration.port, framer=FramerType.RTU)
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/powerdog/powerdog/counter.py
+++ b/packages/modules/devices/powerdog/powerdog/counter.py
@@ -41,13 +41,13 @@ class PowerdogCounter(AbstractCounter):
         with self.__tcp_client:
             if self.component_config.configuration.position_evu:
                 export_power = self.__tcp_client.read_input_registers(
-                    40000, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
+                    40000, ModbusDataType.INT_32, device_id=self.__modbus_id) * -1
                 import_power = self.__tcp_client.read_input_registers(
-                    40024, ModbusDataType.INT_32, unit=self.__modbus_id)
+                    40024, ModbusDataType.INT_32, device_id=self.__modbus_id)
                 power = export_power + import_power
             else:
                 home_consumption = self.__tcp_client.read_input_registers(
-                    40026, ModbusDataType.INT_32, unit=self.__modbus_id)
+                    40026, ModbusDataType.INT_32, device_id=self.__modbus_id)
                 power = home_consumption + inverter_power
                 log.debug("Powerdog Hausverbrauch[W]: " + str(home_consumption))
 

--- a/packages/modules/devices/powerdog/powerdog/inverter.py
+++ b/packages/modules/devices/powerdog/powerdog/inverter.py
@@ -39,7 +39,7 @@ class PowerdogInverter(AbstractInverter):
 
     def update(self) -> float:
         with self.__tcp_client:
-            power = self.__tcp_client.read_input_registers(40002, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
+            power = self.__tcp_client.read_input_registers(40002, ModbusDataType.INT_32, device_id=self.__modbus_id) * -1
 
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/qcells/qcells/bat.py
+++ b/packages/modules/devices/qcells/qcells/bat.py
@@ -30,12 +30,12 @@ class QCellsBat(AbstractBat):
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
 
     def update(self) -> None:
-        power = self.client.read_input_registers(0x0016, ModbusDataType.INT_16, unit=self.__modbus_id)
-        soc = self.client.read_input_registers(0x001C, ModbusDataType.UINT_16, unit=self.__modbus_id)
+        power = self.client.read_input_registers(0x0016, ModbusDataType.INT_16, device_id=self.__modbus_id)
+        soc = self.client.read_input_registers(0x001C, ModbusDataType.UINT_16, device_id=self.__modbus_id)
         imported = self.client.read_input_registers(
-            0x0021, ModbusDataType.UINT_16, unit=self.__modbus_id) * 100
+            0x0021, ModbusDataType.UINT_16, device_id=self.__modbus_id) * 100
         exported = self.client.read_input_registers(
-            0x001D, ModbusDataType.UINT_16, unit=self.__modbus_id) * 100
+            0x001D, ModbusDataType.UINT_16, device_id=self.__modbus_id) * 100
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/qcells/qcells/counter.py
+++ b/packages/modules/devices/qcells/qcells/counter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractCounter
 from modules.common.component_state import CounterState
@@ -32,22 +32,22 @@ class QCellsCounter(AbstractCounter):
 
     def update(self) -> None:
         power = self.client.read_input_registers(0x0046, ModbusDataType.INT_32, wordorder=Endian.Little,
-                                                 unit=self.__modbus_id) * -1
+                                                 device_id=self.__modbus_id) * -1
         frequency = self.client.read_input_registers(
-            0x0007, ModbusDataType.UINT_16, unit=self.__modbus_id) / 100
+            0x0007, ModbusDataType.UINT_16, device_id=self.__modbus_id) / 100
         try:
             powers = [-value for value in self.client.read_input_registers(
-                0x0082, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=self.__modbus_id
+                0x0082, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, device_id=self.__modbus_id
             )]
         except Exception:
             powers = None
         try:
             voltages = [self.client.read_input_registers(
-                0x006A, ModbusDataType.UINT_16, unit=self.__modbus_id
+                0x006A, ModbusDataType.UINT_16, device_id=self.__modbus_id
             ) / 10, self.client.read_input_registers(
-                0x006E, ModbusDataType.UINT_16, unit=self.__modbus_id
+                0x006E, ModbusDataType.UINT_16, device_id=self.__modbus_id
             ) / 10, self.client.read_input_registers(
-                0x0072, ModbusDataType.UINT_16, unit=self.__modbus_id
+                0x0072, ModbusDataType.UINT_16, device_id=self.__modbus_id
             ) / 10]
             if voltages[0] < 1:
                 voltages[0] = 230
@@ -60,7 +60,7 @@ class QCellsCounter(AbstractCounter):
         exported, imported = [value * 10
                               for value in self.client.read_input_registers(
                                   0x0048, [ModbusDataType.UINT_32] * 2,
-                                  wordorder=Endian.Little, unit=self.__modbus_id
+                                  wordorder=Endian.Little, device_id=self.__modbus_id
                               )]
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)

--- a/packages/modules/devices/qcells/qcells/inverter.py
+++ b/packages/modules/devices/qcells/qcells/inverter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common.abstract_device import AbstractInverter
 from modules.common.component_state import InverterState
@@ -32,14 +32,14 @@ class QCellsInverter(AbstractInverter):
 
     def update(self) -> None:
         power_string1 = (self.client.read_input_registers(
-            0x0003, ModbusDataType.INT_16, unit=self.__modbus_id) / 10) * \
-            (self.client.read_input_registers(0x0005, ModbusDataType.INT_16, unit=self.__modbus_id) / 10)
+            0x0003, ModbusDataType.INT_16, device_id=self.__modbus_id) / 10) * \
+            (self.client.read_input_registers(0x0005, ModbusDataType.INT_16, device_id=self.__modbus_id) / 10)
         power_string2 = (self.client.read_input_registers(
-            0x0004, ModbusDataType.INT_16, unit=self.__modbus_id) / 10) * \
-            (self.client.read_input_registers(0x0006, ModbusDataType.INT_16, unit=self.__modbus_id) / 10)
+            0x0004, ModbusDataType.INT_16, device_id=self.__modbus_id) / 10) * \
+            (self.client.read_input_registers(0x0006, ModbusDataType.INT_16, device_id=self.__modbus_id) / 10)
         power = (power_string1 + power_string2) * -1
         exported = self.client.read_input_registers(0x0094, ModbusDataType.UINT_32, wordorder=Endian.Little,
-                                                    unit=self.__modbus_id) * 100
+                                                    device_id=self.__modbus_id) * 100
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/saxpower/saxpower/bat.py
+++ b/packages/modules/devices/saxpower/saxpower/bat.py
@@ -37,7 +37,7 @@ class SaxpowerBat(AbstractBat):
     def update(self) -> None:
         with self.__tcp_client:
             # Die beiden Register müssen zwingend zusammen ausgelesen werden, sonst scheitert die zweite Abfrage.
-            soc, power = self.__tcp_client.read_holding_registers(46, [ModbusDataType.INT_16]*2, unit=self.__modbus_id)
+            soc, power = self.__tcp_client.read_holding_registers(46, [ModbusDataType.INT_16]*2, device_id=self.__modbus_id)
             power = power * -1 + 16384
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/saxpower/saxpower/counter.py
+++ b/packages/modules/devices/saxpower/saxpower/counter.py
@@ -34,7 +34,7 @@ class SaxpowerCounter(AbstractCounter):
         self.peak_filter = PeakFilter(ComponentType.COUNTER, self.component_config.id, self.fault_state)
 
     def update(self) -> None:
-        power = self.client.read_holding_registers(48, ModbusDataType.INT_16, unit=self.__modbus_id)
+        power = self.client.read_holding_registers(48, ModbusDataType.INT_16, device_id=self.__modbus_id)
         power = power - 16384
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/siemens/siemens/bat.py
+++ b/packages/modules/devices/siemens/siemens/bat.py
@@ -36,8 +36,8 @@ class SiemensBat(AbstractBat):
 
     def update(self) -> None:
         with self.__tcp_client:
-            power = self.__tcp_client.read_holding_registers(6, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
-            soc = int(self.__tcp_client.read_holding_registers(8, ModbusDataType.INT_32, unit=self.__modbus_id))
+            power = self.__tcp_client.read_holding_registers(6, ModbusDataType.INT_32, device_id=self.__modbus_id) * -1
+            soc = int(self.__tcp_client.read_holding_registers(8, ModbusDataType.INT_32, device_id=self.__modbus_id))
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/siemens/siemens/counter.py
+++ b/packages/modules/devices/siemens/siemens/counter.py
@@ -36,7 +36,7 @@ class SiemensCounter(AbstractCounter):
 
     def update(self) -> None:
         with self.__tcp_client:
-            power = self.__tcp_client.read_holding_registers(14, ModbusDataType.INT_32, unit=self.__modbus_id)
+            power = self.__tcp_client.read_holding_registers(14, ModbusDataType.INT_32, device_id=self.__modbus_id)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/siemens/siemens/inverter.py
+++ b/packages/modules/devices/siemens/siemens/inverter.py
@@ -36,7 +36,7 @@ class SiemensInverter(AbstractInverter):
 
     def update(self) -> None:
         with self.__tcp_client:
-            power = self.__tcp_client.read_holding_registers(16, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
+            power = self.__tcp_client.read_holding_registers(16, ModbusDataType.INT_32, device_id=self.__modbus_id) * -1
 
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/siemens/siemens_sentron/bat.py
+++ b/packages/modules/devices/siemens/siemens_sentron/bat.py
@@ -32,9 +32,9 @@ class SiemensSentronBat(AbstractBat):
 
     def update(self) -> None:
         with self.__tcp_client:
-            power = self.__tcp_client.read_holding_registers(65, ModbusDataType.FLOAT_32, unit=self.__modbus_id) * -1
-            imported = self.__tcp_client.read_holding_registers(801, ModbusDataType.FLOAT_64, unit=self.__modbus_id)
-            exported = self.__tcp_client.read_holding_registers(809, ModbusDataType.FLOAT_64, unit=self.__modbus_id)
+            power = self.__tcp_client.read_holding_registers(65, ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * -1
+            imported = self.__tcp_client.read_holding_registers(801, ModbusDataType.FLOAT_64, device_id=self.__modbus_id)
+            exported = self.__tcp_client.read_holding_registers(809, ModbusDataType.FLOAT_64, device_id=self.__modbus_id)
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/siemens/siemens_sentron/counter.py
+++ b/packages/modules/devices/siemens/siemens_sentron/counter.py
@@ -32,16 +32,16 @@ class SiemensSentronCounter(AbstractCounter):
 
     def update(self) -> None:
         with self.__tcp_client:
-            imported = self.__tcp_client.read_holding_registers(801, ModbusDataType.FLOAT_64, unit=self.__modbus_id)
-            exported = self.__tcp_client.read_holding_registers(809, ModbusDataType.FLOAT_64, unit=self.__modbus_id)
-            power = self.__tcp_client.read_holding_registers(65, ModbusDataType.FLOAT_32, unit=self.__modbus_id)
-            powers = self.__tcp_client.read_holding_registers(25, [ModbusDataType.FLOAT_32] * 3, unit=self.__modbus_id)
-            frequency = self.__tcp_client.read_holding_registers(55, ModbusDataType.FLOAT_32, unit=self.__modbus_id)
+            imported = self.__tcp_client.read_holding_registers(801, ModbusDataType.FLOAT_64, device_id=self.__modbus_id)
+            exported = self.__tcp_client.read_holding_registers(809, ModbusDataType.FLOAT_64, device_id=self.__modbus_id)
+            power = self.__tcp_client.read_holding_registers(65, ModbusDataType.FLOAT_32, device_id=self.__modbus_id)
+            powers = self.__tcp_client.read_holding_registers(25, [ModbusDataType.FLOAT_32] * 3, device_id=self.__modbus_id)
+            frequency = self.__tcp_client.read_holding_registers(55, ModbusDataType.FLOAT_32, device_id=self.__modbus_id)
             currents = self.__tcp_client.read_holding_registers(
-                13, [ModbusDataType.FLOAT_32] * 3, unit=self.__modbus_id)
-            voltages = self.__tcp_client.read_holding_registers(1, [ModbusDataType.FLOAT_32] * 3, unit=self.__modbus_id)
+                13, [ModbusDataType.FLOAT_32] * 3, device_id=self.__modbus_id)
+            voltages = self.__tcp_client.read_holding_registers(1, [ModbusDataType.FLOAT_32] * 3, device_id=self.__modbus_id)
             power_factors = self.__tcp_client.read_holding_registers(
-                37, [ModbusDataType.FLOAT_32] * 3, unit=self.__modbus_id)
+                37, [ModbusDataType.FLOAT_32] * 3, device_id=self.__modbus_id)
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(

--- a/packages/modules/devices/siemens/siemens_sentron/inverter.py
+++ b/packages/modules/devices/siemens/siemens_sentron/inverter.py
@@ -32,8 +32,8 @@ class SiemensSentronInverter(AbstractInverter):
 
     def update(self) -> None:
         with self.__tcp_client:
-            power = self.__tcp_client.read_holding_registers(65, ModbusDataType.FLOAT_32, unit=self.__modbus_id) * -1
-            exported = self.__tcp_client.read_holding_registers(809, ModbusDataType.FLOAT_64, unit=self.__modbus_id)
+            power = self.__tcp_client.read_holding_registers(65, ModbusDataType.FLOAT_32, device_id=self.__modbus_id) * -1
+            exported = self.__tcp_client.read_holding_registers(809, ModbusDataType.FLOAT_64, device_id=self.__modbus_id)
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/sigenergy/sigenergy/bat.py
+++ b/packages/modules/devices/sigenergy/sigenergy/bat.py
@@ -37,9 +37,9 @@ class SigenergyBat(AbstractBat):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        power = self.client.read_holding_registers(30037, ModbusDataType.INT_32, unit=unit)
+        power = self.client.read_holding_registers(30037, ModbusDataType.INT_32, device_id=unit)
         # soc unit 0.1%
-        soc = self.client.read_holding_registers(30014, ModbusDataType.UINT_16, unit=unit) / 10
+        soc = self.client.read_holding_registers(30014, ModbusDataType.UINT_16, device_id=unit) / 10
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
@@ -59,13 +59,13 @@ class SigenergyBat(AbstractBat):
             log.debug("Keine Batteriesteuerung, Selbstregelung durch Wechselrichter")
             if self.last_mode is not None:
                 # Entladesperre ab 5%, Ansonsten Eigenregelung
-                self.client.write_register(40048, 50, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.client.write_register(40048, 50, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = None
         else:
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht entladen")
             if self.last_mode != 'stop':
                 # Entladesperre auch bei 100% SoC
-                self.client.write_register(40048, 1000, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.client.write_register(40048, 1000, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'stop'
 
     def power_limit_controllable(self) -> bool:

--- a/packages/modules/devices/sigenergy/sigenergy/counter.py
+++ b/packages/modules/devices/sigenergy/sigenergy/counter.py
@@ -32,8 +32,8 @@ class SigenergyCounter:
     def update(self):
         unit = self.component_config.configuration.modbus_id
 
-        powers = self.client.read_holding_registers(30052, [ModbusDataType.INT_32]*3, unit=unit)
-        power = self.client.read_holding_registers(30005, ModbusDataType.INT_32, unit=unit)
+        powers = self.client.read_holding_registers(30052, [ModbusDataType.INT_32]*3, device_id=unit)
+        power = self.client.read_holding_registers(30005, ModbusDataType.INT_32, device_id=unit)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/sigenergy/sigenergy/inverter.py
+++ b/packages/modules/devices/sigenergy/sigenergy/inverter.py
@@ -33,7 +33,7 @@ class SigenergyInverter:
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        power = self.client.read_holding_registers(30035, ModbusDataType.INT_32, unit=unit) * -1
+        power = self.client.read_holding_registers(30035, ModbusDataType.INT_32, device_id=unit) * -1
 
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/sma/sma_sunny_boy/bat.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat.py
@@ -35,16 +35,16 @@ class SunnyBoyBat(AbstractBat):
     def read(self) -> BatState:
         unit = self.component_config.configuration.modbus_id
 
-        soc = self.__tcp_client.read_holding_registers(30845, ModbusDataType.UINT_32, unit=unit)
-        imp = self.__tcp_client.read_holding_registers(31393, ModbusDataType.INT_32, unit=unit)
-        exp = self.__tcp_client.read_holding_registers(31395, ModbusDataType.INT_32, unit=unit)
+        soc = self.__tcp_client.read_holding_registers(30845, ModbusDataType.UINT_32, device_id=unit)
+        imp = self.__tcp_client.read_holding_registers(31393, ModbusDataType.INT_32, device_id=unit)
+        exp = self.__tcp_client.read_holding_registers(31395, ModbusDataType.INT_32, device_id=unit)
         if imp > 5:
             power = imp
         else:
             power = exp * -1
 
-        exported = self.__tcp_client.read_holding_registers(31401, ModbusDataType.UINT_64, unit=unit)
-        imported = self.__tcp_client.read_holding_registers(31397, ModbusDataType.UINT_64, unit=unit)
+        exported = self.__tcp_client.read_holding_registers(31401, ModbusDataType.UINT_64, device_id=unit)
+        imported = self.__tcp_client.read_holding_registers(31397, ModbusDataType.UINT_64, device_id=unit)
 
         if exported == self.SMA_UINT_64_NAN or imported == self.SMA_UINT_64_NAN:
             raise ValueError(f'Batterie lieferte nicht plausible Werte. Export: {exported}, Import: {imported}. ',

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_smart_energy.py
@@ -128,14 +128,14 @@ class SunnyBoySmartEnergyBat(AbstractBat):
         values = {}
         for key in register_names:
             address, data_type = self.REGISTERS[key]
-            values[key] = self.__tcp_client.read_holding_registers(address, data_type, unit=unit)
+            values[key] = self.__tcp_client.read_holding_registers(address, data_type, device_id=unit)
         log.debug(f"Bat raw values {self.__tcp_client.address}: {values}")
         return values
 
     def _write_registers(self, values_to_write: Dict[str, Union[int, float]], unit: int) -> None:
         for key, value in values_to_write.items():
             address, data_type = self.REGISTERS[key]
-            self.__tcp_client.write_register(address, value, data_type, unit=unit)
+            self.__tcp_client.write_register(address, value, data_type, device_id=unit)
             log.debug(f"Neuer Wert {value} in Register {address} geschrieben.")
 
     def power_limit_controllable(self) -> bool:

--- a/packages/modules/devices/sma/sma_sunny_boy/bat_tesvolt.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/bat_tesvolt.py
@@ -35,8 +35,8 @@ class TesvoltBat(AbstractBat):
         self.peak_filter = PeakFilter(ComponentType.BAT, self.component_config.id, self.fault_state)
 
     def update(self) -> None:
-        soc = self.__tcp_client.read_input_registers(1056, ModbusDataType.INT_32, unit=25) / 10
-        power = self.__tcp_client.read_input_registers(1012, ModbusDataType.INT_32, unit=25) * -1
+        soc = self.__tcp_client.read_input_registers(1056, ModbusDataType.INT_32, device_id=25) / 10
+        power = self.__tcp_client.read_input_registers(1012, ModbusDataType.INT_32, device_id=25) * -1
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/sma/sma_sunny_boy/counter.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/counter.py
@@ -35,8 +35,8 @@ class SmaSunnyBoyCounter(AbstractCounter):
     def update(self):
         unit = self.component_config.configuration.modbus_id
 
-        imp = self.__tcp_client.read_holding_registers(30865, ModbusDataType.UINT_32, unit=unit)
-        exp = self.__tcp_client.read_holding_registers(30867, ModbusDataType.UINT_32, unit=unit)
+        imp = self.__tcp_client.read_holding_registers(30865, ModbusDataType.UINT_32, device_id=unit)
+        exp = self.__tcp_client.read_holding_registers(30867, ModbusDataType.UINT_32, device_id=unit)
         if imp > 5:
             power = imp
         else:

--- a/packages/modules/devices/sma/sma_sunny_boy/inverter.py
+++ b/packages/modules/devices/sma/sma_sunny_boy/inverter.py
@@ -50,39 +50,39 @@ class SmaSunnyBoyInverter(AbstractInverter):
 
         if self.component_config.configuration.version == SmaInverterVersion.default:
             # AC Wirkleistung über alle Phasen (W) [Pac]
-            power_total = self.tcp_client.read_holding_registers(30775, ModbusDataType.INT_32, unit=unit)
+            power_total = self.tcp_client.read_holding_registers(30775, ModbusDataType.INT_32, device_id=unit)
             # Gesamtertrag (Wh) [E-Total]
-            energy = self.tcp_client.read_holding_registers(30529, ModbusDataType.UINT_32, unit=unit)
+            energy = self.tcp_client.read_holding_registers(30529, ModbusDataType.UINT_32, device_id=unit)
             # Bei Hybrid Wechselrichtern treten Abweichungen auf, die in der Nacht
             # immer wieder Generatorleistung anzeigen (0-50 Watt). Um dies zu verhindern, schauen wir uns
             # zunächst an, ob vom DC Teil überhaupt Leistung kommt. Ist dies nicht der Fall, können wir power
             # gleich auf 0 setzen.
             # Leistung DC an Eingang 1 und 2
-            dc_power = (self.tcp_client.read_holding_registers(30773, ModbusDataType.INT_32, unit=unit) +
-                        self.tcp_client.read_holding_registers(30961, ModbusDataType.INT_32, unit=unit))
+            dc_power = (self.tcp_client.read_holding_registers(30773, ModbusDataType.INT_32, device_id=unit) +
+                        self.tcp_client.read_holding_registers(30961, ModbusDataType.INT_32, device_id=unit))
 
-            currents = self.tcp_client.read_holding_registers(30977, [ModbusDataType.INT_32]*3, unit=unit)
+            currents = self.tcp_client.read_holding_registers(30977, [ModbusDataType.INT_32]*3, device_id=unit)
             if all(c == self.SMA_INT32_NAN for c in currents):
                 currents = None
             else:
                 currents = [current / -1000 if current != self.SMA_INT32_NAN else 0 for current in currents]
         elif self.component_config.configuration.version == SmaInverterVersion.core2:
             # AC Wirkleistung über alle Phasen (W) [Pac]
-            power_total = self.tcp_client.read_holding_registers(40084, ModbusDataType.INT_16, unit=unit) * 10
+            power_total = self.tcp_client.read_holding_registers(40084, ModbusDataType.INT_16, device_id=unit) * 10
             # Gesamtertrag (Wh) [E-Total] SF=2!
-            energy = self.tcp_client.read_holding_registers(40094, ModbusDataType.UINT_32, unit=unit) * 100
+            energy = self.tcp_client.read_holding_registers(40094, ModbusDataType.UINT_32, device_id=unit) * 100
             # Power
-            dc_power = self.tcp_client.read_holding_registers(40101, ModbusDataType.UINT_32, unit=unit) * 100
+            dc_power = self.tcp_client.read_holding_registers(40101, ModbusDataType.UINT_32, device_id=unit) * 100
             # Phasenstöme
-            current_L1 = self.tcp_client.read_holding_registers(30977, ModbusDataType.INT_32, unit=unit) * -1
-            current_L2 = self.tcp_client.read_holding_registers(30979, ModbusDataType.INT_32, unit=unit) * -1
-            current_L3 = self.tcp_client.read_holding_registers(30981, ModbusDataType.INT_32, unit=unit) * -1
+            current_L1 = self.tcp_client.read_holding_registers(30977, ModbusDataType.INT_32, device_id=unit) * -1
+            current_L2 = self.tcp_client.read_holding_registers(30979, ModbusDataType.INT_32, device_id=unit) * -1
+            current_L3 = self.tcp_client.read_holding_registers(30981, ModbusDataType.INT_32, device_id=unit) * -1
             currents = [current_L1 / 1000, current_L2 / 1000, current_L3 / 1000]
         elif self.component_config.configuration.version == SmaInverterVersion.datamanager:
             # AC Wirkleistung über alle Phasen (W) [Pac]
-            power_total = self.tcp_client.read_holding_registers(30775, ModbusDataType.INT_32, unit=unit)
+            power_total = self.tcp_client.read_holding_registers(30775, ModbusDataType.INT_32, device_id=unit)
             # Total eingespeiste Energie auf allen Außenleitern (Wh) [E-Total]
-            energy = self.tcp_client.read_holding_registers(30513, ModbusDataType.UINT_64, unit=unit)
+            energy = self.tcp_client.read_holding_registers(30513, ModbusDataType.UINT_64, device_id=unit)
             # DC-Power = power_total - Cluster-Controller gibt in Register 30775 immer korrekte Werte aus,
             # daher ist wie bei SmaInverterVersion.default keine Prüfung auf DC-Leistung notwendig.
             # Aus kompatibilitätsgründen wird dc_power auf den Wert der AC-Wirkleistung gesetzt.

--- a/packages/modules/devices/sma/sma_sunny_island/bat.py
+++ b/packages/modules/devices/sma/sma_sunny_island/bat.py
@@ -32,10 +32,10 @@ class SunnyIslandBat(AbstractBat):
         unit = self.component_config.configuration.modbus_id
 
         with self.__tcp_client:
-            soc = self.__tcp_client.read_holding_registers(30845, ModbusDataType.INT_32, unit=unit)
+            soc = self.__tcp_client.read_holding_registers(30845, ModbusDataType.INT_32, device_id=unit)
 
-            power = self.__tcp_client.read_holding_registers(30775, ModbusDataType.INT_32, unit=unit) * -1
-            imported, exported = self.__tcp_client.read_holding_registers(30595, [ModbusDataType.INT_32]*2, unit=unit)
+            power = self.__tcp_client.read_holding_registers(30775, ModbusDataType.INT_32, device_id=unit) * -1
+            imported, exported = self.__tcp_client.read_holding_registers(30595, [ModbusDataType.INT_32]*2, device_id=unit)
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         return BatState(

--- a/packages/modules/devices/sofar/sofar/bat.py
+++ b/packages/modules/devices/sofar/sofar/bat.py
@@ -32,21 +32,21 @@ class SofarBat(AbstractBat):
     def update(self) -> None:
         # 0x900D High 8 bits: the number of battery packs in parallel
         # Lower 8 bits: the number of battery strings in the battery pack
-        battery_packs = self.client.read_holding_registers(0x900D, ModbusDataType.UINT_16, unit=self.__modbus_id) >> 8
+        battery_packs = self.client.read_holding_registers(0x900D, ModbusDataType.UINT_16, device_id=self.__modbus_id) >> 8
         # Power bat1 - bat12: INT_16 in kW accuracy 0,01
         power_regs = [0x0606, 0x060D, 0x0614, 0x061B, 0x0622, 0x0629, 0x0630, 0x0637, 0x0646, 0x064D, 0x0654, 0x065B]
 
-        power = sum(self.client.read_holding_registers(power_regs[idx], ModbusDataType.INT_16, unit=self.__modbus_id)
+        power = sum(self.client.read_holding_registers(power_regs[idx], ModbusDataType.INT_16, device_id=self.__modbus_id)
                     for idx in range(battery_packs)) * 10
-        soc = self.client.read_holding_registers(0x9012, ModbusDataType.UINT_16, unit=self.__modbus_id)
+        soc = self.client.read_holding_registers(0x9012, ModbusDataType.UINT_16, device_id=self.__modbus_id)
         # 0x0696 Bat_charge_total LSB UInt32 0,1 kWh
         # 0x0697 Bat_charge_total UInt32 0,1 kWh
         imported = self.client.read_holding_registers(
-            0x0696, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+            0x0696, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
         # 0x069A Bat_discharge_total LSB UInt32 0,1 kWh
         # 0x069B Bat:discharge_total UInt32 0,1 kWh
         exported = self.client.read_holding_registers(
-            0x069A, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+            0x069A, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/sofar/sofar/counter.py
+++ b/packages/modules/devices/sofar/sofar/counter.py
@@ -32,23 +32,23 @@ class SofarCounter(AbstractCounter):
     def update(self):
         # 0x0485 ActivePower_output_total Int16 in kW accuracy 0,01 discharge + charge -
         # 0x0488 ActivePower_PCC_total Int16 0,01 kW
-        power = self.client.read_holding_registers(0x0488, ModbusDataType.INT_16, unit=self.__modbus_id) * -10
+        power = self.client.read_holding_registers(0x0488, ModbusDataType.INT_16, device_id=self.__modbus_id) * -10
         # 0x0484 Frequency_Grid UInt16 in Hz accuracy 0,01
         frequency = self.client.read_holding_registers(
-            0x0484, ModbusDataType.UINT_16, unit=self.__modbus_id) / 100
+            0x0484, ModbusDataType.UINT_16, device_id=self.__modbus_id) / 100
         try:
             powers = [
-                self.client.read_holding_registers(0x0493, ModbusDataType.INT_16, unit=self.__modbus_id) * -10,
-                self.client.read_holding_registers(0x049E, ModbusDataType.INT_16, unit=self.__modbus_id) * -10,
-                self.client.read_holding_registers(0x04A9, ModbusDataType.INT_16, unit=self.__modbus_id) * -10]
+                self.client.read_holding_registers(0x0493, ModbusDataType.INT_16, device_id=self.__modbus_id) * -10,
+                self.client.read_holding_registers(0x049E, ModbusDataType.INT_16, device_id=self.__modbus_id) * -10,
+                self.client.read_holding_registers(0x04A9, ModbusDataType.INT_16, device_id=self.__modbus_id) * -10]
         except Exception:
             powers = None
         # 0x0692 Energy_Selling_Total UInt32 in kwH accuracy 0,01 LSB
         # 0x0693 Energy_Selling_Total UInt32 in kwH accuracy 0,01
-        exported = self.client.read_holding_registers(0x0692, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+        exported = self.client.read_holding_registers(0x0692, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
         # 0x068E Energy_Purchase_Total UInt32 in kwH accuracy 0,01 LSB
         # 0x068F Energy_Purchase_Total UInt32 in kwH accuracy 0,01
-        imported = self.client.read_holding_registers(0x068E, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+        imported = self.client.read_holding_registers(0x068E, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(

--- a/packages/modules/devices/sofar/sofar/inverter.py
+++ b/packages/modules/devices/sofar/sofar/inverter.py
@@ -31,8 +31,8 @@ class SofarInverter(AbstractInverter):
 
     def update(self) -> None:
         # 0x05C4 Power_PV_Total UINT16 in kW accuracy 0,1
-        power = self.client.read_holding_registers(0x05C4, ModbusDataType.UINT_16, unit=self.__modbus_id) * -100
-        exported = self.client.read_holding_registers(0x0686, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+        power = self.client.read_holding_registers(0x05C4, ModbusDataType.UINT_16, device_id=self.__modbus_id) * -100
+        exported = self.client.read_holding_registers(0x0686, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/solakon/solakon_one/bat.py
+++ b/packages/modules/devices/solakon/solakon_one/bat.py
@@ -34,13 +34,13 @@ class SolakonOneBat(AbstractBat):
 
         # AC Leistung am Stecker, Batterie aus dem Netz aufladen hat positive Werte,
         # Leistung aus der Batterie und/oder aus PV ins Netz abgeben hat negative Werte
-        power = self.client.read_holding_registers(39134, ModbusDataType.INT_32, unit=unit) * -1
+        power = self.client.read_holding_registers(39134, ModbusDataType.INT_32, device_id=unit) * -1
         # SoC Ladezustand der Batterie in %
-        soc = self.client.read_holding_registers(39424, ModbusDataType.INT_16, unit=unit)
+        soc = self.client.read_holding_registers(39424, ModbusDataType.INT_16, device_id=unit)
         # gesamte DC Ladung der Batterie in Wh
-        imported = self.client.read_holding_registers(39605, ModbusDataType.UINT_32, unit=unit) * 10
+        imported = self.client.read_holding_registers(39605, ModbusDataType.UINT_32, device_id=unit) * 10
         # gesamte DC Entladung der Batterie in Wh
-        exported = self.client.read_holding_registers(39609, ModbusDataType.UINT_32, unit=unit) * 10
+        exported = self.client.read_holding_registers(39609, ModbusDataType.UINT_32, device_id=unit) * 10
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/solakon/solakon_one/inverter.py
+++ b/packages/modules/devices/solakon/solakon_one/inverter.py
@@ -30,9 +30,9 @@ class SolakonOneInverter(AbstractInverter):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
         # Gesamte DC PV Leistung aller vier MPPT in W
-        power = self.client.read_holding_registers(39118, ModbusDataType.INT_32, unit=unit) * -1
+        power = self.client.read_holding_registers(39118, ModbusDataType.INT_32, device_id=unit) * -1
         # Gesamte DC PV Produktion in Wh
-        exported = self.client.read_holding_registers(39601, ModbusDataType.UINT_32, unit=unit) * 10
+        exported = self.client.read_holding_registers(39601, ModbusDataType.UINT_32, device_id=unit) * 10
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/solaredge/solaredge/bat.py
+++ b/packages/modules/devices/solaredge/solaredge/bat.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, TypedDict, Dict, Union, Optional, Tuple
 
 
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 import pymodbus
 
 
@@ -99,10 +99,10 @@ class SolaredgeBat(AbstractBat):
 
         # Read SoC and Power from the appropriate registers
         soc = self.__tcp_client.read_holding_registers(
-            soc_reg, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit
+            soc_reg, ModbusDataType.FLOAT_32, wordorder=Endian.Little, device_id=unit
         )
         power = self.__tcp_client.read_holding_registers(
-            power_reg, ModbusDataType.FLOAT_32, wordorder=Endian.Little, unit=unit
+            power_reg, ModbusDataType.FLOAT_32, wordorder=Endian.Little, device_id=unit
         )
 
         # Handle unsupported case
@@ -203,7 +203,7 @@ class SolaredgeBat(AbstractBat):
             address, data_type = self.REGISTERS[key]
             try:
                 values[key] = self.__tcp_client.read_holding_registers(
-                    address, data_type, wordorder=Endian.Little, unit=unit
+                    address, data_type, wordorder=Endian.Little, device_id=unit
                 )
             except pymodbus.exceptions.ModbusException as e:
                 log.error(f"Failed to read register {key} at address {address}: {e}")
@@ -217,7 +217,7 @@ class SolaredgeBat(AbstractBat):
         for key, value in values_to_write.items():
             address, data_type = self.REGISTERS[key]
             try:
-                self.__tcp_client.write_register(address, value, data_type, wordorder=Endian.Little, unit=unit)
+                self.__tcp_client.write_register(address, value, data_type, wordorder=Endian.Little, device_id=unit)
                 log.debug(f"Neuer Wert {value} in Register {address} geschrieben.")
             except pymodbus.exceptions.ModbusException as e:
                 log.error(f"Failed to write register {key} at address {address}: {e}")

--- a/packages/modules/devices/solaredge/solaredge/counter.py
+++ b/packages/modules/devices/solaredge/solaredge/counter.py
@@ -57,7 +57,7 @@ class SolaredgeCounter(AbstractCounter):
             (self.registers.imp_exp_scale, ModbusDataType.INT_16),
         )
         resp = self.__tcp_client.read_holding_registers_bulk(
-            self.registers.currents, 52, mapping=reg_mapping, unit=self.component_config.configuration.modbus_id)
+            self.registers.currents, 52, mapping=reg_mapping, device_id=self.component_config.configuration.modbus_id)
 
         imported = scale_registers(resp[self.registers.imported], resp[self.registers.imp_exp_scale])
         exported = scale_registers(resp[self.registers.exported], resp[self.registers.imp_exp_scale])

--- a/packages/modules/devices/solaredge/solaredge/external_inverter.py
+++ b/packages/modules/devices/solaredge/solaredge/external_inverter.py
@@ -54,7 +54,7 @@ class SolaredgeExternalInverter(AbstractInverter):
             (self.registers.imp_exp_scale, ModbusDataType.INT_16),
         )
         resp = self.__tcp_client.read_holding_registers_bulk(
-            self.registers.currents, 52, mapping=reg_mapping, unit=self.component_config.configuration.modbus_id)
+            self.registers.currents, 52, mapping=reg_mapping, device_id=self.component_config.configuration.modbus_id)
 
         factor = self.component_config.configuration.factor
 

--- a/packages/modules/devices/solaredge/solaredge/inverter.py
+++ b/packages/modules/devices/solaredge/solaredge/inverter.py
@@ -62,7 +62,7 @@ class SolaredgeInverter(AbstractInverter):
 
     def read_state(self):
         resp = self.__tcp_client.read_holding_registers_bulk(
-            Register.CURRENTS, 30, mapping=self.REG_MAPPING, unit=self.component_config.configuration.modbus_id)
+            Register.CURRENTS, 30, mapping=self.REG_MAPPING, device_id=self.component_config.configuration.modbus_id)
 
         power = scale_registers(resp[Register.POWER], resp[Register.POWER_SCALE]) * -1
         self.peak_filter.check_values(power)

--- a/packages/modules/devices/solaredge/solaredge/meter.py
+++ b/packages/modules/devices/solaredge/solaredge/meter.py
@@ -31,7 +31,7 @@ class SolaredgeMeterRegisters:
         # 40205: AC Frequency Scale Factor
         self.frequency = 40204
         self.frequency_scale = 40205
-        # 40222/40223/40224: Power factor by phase (unit=%)
+        # 40222/40223/40224: Power factor by phase (device_id=%)
         # 40225: AC Power Factor Scale Factor
         self.power_factors = 40222
         self.power_factors_scale = 40225
@@ -96,14 +96,14 @@ def _get_synergy_units(component_config: Union[SolaredgeBatSetup,
                                                SolaredgeExternalInverterSetup],
                        client) -> int:
     if client.read_holding_registers(40121, ModbusDataType.UINT_16,
-                                     unit=component_config.configuration.modbus_id
+                                     device_id=component_config.configuration.modbus_id
                                      ) == synergy_unit_identifier:
         # Snyergy-Units vom Haupt-WR des angeschlossenen Meters ermitteln. Es kann mehrere Haupt-WR mit
         # unterschiedlichen Modbus-IDs im Verbund geben.
         log.debug("Synergy Units supported")
         synergy_units = int(client.read_holding_registers(
             40129, ModbusDataType.UINT_16,
-            unit=component_config.configuration.modbus_id)) or 1
+            device_id=component_config.configuration.modbus_id)) or 1
         log.debug(
             f"Synergy Units detected for Modbus ID {component_config.configuration.modbus_id}: {synergy_units}")
     else:

--- a/packages/modules/devices/solarmax/solarmax/bat.py
+++ b/packages/modules/devices/solarmax/solarmax/bat.py
@@ -2,7 +2,7 @@
 import logging
 from typing import TypedDict, Any, Optional
 
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 from modules.common.abstract_device import AbstractBat
 from modules.common.component_state import BatState
 from modules.common.component_type import ComponentDescriptor
@@ -37,8 +37,8 @@ class SolarmaxBat(AbstractBat):
 
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
-        power = self.client.read_input_registers(114, ModbusDataType.INT_32, unit=unit, wordorder=Endian.Little)
-        soc = self.client.read_input_registers(122, ModbusDataType.INT_16, unit=unit)
+        power = self.client.read_input_registers(114, ModbusDataType.INT_32, device_id=unit, wordorder=Endian.Little)
+        soc = self.client.read_input_registers(122, ModbusDataType.INT_16, device_id=unit)
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 
@@ -57,24 +57,24 @@ class SolarmaxBat(AbstractBat):
         if power_limit is None:
             log.debug("Keine Batteriesteuerung, Selbstregelung durch Wechselrichter")
             if self.last_mode is not None:
-                self.client.write_register(142, 0, data_type=ModbusDataType.INT_16, unit=unit)
+                self.client.write_register(142, 0, data_type=ModbusDataType.INT_16, device_id=unit)
                 self.last_mode = None
         elif power_limit >= 0:
             # Solarmax kann nicht aktiv laden
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht entladen")
-            self.client.write_register(140, 0, data_type=ModbusDataType.INT_16, unit=unit)
-            self.client.write_register(141, 0, data_type=ModbusDataType.INT_16, unit=unit)
-            self.client.write_register(142, 1, data_type=ModbusDataType.INT_16, unit=unit)
+            self.client.write_register(140, 0, data_type=ModbusDataType.INT_16, device_id=unit)
+            self.client.write_register(141, 0, data_type=ModbusDataType.INT_16, device_id=unit)
+            self.client.write_register(142, 1, data_type=ModbusDataType.INT_16, device_id=unit)
             self.last_mode = 'stop'
         elif power_limit < 0:
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W entladen für den Hausverbrauch")
-            self.client.write_register(142, 1, data_type=ModbusDataType.INT_16, unit=unit)
+            self.client.write_register(142, 1, data_type=ModbusDataType.INT_16, device_id=unit)
             self.last_mode = 'discharge'
             # Die maximale Entladeleistung begrenzen auf 5000W, maximaler Wertebereich Modbusregister.
             power_value = int(min(abs(power_limit), 7000))
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
-            self.client.write_register(140, power_value, data_type=ModbusDataType.INT_16, unit=unit)
-            self.client.write_register(141, power_value, data_type=ModbusDataType.INT_16, unit=unit)
+            self.client.write_register(140, power_value, data_type=ModbusDataType.INT_16, device_id=unit)
+            self.client.write_register(141, power_value, data_type=ModbusDataType.INT_16, device_id=unit)
 
     def power_limit_controllable(self) -> bool:
         return self.component_config.configuration.power_limit_controllable

--- a/packages/modules/devices/solarmax/solarmax/counter_maxstorage.py
+++ b/packages/modules/devices/solarmax/solarmax/counter_maxstorage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
 
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 from modules.common.abstract_device import AbstractCounter
 from modules.common.component_state import CounterState
 from modules.common.component_type import ComponentDescriptor
@@ -36,7 +36,7 @@ class SolarmaxMsCounter(AbstractCounter):
 
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
-        power = self.client.read_input_registers(118, ModbusDataType.INT_32, unit=unit, wordorder=Endian.Little) * -1
+        power = self.client.read_input_registers(118, ModbusDataType.INT_32, device_id=unit, wordorder=Endian.Little) * -1
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/solarmax/solarmax/inverter.py
+++ b/packages/modules/devices/solarmax/solarmax/inverter.py
@@ -35,7 +35,7 @@ class SolarmaxInverter(AbstractInverter):
 
     def update(self) -> None:
         power = self.client.read_holding_registers(4151, ModbusDataType.UINT_32,
-                                                   unit=self.component_config.configuration.modbus_id) * -1
+                                                   device_id=self.component_config.configuration.modbus_id) * -1
         power = power / 10
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/solarmax/solarmax/inverter_maxstorage.py
+++ b/packages/modules/devices/solarmax/solarmax/inverter_maxstorage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from typing import TypedDict, Any
 
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 from modules.common.abstract_device import AbstractInverter
 from modules.common.component_state import InverterState
 from modules.common.component_type import ComponentDescriptor
@@ -36,7 +36,7 @@ class SolarmaxMsInverter(AbstractInverter):
 
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
-        power = self.client.read_input_registers(120, ModbusDataType.INT_32, unit=unit, wordorder=Endian.Little) * -1
+        power = self.client.read_input_registers(120, ModbusDataType.INT_32, device_id=unit, wordorder=Endian.Little) * -1
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/solax/solax/bat.py
+++ b/packages/modules/devices/solax/solax/bat.py
@@ -36,8 +36,8 @@ class SolaxBat(AbstractBat):
         unit = self.device_config.configuration.modbus_id
 
         # kein Speicher für Versionen G2 und G4
-        power = self.__tcp_client.read_input_registers(0x0016, ModbusDataType.INT_16, unit=unit)
-        soc = self.__tcp_client.read_input_registers(0x001C, ModbusDataType.UINT_16, unit=unit)
+        power = self.__tcp_client.read_input_registers(0x0016, ModbusDataType.INT_16, device_id=unit)
+        soc = self.__tcp_client.read_input_registers(0x001C, ModbusDataType.UINT_16, device_id=unit)
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
         bat_state = BatState(

--- a/packages/modules/devices/solax/solax/counter.py
+++ b/packages/modules/devices/solax/solax/counter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import Any, TypedDict
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common import modbus
 from modules.common.abstract_device import AbstractCounter
@@ -37,32 +37,32 @@ class SolaxCounter(AbstractCounter):
 
         if SolaxVersion(self.device_config.configuration.version) == SolaxVersion.G2:
             power = self.__tcp_client.read_input_registers(
-                0x043B, ModbusDataType.INT_32, wordorder=Endian.Little, unit=unit) * -1
-            frequency = self.__tcp_client.read_input_registers(0x0407, ModbusDataType.UINT_16, unit=unit) / 100
+                0x043B, ModbusDataType.INT_32, wordorder=Endian.Little, device_id=unit) * -1
+            frequency = self.__tcp_client.read_input_registers(0x0407, ModbusDataType.UINT_16, device_id=unit) / 100
             powers = [-value for value in self.__tcp_client.read_input_registers(
-                0x0704, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=unit)]
+                0x0704, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, device_id=unit)]
             exported, imported = [value * 10 for value in self.__tcp_client.read_input_registers(
-                0x043D, [ModbusDataType.UINT_32] * 2, wordorder=Endian.Little, unit=unit)]
+                0x043D, [ModbusDataType.UINT_32] * 2, wordorder=Endian.Little, device_id=unit)]
 
         elif SolaxVersion(self.device_config.configuration.version) == SolaxVersion.G3:
             power = self.__tcp_client.read_input_registers(
-                0x0046, ModbusDataType.INT_32, wordorder=Endian.Little, unit=unit) * -1
-            frequency = self.__tcp_client.read_input_registers(0x0007, ModbusDataType.UINT_16, unit=unit) / 100
+                0x0046, ModbusDataType.INT_32, wordorder=Endian.Little, device_id=unit) * -1
+            frequency = self.__tcp_client.read_input_registers(0x0007, ModbusDataType.UINT_16, device_id=unit) / 100
             try:
                 powers = [-value for value in self.__tcp_client.read_input_registers(
-                    0x0082, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, unit=unit)]
+                    0x0082, [ModbusDataType.INT_32] * 3, wordorder=Endian.Little, device_id=unit)]
             except Exception:
                 powers = None
             exported, imported = [value * 10 for value in self.__tcp_client.read_input_registers(
-                0x0048, [ModbusDataType.UINT_32] * 2, wordorder=Endian.Little, unit=unit)]
+                0x0048, [ModbusDataType.UINT_32] * 2, wordorder=Endian.Little, device_id=unit)]
 
         else:
             power = self.__tcp_client.read_input_registers(
-                0x0409, ModbusDataType.INT_32, wordorder=Endian.Little, unit=unit) * -1
-            frequency = self.__tcp_client.read_input_registers(0x0406, ModbusDataType.UINT_16, unit=unit) / 100
+                0x0409, ModbusDataType.INT_32, wordorder=Endian.Little, device_id=unit) * -1
+            frequency = self.__tcp_client.read_input_registers(0x0406, ModbusDataType.UINT_16, device_id=unit) / 100
             powers = None
             exported, imported = [value * 100 for value in self.__tcp_client.read_input_registers(
-                0x042F, [ModbusDataType.UINT_32] * 2, wordorder=Endian.Little, unit=unit)]
+                0x042F, [ModbusDataType.UINT_32] * 2, wordorder=Endian.Little, device_id=unit)]
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(
             imported=imported,

--- a/packages/modules/devices/solax/solax/inverter.py
+++ b/packages/modules/devices/solax/solax/inverter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from typing import Any, TypedDict
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 from modules.common import modbus
 from modules.common.abstract_device import AbstractInverter
@@ -36,19 +36,19 @@ class SolaxInverter(AbstractInverter):
         unit = self.device_config.configuration.modbus_id
 
         if SolaxVersion(self.device_config.configuration.version) == SolaxVersion.G2:
-            power = self.__tcp_client.read_input_registers(0x0413, ModbusDataType.UINT_16, unit=unit) * -1
+            power = self.__tcp_client.read_input_registers(0x0413, ModbusDataType.UINT_16, device_id=unit) * -1
             exported = self.__tcp_client.read_input_registers(
-                0x0423, ModbusDataType.UINT_32, wordorder=Endian.Little, unit=unit) * 100
+                0x0423, ModbusDataType.UINT_32, wordorder=Endian.Little, device_id=unit) * 100
         elif SolaxVersion(self.device_config.configuration.version) == SolaxVersion.G3:
-            power_temp = self.__tcp_client.read_input_registers(0x000A, [ModbusDataType.UINT_16] * 2, unit=unit)
+            power_temp = self.__tcp_client.read_input_registers(0x000A, [ModbusDataType.UINT_16] * 2, device_id=unit)
             power = sum(power_temp) * -1
             exported = self.__tcp_client.read_input_registers(
-                0x0052, ModbusDataType.UINT_32, wordorder=Endian.Little, unit=unit) * 100
+                0x0052, ModbusDataType.UINT_32, wordorder=Endian.Little, device_id=unit) * 100
         else:
-            power_temp = self.__tcp_client.read_input_registers(0x0410, [ModbusDataType.UINT_16] * 2, unit=unit)
+            power_temp = self.__tcp_client.read_input_registers(0x0410, [ModbusDataType.UINT_16] * 2, device_id=unit)
             power = sum(power_temp) * -1
             exported = self.__tcp_client.read_input_registers(
-                0x042B, ModbusDataType.UINT_32, wordorder=Endian.Little, unit=unit) * 100
+                0x042B, ModbusDataType.UINT_32, wordorder=Endian.Little, device_id=unit) * 100
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/solis/solis/bat.py
+++ b/packages/modules/devices/solis/solis/bat.py
@@ -33,12 +33,12 @@ class SolisBat(AbstractBat):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        power = self.client.read_input_registers(33149, ModbusDataType.INT_32, unit=unit)
-        soc = self.client.read_input_registers(33139, ModbusDataType.UINT_16, unit=unit)
+        power = self.client.read_input_registers(33149, ModbusDataType.INT_32, device_id=unit)
+        soc = self.client.read_input_registers(33139, ModbusDataType.UINT_16, device_id=unit)
         # Geladen in kWh
-        imported = self.client.read_input_registers(33161, ModbusDataType.UINT_32, unit=unit) * 1000
+        imported = self.client.read_input_registers(33161, ModbusDataType.UINT_32, device_id=unit) * 1000
         # Entladen in kWh
-        exported = self.client.read_input_registers(33165, ModbusDataType.UINT_32, unit=unit) * 1000
+        exported = self.client.read_input_registers(33165, ModbusDataType.UINT_32, device_id=unit) * 1000
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/solis/solis/counter.py
+++ b/packages/modules/devices/solis/solis/counter.py
@@ -37,11 +37,11 @@ class SolisCounter:
         if self.version == SolisVersion.inverter:
             register_offset = -1
 
-        power = self.client.read_input_registers(3263 + register_offset, ModbusDataType.INT_32, unit=unit) * -1
-        powers = self.client.read_input_registers(3257 + register_offset, [ModbusDataType.INT_32]*3, unit=unit)
-        frequency = self.client.read_input_registers(3282 + register_offset, ModbusDataType.UINT_16, unit=unit) / 100
-        imported = self.client.read_input_registers(3283 + register_offset, ModbusDataType.UINT_32, unit=unit) * 10
-        exported = self.client.read_input_registers(3285 + register_offset, ModbusDataType.UINT_32, unit=unit) * 10
+        power = self.client.read_input_registers(3263 + register_offset, ModbusDataType.INT_32, device_id=unit) * -1
+        powers = self.client.read_input_registers(3257 + register_offset, [ModbusDataType.INT_32]*3, device_id=unit)
+        frequency = self.client.read_input_registers(3282 + register_offset, ModbusDataType.UINT_16, device_id=unit) / 100
+        imported = self.client.read_input_registers(3283 + register_offset, ModbusDataType.UINT_32, device_id=unit) * 10
+        exported = self.client.read_input_registers(3285 + register_offset, ModbusDataType.UINT_32, device_id=unit) * 10
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(

--- a/packages/modules/devices/solis/solis/inverter.py
+++ b/packages/modules/devices/solis/solis/inverter.py
@@ -33,11 +33,11 @@ class SolisInverter:
         unit = self.component_config.configuration.modbus_id
 
         if self.version == SolisVersion.inverter:
-            power = self.client.read_input_registers(3004, ModbusDataType.UINT_32, unit=unit) * -1
-            exported = self.client.read_input_registers(3008, ModbusDataType.UINT_32, unit=unit) * 1000
+            power = self.client.read_input_registers(3004, ModbusDataType.UINT_32, device_id=unit) * -1
+            exported = self.client.read_input_registers(3008, ModbusDataType.UINT_32, device_id=unit) * 1000
         elif self.version == SolisVersion.hybrid:
-            power = self.client.read_input_registers(33057, ModbusDataType.UINT_32, unit=unit) * -1
-            exported = self.client.read_input_registers(33029, ModbusDataType.UINT_32, unit=unit) * 1000
+            power = self.client.read_input_registers(33057, ModbusDataType.UINT_32, device_id=unit) * -1
+            exported = self.client.read_input_registers(33029, ModbusDataType.UINT_32, device_id=unit) * 1000
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/studer/studer/bat.py
+++ b/packages/modules/devices/studer/studer/bat.py
@@ -32,10 +32,10 @@ class StuderBat(AbstractBat):
         unit = self.component_config.configuration.modbus_id
 
         with self.__tcp_client:
-            power = self.__tcp_client.read_input_registers(6, ModbusDataType.FLOAT_32, unit=unit)
-            imported = self.__tcp_client.read_input_registers(14, ModbusDataType.FLOAT_32, unit=unit) * 48
-            exported = self.__tcp_client.read_input_registers(16, ModbusDataType.FLOAT_32, unit=unit) * 48
-            soc = self.__tcp_client.read_input_registers(4, ModbusDataType.FLOAT_32, unit=unit)
+            power = self.__tcp_client.read_input_registers(6, ModbusDataType.FLOAT_32, device_id=unit)
+            imported = self.__tcp_client.read_input_registers(14, ModbusDataType.FLOAT_32, device_id=unit) * 48
+            exported = self.__tcp_client.read_input_registers(16, ModbusDataType.FLOAT_32, device_id=unit) * 48
+            soc = self.__tcp_client.read_input_registers(4, ModbusDataType.FLOAT_32, device_id=unit)
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         bat_state = BatState(

--- a/packages/modules/devices/studer/studer/inverter.py
+++ b/packages/modules/devices/studer/studer/inverter.py
@@ -43,7 +43,7 @@ class StuderInverter(AbstractInverter):
             power = 0
             for i in range(1, vc_count+1):
                 mb_unit_dev = mb_unit+i
-                power += self.__tcp_client.read_input_registers(mb_register, ModbusDataType.FLOAT_32, unit=mb_unit_dev)
+                power += self.__tcp_client.read_input_registers(mb_register, ModbusDataType.FLOAT_32, device_id=mb_unit_dev)
             power = power * -1000
 
             if vc_type == 'VS':
@@ -54,7 +54,7 @@ class StuderInverter(AbstractInverter):
             for i in range(1, vc_count + 1):
                 mb_unit_dev = mb_unit + i
                 exported += self.__tcp_client.read_input_registers(mb_register, ModbusDataType.FLOAT_32,
-                                                                   unit=mb_unit_dev)
+                                                                   device_id=mb_unit_dev)
             exported = exported * 1000000
 
         _, exported = self.peak_filter.check_values(power, None, exported)

--- a/packages/modules/devices/sungrow/sungrow_ihm/bat.py
+++ b/packages/modules/devices/sungrow/sungrow_ihm/bat.py
@@ -37,10 +37,10 @@ class SungrowIHMBat(AbstractBat):
 
     def update(self) -> None:
         unit = self.device_config.configuration.modbus_id
-        soc = int(self.__tcp_client.read_input_registers(8162, ModbusDataType.UINT_16, unit=unit) / 10)
+        soc = int(self.__tcp_client.read_input_registers(8162, ModbusDataType.UINT_16, device_id=unit) / 10)
 
         bat_power = self.__tcp_client.read_input_registers(8160, ModbusDataType.INT_32,
-                                                           wordorder=Endian.Little, unit=unit) * -10
+                                                           wordorder=Endian.Little, device_id=unit) * -10
 
         self.peak_filter.check_values(bat_power)
         imported, exported = self.sim_counter.sim_count(bat_power)
@@ -59,35 +59,35 @@ class SungrowIHMBat(AbstractBat):
         if power_limit is None:
             log.debug("Keine Batteriesteuerung, Selbstregelung durch Wechselrichter")
             if self.last_mode is not None:
-                self.__tcp_client.write_register(8023, 1, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(8024, 0xCC, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(8023, 1, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(8024, 0xCC, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = None
         elif power_limit == 0:
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht entladen")
             if self.last_mode != 'stop':
-                self.__tcp_client.write_register(8023, 5, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(8024, 0xCC, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(8023, 5, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(8024, 0xCC, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'stop'
         elif power_limit < 0:
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W entladen für den Hausverbrauch")
             if self.last_mode != 'discharge':
-                self.__tcp_client.write_register(8023, 5, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(8024, 0xBB, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(8023, 5, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(8024, 0xBB, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'discharge'
             power_value = int(power_limit / 100)
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W entladen für den Hausverbrauch")
             self.__tcp_client.write_register(8025, power_value, data_type=ModbusDataType.UINT_32,
-                                             wordorder=Endian.Little, unit=unit)
+                                             wordorder=Endian.Little, device_id=unit)
         elif power_limit > 0:
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W geladen")
             if self.last_mode != 'charge':
-                self.__tcp_client.write_register(8023, 5, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(8025, 0xAA, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(8023, 5, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(8025, 0xAA, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'charge'
             power_value = int(power_limit / 100)
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W geladen")
             self.__tcp_client.write_register(8025, power_value, data_type=ModbusDataType.UINT_32,
-                                             wordorder=Endian.Little, unit=unit)
+                                             wordorder=Endian.Little, device_id=unit)
 
     def power_limit_controllable(self) -> bool:
         return True

--- a/packages/modules/devices/sungrow/sungrow_ihm/counter.py
+++ b/packages/modules/devices/sungrow/sungrow_ihm/counter.py
@@ -34,15 +34,15 @@ class SungrowIHMCounter(AbstractCounter):
     def update(self):
         unit = self.device_config.configuration.modbus_id
         power = self.__tcp_client.read_input_registers(8156, ModbusDataType.INT_32,
-                                                       wordorder=Endian.Little, unit=unit) * -10
+                                                       wordorder=Endian.Little, device_id=unit) * -10
 
         powers = self.__tcp_client.read_input_registers(8558, [ModbusDataType.UINT_32] * 3,
-                                                        wordorder=Endian.Little, unit=unit)
+                                                        wordorder=Endian.Little, device_id=unit)
 
-        frequency = self.__tcp_client.read_input_registers(8557, ModbusDataType.UINT_16, unit=unit) / 10
+        frequency = self.__tcp_client.read_input_registers(8557, ModbusDataType.UINT_16, device_id=unit) / 10
 
         voltages = self.__tcp_client.read_input_registers(8554, [ModbusDataType.UINT_16] * 3,
-                                                          wordorder=Endian.Little, unit=unit)
+                                                          wordorder=Endian.Little, device_id=unit)
 
         voltages = [value / 10 for value in voltages]
 

--- a/packages/modules/devices/sungrow/sungrow_ihm/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow_ihm/inverter.py
@@ -35,7 +35,7 @@ class SungrowIHMInverter(AbstractInverter):
         unit = self.device_config.configuration.modbus_id
 
         power = self.__tcp_client.read_input_registers(8154, ModbusDataType.INT_32,
-                                                       wordorder=Endian.Little, unit=unit) * -10
+                                                       wordorder=Endian.Little, device_id=unit) * -10
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/sungrow/sungrow_micro/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow_micro/inverter.py
@@ -35,7 +35,7 @@ class SungrowMicroInverter(AbstractInverter):
         unit = self.device_config.configuration.modbus_id
 
         power = self.__tcp_client.read_input_registers(32213, ModbusDataType.UINT_32,
-                                                       wordorder=Endian.Little, unit=unit) * -1
+                                                       wordorder=Endian.Little, device_id=unit) * -1
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/sungrow/sungrow_sg/counter.py
+++ b/packages/modules/devices/sungrow/sungrow_sg/counter.py
@@ -37,21 +37,21 @@ class SungrowSGCounter(AbstractCounter):
     def update(self):
         unit = self.device_config.configuration.modbus_id
         power = self.__tcp_client.read_input_registers(5082, ModbusDataType.INT_32,
-                                                       wordorder=Endian.Little, unit=unit)
+                                                       wordorder=Endian.Little, device_id=unit)
 
         try:
             powers = self.__tcp_client.read_input_registers(5084, [ModbusDataType.INT_32] * 3,
-                                                            wordorder=Endian.Little, unit=unit)
+                                                            wordorder=Endian.Little, device_id=unit)
         except Exception:
             powers = None
             self.fault_state.no_error(self.fault_text)
 
-        frequency = self.__tcp_client.read_input_registers(5035, ModbusDataType.UINT_16, unit=unit) / 10
+        frequency = self.__tcp_client.read_input_registers(5035, ModbusDataType.UINT_16, device_id=unit) / 10
 
-        power_factor = self.__tcp_client.read_input_registers(5034, ModbusDataType.INT_16, unit=unit) / 1000
+        power_factor = self.__tcp_client.read_input_registers(5034, ModbusDataType.INT_16, device_id=unit) / 1000
 
         voltages = self.__tcp_client.read_input_registers(5018, [ModbusDataType.UINT_16] * 3,
-                                                          wordorder=Endian.Little, unit=unit)
+                                                          wordorder=Endian.Little, device_id=unit)
 
         voltages = [value / 10 for value in voltages]
 

--- a/packages/modules/devices/sungrow/sungrow_sg/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow_sg/inverter.py
@@ -35,11 +35,11 @@ class SungrowSGInverter(AbstractInverter):
         unit = self.device_config.configuration.modbus_id
 
         power = self.__tcp_client.read_input_registers(5030, ModbusDataType.INT_32,
-                                                       wordorder=Endian.Little, unit=unit) * -1
+                                                       wordorder=Endian.Little, device_id=unit) * -1
         dc_power = self.__tcp_client.read_input_registers(5016, ModbusDataType.UINT_32,
-                                                          wordorder=Endian.Little, unit=unit) * -1
+                                                          wordorder=Endian.Little, device_id=unit) * -1
 
-        currents = self.__tcp_client.read_input_registers(5021, [ModbusDataType.INT_16]*3, unit=unit)
+        currents = self.__tcp_client.read_input_registers(5021, [ModbusDataType.INT_16]*3, device_id=unit)
 
         currents = [value * -0.1 for value in currents]
 

--- a/packages/modules/devices/sungrow/sungrow_sh/bat.py
+++ b/packages/modules/devices/sungrow/sungrow_sh/bat.py
@@ -43,19 +43,19 @@ class SungrowSHBat(AbstractBat):
 
         try:
             self.__tcp_client.read_input_registers(5213, ModbusDataType.INT_32,
-                                                   wordorder=Endian.Little, unit=unit)
-            self.__tcp_client.read_input_registers(5630, ModbusDataType.INT_16, unit=unit)
+                                                   wordorder=Endian.Little, device_id=unit)
+            self.__tcp_client.read_input_registers(5630, ModbusDataType.INT_16, device_id=unit)
             log.debug("Battery register check: using new_registers (5213/5630).")
             return RegMode.NEW_REGISTERS
         except Exception:
             pass
         # register 13000 is always available, if unused it contains zero
         # register type can only be determined if battery power is not zero
-        if self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, unit=unit) == 0:
+        if self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, device_id=unit) == 0:
             raise ValueError("Speicherleistung aktuell 0kW. Registertyp wird gesetzt sobald "
                              "Speicher Leistungswerte liefert.")
         try:
-            if self.__tcp_client.read_input_registers(13000, ModbusDataType.UINT_16, unit=unit) != 0:
+            if self.__tcp_client.read_input_registers(13000, ModbusDataType.UINT_16, device_id=unit) != 0:
                 # if battery power is not zero and register 13000 shows status bits, old registers are used
                 log.debug("Battery register check: using old_registers (13021 + 13000 bits for sign).")
                 return RegMode.OLD_REGISTERS
@@ -67,20 +67,20 @@ class SungrowSHBat(AbstractBat):
 
     def update(self) -> None:
         unit = self.device_config.configuration.modbus_id
-        soc = int(self.__tcp_client.read_input_registers(13022, ModbusDataType.UINT_16, unit=unit) / 10)
+        soc = int(self.__tcp_client.read_input_registers(13022, ModbusDataType.UINT_16, device_id=unit) / 10)
 
         # === Mode 1: new_registers ===
         if self.register_check == RegMode.NEW_REGISTERS:
-            bat_current = self.__tcp_client.read_input_registers(5630, ModbusDataType.INT_16, unit=unit) * -0.1
+            bat_current = self.__tcp_client.read_input_registers(5630, ModbusDataType.INT_16, device_id=unit) * -0.1
             bat_power = self.__tcp_client.read_input_registers(5213, ModbusDataType.INT_32,
-                                                               wordorder=Endian.Little, unit=unit) * -1
+                                                               wordorder=Endian.Little, device_id=unit) * -1
 
         # === Mode 2: old_registers ===
         elif self.register_check == RegMode.OLD_REGISTERS:
-            bat_current = self.__tcp_client.read_input_registers(13020, ModbusDataType.INT_16, unit=unit) * -0.1
-            bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, unit=unit)
+            bat_current = self.__tcp_client.read_input_registers(13020, ModbusDataType.INT_16, device_id=unit) * -0.1
+            bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, device_id=unit)
 
-            resp = self.__tcp_client._delegate.read_input_registers(13000, 1, unit=unit)
+            resp = self.__tcp_client._delegate.read_input_registers(13000, 1, device_id=unit)
             running_state = resp.registers[0]
             is_charging = (running_state & 0x02) != 0
             is_discharging = (running_state & 0x04) != 0
@@ -92,13 +92,13 @@ class SungrowSHBat(AbstractBat):
 
         # === Mode 3: fallback ===
         else:
-            bat_current = self.__tcp_client.read_input_registers(13020, ModbusDataType.INT_16, unit=unit) * -0.1
-            bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, unit=unit)
+            bat_current = self.__tcp_client.read_input_registers(13020, ModbusDataType.INT_16, device_id=unit) * -0.1
+            bat_power = self.__tcp_client.read_input_registers(13021, ModbusDataType.UINT_16, device_id=unit)
 
             total_power = self.__tcp_client.read_input_registers(13033, ModbusDataType.INT_32,
-                                                                 wordorder=Endian.Little, unit=unit)
+                                                                 wordorder=Endian.Little, device_id=unit)
             pv_power = self.__tcp_client.read_input_registers(5016, ModbusDataType.UINT_32,
-                                                              wordorder=Endian.Little, unit=unit)
+                                                              wordorder=Endian.Little, device_id=unit)
 
             if total_power > pv_power:
                 bat_power = -abs(bat_power)
@@ -125,35 +125,35 @@ class SungrowSHBat(AbstractBat):
         if power_limit is None:
             log.debug("Keine Batteriesteuerung, Selbstregelung durch Wechselrichter")
             if self.last_mode is not None:
-                self.__tcp_client.write_register(13049, 0, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(13050, 0xCC, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(13049, 0, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(13050, 0xCC, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = None
         elif power_limit == 0:
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht entladen")
             if self.last_mode != 'stop':
-                self.__tcp_client.write_register(13049, 2, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(13050, 0xCC, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(13049, 2, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(13050, 0xCC, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'stop'
         elif power_limit < 0:
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W entladen für den Hausverbrauch")
             if self.last_mode != 'discharge':
-                self.__tcp_client.write_register(13049, 2, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(13050, 0xBB, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(13049, 2, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(13050, 0xBB, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'discharge'
             # Die maximale Entladeleistung begrenzen auf 5000W, maximaler Wertebereich Modbusregister.
             power_value = int(min(abs(power_limit), 5000))
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
-            self.__tcp_client.write_register(13051, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.__tcp_client.write_register(13051, power_value, data_type=ModbusDataType.UINT_16, device_id=unit)
         elif power_limit > 0:
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_limit} W geladen")
             if self.last_mode != 'charge':
-                self.__tcp_client.write_register(13049, 2, data_type=ModbusDataType.UINT_16, unit=unit)
-                self.__tcp_client.write_register(13050, 0xAA, data_type=ModbusDataType.UINT_16, unit=unit)
+                self.__tcp_client.write_register(13049, 2, data_type=ModbusDataType.UINT_16, device_id=unit)
+                self.__tcp_client.write_register(13050, 0xAA, data_type=ModbusDataType.UINT_16, device_id=unit)
                 self.last_mode = 'charge'
             # Die maximale Entladeleistung begrenzen auf 5000W, maximaler Wertebereich Modbusregister.
             power_value = int(min(power_limit, 5000))
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W geladen")
-            self.__tcp_client.write_register(13051, power_value, data_type=ModbusDataType.UINT_16, unit=unit)
+            self.__tcp_client.write_register(13051, power_value, data_type=ModbusDataType.UINT_16, device_id=unit)
 
     def power_limit_controllable(self) -> bool:
         return True

--- a/packages/modules/devices/sungrow/sungrow_sh/counter.py
+++ b/packages/modules/devices/sungrow/sungrow_sh/counter.py
@@ -38,29 +38,29 @@ class SungrowSHCounter(AbstractCounter):
     def update(self):
         unit = self.device_config.configuration.modbus_id
         power = self.__tcp_client.read_input_registers(13009, ModbusDataType.INT_32,
-                                                       wordorder=Endian.Little, unit=unit) * -1
+                                                       wordorder=Endian.Little, device_id=unit) * -1
         try:
             powers = self.__tcp_client.read_input_registers(5602, [ModbusDataType.INT_32] * 3,
-                                                            wordorder=Endian.Little, unit=unit)
+                                                            wordorder=Endian.Little, device_id=unit)
         except Exception:
             powers = None
             self.fault_state.no_error(self.fault_text)
 
-        frequency = self.__tcp_client.read_input_registers(5035, ModbusDataType.UINT_16, unit=unit) / 10
+        frequency = self.__tcp_client.read_input_registers(5035, ModbusDataType.UINT_16, device_id=unit) / 10
         if self.device_config.configuration.version == Version.SH_winet_dongle:
             # On WiNet-S, the frequency accuracy is higher by one place
             frequency /= 10
 
-        power_factor = self.__tcp_client.read_input_registers(5034, ModbusDataType.INT_16, unit=unit) / 1000
+        power_factor = self.__tcp_client.read_input_registers(5034, ModbusDataType.INT_16, device_id=unit) / 1000
 
         if self.device_config.configuration.version == Version.SH:
             # SH (LAN) provides accurate values from meter
             voltages = self.__tcp_client.read_input_registers(5740, [ModbusDataType.UINT_16] * 3,
-                                                              wordorder=Endian.Little, unit=unit)
+                                                              wordorder=Endian.Little, device_id=unit)
         else:
             # These are actually output voltages of the inverter:
             voltages = self.__tcp_client.read_input_registers(5018, [ModbusDataType.UINT_16] * 3,
-                                                              wordorder=Endian.Little, unit=unit)
+                                                              wordorder=Endian.Little, device_id=unit)
 
         voltages = [value / 10 for value in voltages]
 

--- a/packages/modules/devices/sungrow/sungrow_sh/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow_sh/inverter.py
@@ -35,11 +35,11 @@ class SungrowSHInverter(AbstractInverter):
         unit = self.device_config.configuration.modbus_id
 
         power = self.__tcp_client.read_input_registers(13033, ModbusDataType.INT_32,
-                                                       wordorder=Endian.Little, unit=unit) * -1
+                                                       wordorder=Endian.Little, device_id=unit) * -1
         dc_power = self.__tcp_client.read_input_registers(5016, ModbusDataType.UINT_32,
-                                                          wordorder=Endian.Little, unit=unit) * -1
+                                                          wordorder=Endian.Little, device_id=unit) * -1
 
-        currents = self.__tcp_client.read_input_registers(13030, [ModbusDataType.INT_16]*3, unit=unit)
+        currents = self.__tcp_client.read_input_registers(13030, [ModbusDataType.INT_16]*3, device_id=unit)
 
         currents = [value * -0.1 for value in currents]
 

--- a/packages/modules/devices/thermia/thermia/counter.py
+++ b/packages/modules/devices/thermia/thermia/counter.py
@@ -8,7 +8,7 @@ from modules.common.modbus import ModbusDataType, ModbusTcpClient_
 from modules.common.simcount import SimCounter
 from modules.common.store import get_counter_value_store
 from modules.devices.thermia.thermia.config import ThermiaCounterSetup
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 from modules.common.utils.peak_filter import PeakFilter
 from modules.common.component_type import ComponentType
 
@@ -36,15 +36,15 @@ class ThermiaCounter(AbstractCounter):
     def update(self):
         with self.client:
             voltages = [val / 100 for val in self.client.read_input_registers(
-                72, [ModbusDataType.INT_16] * 3, unit=self.modbus_id)]
+                72, [ModbusDataType.INT_16] * 3, device_id=self.modbus_id)]
             powers = [val / 1 for val in self.client.read_input_registers(
-                78, [ModbusDataType.INT_16] * 3, unit=self.modbus_id)]
+                78, [ModbusDataType.INT_16] * 3, device_id=self.modbus_id)]
             power = sum(powers)
             currents = [(val / 100) for val in self.client.read_input_registers(
-                69, [ModbusDataType.INT_16] * 3, unit=self.modbus_id)]
+                69, [ModbusDataType.INT_16] * 3, device_id=self.modbus_id)]
             imported = self.client.read_input_registers(
                 83, ModbusDataType.INT_32, wordorder=Endian.Little,
-                unit=self.modbus_id) * 100
+                device_id=self.modbus_id) * 100
             exported = 0
 
         imported, _ = self.peak_filter.check_values(power, imported, None)

--- a/packages/modules/devices/upower/upower/bat.py
+++ b/packages/modules/devices/upower/upower/bat.py
@@ -33,19 +33,19 @@ class UPowerBat(AbstractBat):
 
     def update(self) -> None:
         if self.version == UPowerVersion.GEN_1:
-            power = self.client.read_input_registers(30258, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
-            soc = self.client.read_input_registers(33000, ModbusDataType.UINT_16, unit=self.__modbus_id)
+            power = self.client.read_input_registers(30258, ModbusDataType.INT_32, device_id=self.__modbus_id) * -1
+            soc = self.client.read_input_registers(33000, ModbusDataType.UINT_16, device_id=self.__modbus_id)
             imported = self.client.read_input_registers(
-                31108, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                31108, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
             exported = self.client.read_input_registers(
-                31110, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                31110, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
             imported, exported = self.peak_filter.check_values(power, imported, exported)
         else:
             # 1221 Total Bat Power
             # 1427 Battery 1 current power
             # Bat 1 (additional batteries offset by 50)
-            power = self.client.read_input_registers(1427, ModbusDataType.INT_16, unit=self.__modbus_id)
-            soc = self.client.read_input_registers(1402, ModbusDataType.UINT_16, unit=self.__modbus_id) / 10
+            power = self.client.read_input_registers(1427, ModbusDataType.INT_16, device_id=self.__modbus_id)
+            soc = self.client.read_input_registers(1402, ModbusDataType.UINT_16, device_id=self.__modbus_id) / 10
             self.peak_filter.check_values(power)
             imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/upower/upower/counter.py
+++ b/packages/modules/devices/upower/upower/counter.py
@@ -33,21 +33,21 @@ class UPowerCounter(AbstractCounter):
 
     def update(self):
         if self.version == UPowerVersion.GEN_1:
-            power = self.client.read_holding_registers(1000, ModbusDataType.INT_32, unit=self.__modbus_id) * -1
-            frequency = self.client.read_holding_registers(11015, ModbusDataType.UINT_16, unit=self.__modbus_id)
+            power = self.client.read_holding_registers(1000, ModbusDataType.INT_32, device_id=self.__modbus_id) * -1
+            frequency = self.client.read_holding_registers(11015, ModbusDataType.UINT_16, device_id=self.__modbus_id)
 
             powers = [-value for value in self.client.read_holding_registers(
-                10994, [ModbusDataType.INT_32] * 3, unit=self.__modbus_id)]
-            exported = self.client.read_holding_registers(31102, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
-            imported = self.client.read_holding_registers(31104, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+                10994, [ModbusDataType.INT_32] * 3, device_id=self.__modbus_id)]
+            exported = self.client.read_holding_registers(31102, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
+            imported = self.client.read_holding_registers(31104, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
             imported, exported = self.peak_filter.check_values(power, imported, exported)
         else:
-            power = self.client.read_holding_registers(1219, ModbusDataType.INT_16, unit=self.__modbus_id) * -10
+            power = self.client.read_holding_registers(1219, ModbusDataType.INT_16, device_id=self.__modbus_id) * -10
             frequency = self.client.read_holding_registers(
-                1759, ModbusDataType.UINT_16, unit=self.__modbus_id) / 100
+                1759, ModbusDataType.UINT_16, device_id=self.__modbus_id) / 100
 
             powers = [-10 * value for value in self.client.read_holding_registers(
-                1750, [ModbusDataType.INT_16] * 3, unit=self.__modbus_id
+                1750, [ModbusDataType.INT_16] * 3, device_id=self.__modbus_id
             )]
             self.peak_filter.check_values(power)
             imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/upower/upower/inverter.py
+++ b/packages/modules/devices/upower/upower/inverter.py
@@ -30,11 +30,11 @@ class UPowerInverter(AbstractInverter):
 
     def update(self) -> None:
         if self.version == UPowerVersion.GEN_1:
-            power = self.client.read_holding_registers(11028, ModbusDataType.UINT_32, unit=self.__modbus_id) * -1
-            exported = self.client.read_holding_registers(11020, ModbusDataType.UINT_32, unit=self.__modbus_id) * 100
+            power = self.client.read_holding_registers(11028, ModbusDataType.UINT_32, device_id=self.__modbus_id) * -1
+            exported = self.client.read_holding_registers(11020, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 100
         else:
-            power = self.client.read_holding_registers(1220, ModbusDataType.UINT_16, unit=self.__modbus_id) * -1
-            exported = self.client.read_holding_registers(1006, ModbusDataType.UINT_32, unit=self.__modbus_id) * 10
+            power = self.client.read_holding_registers(1220, ModbusDataType.UINT_16, device_id=self.__modbus_id) * -1
+            exported = self.client.read_holding_registers(1006, ModbusDataType.UINT_32, device_id=self.__modbus_id) * 10
 
         _, exported = self.peak_filter.check_values(power, None, exported)
         inverter_state = InverterState(

--- a/packages/modules/devices/varta/varta/bat_modbus.py
+++ b/packages/modules/devices/varta/varta/bat_modbus.py
@@ -37,8 +37,8 @@ class VartaBatModbus(AbstractBat):
         self.set_state(self.get_state())
 
     def get_state(self) -> BatState:
-        soc = self.client.read_holding_registers(1068, ModbusDataType.INT_16, unit=self.__modbus_id)
-        power = self.client.read_holding_registers(1066, ModbusDataType.INT_16, unit=self.__modbus_id)
+        soc = self.client.read_holding_registers(1068, ModbusDataType.INT_16, device_id=self.__modbus_id)
+        power = self.client.read_holding_registers(1066, ModbusDataType.INT_16, device_id=self.__modbus_id)
         self.peak_filter.check_values(power)
         return BatState(
             power=power,

--- a/packages/modules/devices/varta/varta/counter.py
+++ b/packages/modules/devices/varta/varta/counter.py
@@ -34,7 +34,7 @@ class VartaCounter(AbstractCounter):
         self.peak_filter = PeakFilter(ComponentType.COUNTER, self.component_config.id, self.fault_state)
 
     def update(self):
-        power = self.client.read_holding_registers(1078, ModbusDataType.INT_16, unit=self.__modbus_id) * -1
+        power = self.client.read_holding_registers(1078, ModbusDataType.INT_16, device_id=self.__modbus_id) * -1
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/varta/varta/inverter.py
+++ b/packages/modules/devices/varta/varta/inverter.py
@@ -33,7 +33,7 @@ class VartaInverter:
         self.peak_filter = PeakFilter(ComponentType.INVERTER, self.component_config.id, self.fault_state)
 
     def update(self):
-        power = self.client.read_holding_registers(1102, ModbusDataType.UINT_16, unit=self.__modbus_id) * -1
+        power = self.client.read_holding_registers(1102, ModbusDataType.UINT_16, device_id=self.__modbus_id) * -1
         self.peak_filter.check_values(power)
         _, exported = self.sim_counter.sim_count(power)
 

--- a/packages/modules/devices/victron/victron/bat.py
+++ b/packages/modules/devices/victron/victron/bat.py
@@ -41,8 +41,8 @@ class VictronBat(AbstractBat):
     def update(self) -> None:
         modbus_id = self.component_config.configuration.modbus_id
         with self.__tcp_client:
-            power = self.__tcp_client.read_holding_registers(842, ModbusDataType.INT_16, unit=modbus_id)
-            soc = self.__tcp_client.read_holding_registers(843, ModbusDataType.UINT_16, unit=modbus_id)
+            power = self.__tcp_client.read_holding_registers(842, ModbusDataType.INT_16, device_id=modbus_id)
+            soc = self.__tcp_client.read_holding_registers(843, ModbusDataType.UINT_16, device_id=modbus_id)
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)
         bat_state = BatState(
@@ -57,7 +57,7 @@ class VictronBat(AbstractBat):
     def set_power_limit(self, power_limit: Optional[int]) -> None:
         modbus_id = self.component_config.configuration.modbus_id
         # Wenn Victron Dynamic ESS aktiv, erfolgt keine weitere Regelung in openWB
-        dynamic_ess_mode = self.__tcp_client.read_holding_registers(5400, ModbusDataType.UINT_16, unit=modbus_id)
+        dynamic_ess_mode = self.__tcp_client.read_holding_registers(5400, ModbusDataType.UINT_16, device_id=modbus_id)
         if dynamic_ess_mode == 1:
             log.debug("Dynamic ESS Mode ist aktiv, daher erfolgt keine Regelung des Speichers durch openWB")
             return
@@ -66,18 +66,18 @@ class VictronBat(AbstractBat):
             log.debug("Keine Batteriesteuerung, Selbstregelung durch Wechselrichter")
             if self.last_mode is not None:
                 # ESS Mode 2 und Leistung EVU auf 0kW setzen für Selbstregelung
-                self.__tcp_client.write_register(2902, 2, data_type=ModbusDataType.UINT_16, unit=modbus_id)
-                self.__tcp_client.write_register(2702, 100, data_type=ModbusDataType.UINT_16, unit=modbus_id)
-                self.__tcp_client.write_register(2716, 0, data_type=ModbusDataType.INT_32, unit=modbus_id)
+                self.__tcp_client.write_register(2902, 2, data_type=ModbusDataType.UINT_16, device_id=modbus_id)
+                self.__tcp_client.write_register(2702, 100, data_type=ModbusDataType.UINT_16, device_id=modbus_id)
+                self.__tcp_client.write_register(2716, 0, data_type=ModbusDataType.INT_32, device_id=modbus_id)
                 self.last_mode = None
         elif power_limit == 0:
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht entladen")
             if self.last_mode != 'stop':
                 # ESS Mode 2 und Discharge Power 0% für externe Steuerung und keine Entladung
                 # Leistung an EVU-Punkt auf 0kW setzen -> Eigenregelung bei laden und Entladen verhindern
-                self.__tcp_client.write_register(2902, 2, data_type=ModbusDataType.UINT_16, unit=modbus_id)
-                self.__tcp_client.write_register(2702, 0, data_type=ModbusDataType.UINT_16, unit=modbus_id)
-                self.__tcp_client.write_register(2716, 0, data_type=ModbusDataType.INT_32, unit=modbus_id)
+                self.__tcp_client.write_register(2902, 2, data_type=ModbusDataType.UINT_16, device_id=modbus_id)
+                self.__tcp_client.write_register(2702, 0, data_type=ModbusDataType.UINT_16, device_id=modbus_id)
+                self.__tcp_client.write_register(2716, 0, data_type=ModbusDataType.INT_32, device_id=modbus_id)
                 self.last_mode = 'stop'
         elif power_limit < 0:
             evu_power = data.data.counter_all_data.get_evu_counter().data.get.power
@@ -87,14 +87,14 @@ class VictronBat(AbstractBat):
                       f"Aktuelle Speicherleistung: {self.current_power} W, EVU-Leistung: {evu_power} W "
                       f"EVU-Leistung um {power_limit - self.current_power} W anpassen auf {set_power} W")
             if self.last_mode != 'discharge':
-                self.__tcp_client.write_register(2902, 2, data_type=ModbusDataType.UINT_16, unit=modbus_id)
-                self.__tcp_client.write_register(2702, 100, data_type=ModbusDataType.UINT_16, unit=modbus_id)
+                self.__tcp_client.write_register(2902, 2, data_type=ModbusDataType.UINT_16, device_id=modbus_id)
+                self.__tcp_client.write_register(2702, 100, data_type=ModbusDataType.UINT_16, device_id=modbus_id)
                 self.last_mode = 'discharge'
 
             # Setzen der angestrebten EVU-Leistung, Speicher versucht seine Leistung
             # anzupassen um den Zielwert zu erreichen
             self.__tcp_client.write_register(
-                2716, set_power, data_type=ModbusDataType.INT_32, unit=modbus_id)
+                2716, set_power, data_type=ModbusDataType.INT_32, device_id=modbus_id)
         elif power_limit > 0:
             evu_power = data.data.counter_all_data.get_evu_counter().data.get.power
             set_power = (power_limit - self.current_power) + evu_power
@@ -103,11 +103,11 @@ class VictronBat(AbstractBat):
                       f"Aktuelle Speicherleistung: {self.current_power} W, EVU-Leistung: {evu_power} W "
                       f"EVU-Leistung um {power_limit - self.current_power} W anpassen auf {set_power} W")
             if self.last_mode != 'charge':
-                self.__tcp_client.write_register(2902, 2, data_type=ModbusDataType.UINT_16, unit=modbus_id)
-                self.__tcp_client.write_register(2702, 100, data_type=ModbusDataType.UINT_16, unit=modbus_id)
+                self.__tcp_client.write_register(2902, 2, data_type=ModbusDataType.UINT_16, device_id=modbus_id)
+                self.__tcp_client.write_register(2702, 100, data_type=ModbusDataType.UINT_16, device_id=modbus_id)
                 self.last_mode = 'charge'
             self.__tcp_client.write_register(
-                2716, set_power, data_type=ModbusDataType.INT_32, unit=modbus_id)
+                2716, set_power, data_type=ModbusDataType.INT_32, device_id=modbus_id)
 
     def power_limit_controllable(self) -> bool:
         return True

--- a/packages/modules/devices/victron/victron/counter.py
+++ b/packages/modules/devices/victron/victron/counter.py
@@ -37,16 +37,16 @@ class VictronCounter(AbstractCounter):
         energy_meter = self.component_config.configuration.energy_meter
         with self.__tcp_client:
             if energy_meter:
-                powers = self.__tcp_client.read_holding_registers(2600, [ModbusDataType.INT_16]*3, unit=unit)
+                powers = self.__tcp_client.read_holding_registers(2600, [ModbusDataType.INT_16]*3, device_id=unit)
                 currents = [
-                    self.__tcp_client.read_holding_registers(reg, ModbusDataType.INT_16, unit=unit) / 10
+                    self.__tcp_client.read_holding_registers(reg, ModbusDataType.INT_16, device_id=unit) / 10
                     for reg in [2617, 2619, 2621]]
                 voltages = [
-                    self.__tcp_client.read_holding_registers(reg, ModbusDataType.UINT_16, unit=unit) / 10
+                    self.__tcp_client.read_holding_registers(reg, ModbusDataType.UINT_16, device_id=unit) / 10
                     for reg in [2616, 2618, 2620]]
                 power = sum(powers)
             else:
-                powers = self.__tcp_client.read_holding_registers(820, [ModbusDataType.INT_16]*3, unit=unit)
+                powers = self.__tcp_client.read_holding_registers(820, [ModbusDataType.INT_16]*3, device_id=unit)
                 power = sum(powers)
 
         self.peak_filter.check_values(power)

--- a/packages/modules/devices/victron/victron/inverter.py
+++ b/packages/modules/devices/victron/victron/inverter.py
@@ -40,7 +40,7 @@ class VictronInverter(AbstractInverter):
         with self.__tcp_client:
             if self.component_config.configuration.mppt:
                 try:
-                    power = self.__tcp_client.read_holding_registers(789, ModbusDataType.UINT_16, unit=modbus_id) / -10
+                    power = self.__tcp_client.read_holding_registers(789, ModbusDataType.UINT_16, device_id=modbus_id) / -10
                 except Exception as e:
                     if "GatewayPathUnavailable" in str(e):
                         power = 0
@@ -52,8 +52,8 @@ class VictronInverter(AbstractInverter):
                 # Adresse 808-810 ac output connected pv
                 # Adresse 811-813 ac input connected pv
                 # Adresse 850 mppt Leistung
-                power_temp1 = self.__tcp_client.read_holding_registers(808, [ModbusDataType.UINT_16]*6, unit=100)
-                power_temp2 = self.__tcp_client.read_holding_registers(850, ModbusDataType.UINT_16, unit=100)
+                power_temp1 = self.__tcp_client.read_holding_registers(808, [ModbusDataType.UINT_16]*6, device_id=100)
+                power_temp2 = self.__tcp_client.read_holding_registers(850, ModbusDataType.UINT_16, device_id=100)
                 power = (sum(power_temp1)+power_temp2) * -1
 
         self.peak_filter.check_values(power)

--- a/packages/modules/devices/victron/victron_3p75ct/counter.py
+++ b/packages/modules/devices/victron/victron_3p75ct/counter.py
@@ -33,22 +33,22 @@ class VictronCounter(AbstractCounter):
         unit = 1  # Modbus ID ist immer 1 da Standalone Produkt
         with self.__udp_client:
             powers = [
-                self.__udp_client.read_holding_registers(reg, ModbusDataType.INT_32, unit=unit) / 1
+                self.__udp_client.read_holding_registers(reg, ModbusDataType.INT_32, device_id=unit) / 1
                 for reg in [0x3082, 0x3086, 0x308A]]
             currents = [
-                self.__udp_client.read_holding_registers(reg, ModbusDataType.INT_16, unit=unit) / 100
+                self.__udp_client.read_holding_registers(reg, ModbusDataType.INT_16, device_id=unit) / 100
                 for reg in [0x3041, 0x3049, 0x3051]]
             voltages = [
-                self.__udp_client.read_holding_registers(reg, ModbusDataType.INT_16, unit=unit) / 100
+                self.__udp_client.read_holding_registers(reg, ModbusDataType.INT_16, device_id=unit) / 100
                 for reg in [0x3040, 0x3048, 0x3050]]
             power_factors = [
-                self.__udp_client.read_holding_registers(reg, ModbusDataType.INT_16, unit=unit) / 1000
+                self.__udp_client.read_holding_registers(reg, ModbusDataType.INT_16, device_id=unit) / 1000
                 for reg in [0x3047, 0x304F, 0x3057]]
 
             power = sum(powers)
-            frequency = self.__udp_client.read_holding_registers(0x3032, ModbusDataType.UINT_16, unit=unit) / 100
-            imported = self.__udp_client.read_holding_registers(0x3034, ModbusDataType.UINT_32, unit=unit) * 10
-            exported = self.__udp_client.read_holding_registers(0x3036, ModbusDataType.UINT_32, unit=unit) * 10
+            frequency = self.__udp_client.read_holding_registers(0x3032, ModbusDataType.UINT_16, device_id=unit) / 100
+            imported = self.__udp_client.read_holding_registers(0x3034, ModbusDataType.UINT_32, device_id=unit) * 10
+            exported = self.__udp_client.read_holding_registers(0x3036, ModbusDataType.UINT_32, device_id=unit) * 10
 
         imported, exported = self.peak_filter.check_values(power, imported, exported)
         counter_state = CounterState(

--- a/packages/modules/io_devices/dimm_kit/api.py
+++ b/packages/modules/io_devices/dimm_kit/api.py
@@ -44,13 +44,13 @@ def create_io(config: IoLan):
         # analog inputs are configured as 0-5V (AI1-AI4) and 0-25mA (AI5-AI8) as default
         # the values are reported as integers in range of 0-1024
         time.sleep(0.1)
-        analog_read = client.read_input_registers(0x00, [ModbusDataType.UINT_16]*8, unit=config.configuration.modbus_id)
+        analog_read = client.read_input_registers(0x00, [ModbusDataType.UINT_16]*8, device_id=config.configuration.modbus_id)
         analog_input = {getattr(AnalogInputMapping, f'AI{pin+1}').name: analog_read[pin] * 5 for pin in range(8)}
         time.sleep(0.1)
-        digital_input_read = client.read_coils(0x00, 8, unit=config.configuration.modbus_id)
+        digital_input_read = client.read_coils(0x00, 8, device_id=config.configuration.modbus_id)
         digital_input = {getattr(DigitalInputMapping, f'DI{pin+1}').name: digital_input_read[pin] for pin in range(8)}
         time.sleep(0.1)
-        digital_output_read = client.read_coils(0x10, 8, unit=config.configuration.modbus_id)
+        digital_output_read = client.read_coils(0x10, 8, device_id=config.configuration.modbus_id)
         digital_output = {
             getattr(DigitalOutputMapping, f'DO{pin+1}').name: digital_output_read[pin] for pin in range(8)}
         return IoState(
@@ -63,13 +63,13 @@ def create_io(config: IoLan):
         nonlocal client
         for i, value in digital_output.items():
             client.write_single_coil(DigitalOutputMapping[i].value, 1 if value is True else 0,
-                                     unit=config.configuration.modbus_id)
+                                     device_id=config.configuration.modbus_id)
 
     def initializer():
         nonlocal client
         client = ModbusTcpClient_(config.configuration.host, config.configuration.port)
         for output, value in config.output["digital"].items():
-            client.write_single_coil(DigitalOutputMapping[output].value, value, unit=config.configuration.modbus_id)
+            client.write_single_coil(DigitalOutputMapping[output].value, value, device_id=config.configuration.modbus_id)
     return ConfigurableIo(config=config, component_reader=read, component_writer=write, initializer=initializer)
 
 

--- a/packages/modules/smarthome/acthor/watt.py
+++ b/packages/modules/smarthome/acthor/watt.py
@@ -4,7 +4,7 @@ import os
 import struct
 import codecs
 import logging
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 from smarthome.smartret import writeret
 
 log = logging.getLogger("acthor")
@@ -72,10 +72,10 @@ powerc = 0
 client = ModbusTcpClient(ipadr, port=502)
 #
 start = 1000
-resp = client.read_holding_registers(start, 35, unit=1)
+resp = client.read_holding_registers(start, count=35, device_id=1)
 # Test only
 # start = 3524
-# resp = client.read_input_registers(start, 35, unit=1)
+# resp = client.read_input_registers(start, count=35, device_id=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
@@ -163,7 +163,7 @@ if count5 == 0:
                  (devicenumber, ipadr, atype, instpower, faktor))
     # modbus write
     if modbuswrite == 1:
-        rq = client.write_register(1000, neupower, unit=1)
+        rq = client.write_register(1000, neupower, device_id=1)
         if count1 < 3:
             log.info("watt devicenr %d ipadr %s device written by modbus " %
                      (devicenumber, ipadr))

--- a/packages/modules/smarthome/askoheat/watt.py
+++ b/packages/modules/smarthome/askoheat/watt.py
@@ -3,7 +3,7 @@ import sys
 import os
 import struct
 import codecs
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 from smarthome.smartlog import initlog
 from smarthome.smartret import writeret
@@ -32,7 +32,7 @@ client = ModbusTcpClient(ipadr, port=502)
 start = 110
 # test
 # start = 3522
-resp = client.read_input_registers(start, 1, unit=1)
+resp = client.read_input_registers(start, count=1, device_id=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
@@ -40,7 +40,7 @@ aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
 start = 638
 #  test
 # start = 3522
-resp = client.read_input_registers(start, 1, unit=1)
+resp = client.read_input_registers(start, count=1, device_id=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 temp0 = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
@@ -95,7 +95,7 @@ if count5 == 0:
                  (devicenumber, ipadr, neupower, pvmodus, modbuswrite))
     # modbus write
     if modbuswrite == 1:
-        rq = client.write_register(201, neupower, unit=1)
+        rq = client.write_register(201, neupower, device_id=1)
         if count1 < 3:
             log.info("watt devicenr %d ipadr %s device written by modbus " %
                      (devicenumber, ipadr))

--- a/packages/modules/smarthome/elwa/watt.py
+++ b/packages/modules/smarthome/elwa/watt.py
@@ -3,7 +3,7 @@ import sys
 import os
 import struct
 import codecs
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 from smarthome.smartret import writeret
 
@@ -31,9 +31,9 @@ if os.path.isfile(file_stringpv):
 client = ModbusTcpClient(ipadr, port=502)
 # Test only
 # # start = 3524
-# resp=client.read_input_registers(start,20,unit=1)
+# resp=client.read_input_registers(start, count=20, device_id=1)
 start = 1000
-resp = client.read_holding_registers(start, 20, unit=1)
+resp = client.read_holding_registers(start, count=20, device_id=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
@@ -127,7 +127,7 @@ if count5 == 0:
                  (devicenumber, ipadr, neupower, pvmodus, modbuswrite))
     # modbus write
     if modbuswrite == 1:
-        rq = client.write_register(1000, neupower, unit=1)
+        rq = client.write_register(1000, neupower, device_id=1)
         if count1 < 3:
             log.info("watt devicenr %d ipadr %s device written by modbus " %
                      (devicenumber, ipadr))

--- a/packages/modules/smarthome/idm/watt.py
+++ b/packages/modules/smarthome/idm/watt.py
@@ -3,9 +3,9 @@ import sys
 import os
 import struct
 import logging
-from pymodbus.constants import Endian
-from pymodbus.payload import BinaryPayloadBuilder
-from pymodbus.client.sync import ModbusTcpClient
+from modules.common.pymodbus_compat import Endian
+from modules.common.pymodbus_compat import BinaryPayloadBuilder
+from pymodbus.client import ModbusTcpClient
 from smarthome.smartlog import initlog
 from smarthome.smartret import writeret
 devicenumber = int(sys.argv[1])
@@ -47,10 +47,10 @@ client = ModbusTcpClient(ipadr, port=502)
 #  prod
 start = 4122
 if navvers == "2":
-    rr = client.read_input_registers(start, 2, unit=1)
+    rr = client.read_input_registers(start, count=2, device_id=1)
 else:
-    rr = client.read_holding_registers(start, 2, unit=1)
-raw = struct.pack('>HH', rr.getRegister(1), rr.getRegister(0))
+    rr = client.read_holding_registers(start, count=2, device_id=1)
+raw = struct.pack('>HH', rr.registers[1], rr.registers[0])
 lkw = float(struct.unpack('>f', raw)[0])
 aktpower = int(lkw*1000)
 modbuswrite = 0
@@ -124,11 +124,11 @@ if count5 == 0:
                  % (devicenumber, ipadr, neupower, pvmodus, modbuswrite))
     # modbus write
     if modbuswrite == 1:
-        client.write_registers(74, regnew, unit=1)
+        client.write_registers(74, regnew, device_id=1)
         if count1 < 3:
             log.info("devicenr %d ipadr %s device written by modbus " %
                      (devicenumber, ipadr))
-    client.write_registers(78, pvwnew, unit=1)
+    client.write_registers(78, pvwnew, device_id=1)
 else:
     if pvmodus == 99:
         pvmodus = 0

--- a/packages/modules/smarthome/lambda_/off.py
+++ b/packages/modules/smarthome/lambda_/off.py
@@ -5,7 +5,7 @@ import struct
 import codecs
 import logging
 from smarthome.smartlog import initlog
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
 devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
@@ -22,7 +22,7 @@ log.info(' off.py devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)'
          % (devicenumber, ipadr, uberschuss))
 client = ModbusTcpClient(ipadr, port=502)
 start = 103
-resp = client.read_holding_registers(start, 2, unit=1)
+resp = client.read_holding_registers(start, count=2, device_id=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])

--- a/packages/modules/smarthome/lambda_/on.py
+++ b/packages/modules/smarthome/lambda_/on.py
@@ -4,7 +4,7 @@ import struct
 import codecs
 import logging
 from smarthome.smartlog import initlog
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
 devicenumber = int(sys.argv[1])
 ipadr = str(sys.argv[2])
@@ -23,7 +23,7 @@ log.info(' on.py devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)'
          % (devicenumber, ipadr, uberschuss))
 client = ModbusTcpClient(ipadr, port=502)
 start = 103
-resp = client.read_holding_registers(start, 2, unit=1)
+resp = client.read_holding_registers(start, count=2, device_id=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])

--- a/packages/modules/smarthome/lambda_/watt.py
+++ b/packages/modules/smarthome/lambda_/watt.py
@@ -5,9 +5,9 @@ import time
 import struct
 import codecs
 import logging
-from pymodbus.payload import Endian
-from pymodbus.payload import BinaryPayloadBuilder
-from pymodbus.client.sync import ModbusTcpClient
+from modules.common.pymodbus_compat import Endian
+from modules.common.pymodbus_compat import BinaryPayloadBuilder
+from pymodbus.client import ModbusTcpClient
 from smarthome.smartlog import initlog
 from smarthome.smartret import writeret
 named_tuple = time.localtime()  # getstruct_time
@@ -53,7 +53,7 @@ if os.path.isfile(file_stringpv):
 # aktuelle Leistung lesen
 with ModbusTcpClient(ipadr, port=502) as client:
     start = 103
-    resp = client.read_holding_registers(start, 2, unit=1)
+    resp = client.read_holding_registers(start, count=2, device_id=1)
     #
     value1 = resp.registers[0]
     all = format(value1, '04x')
@@ -104,7 +104,7 @@ with ModbusTcpClient(ipadr, port=502) as client:
             builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
             builder.add_16bit_int(neupower)
             pay = builder.to_registers()
-            client.write_registers(102, [pay[0]], unit=1)
+            client.write_registers(102, [pay[0]], device_id=1)
             if count1 < 3:
                 log.info(' %d ipadr %s written %6d %#4X' %
                          (devicenumber, ipadr, pay[0], pay[0]))

--- a/packages/modules/smarthome/nibe/watt.py
+++ b/packages/modules/smarthome/nibe/watt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import sys
 import json
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 
 # get variables from arguments
 devicenumber = str(sys.argv[1])  # SmartHome device number
@@ -18,10 +18,10 @@ SERVER_PORT = "502"  # TCP port to connect to, should be moved into argument as 
 CurrentPowerRegisterAddress = 2166  # register for current power reading
 
 # need to specify framer to enable RTUoverTCP
-client = ModbusTcpClient(SERVER_HOST, SERVER_PORT)
+client = ModbusTcpClient(SERVER_HOST, port=SERVER_PORT)
 
 # Aktueller Verbrauch
-resp = client.read_input_registers(CurrentPowerRegisterAddress, 1, unit=1)
+resp = client.read_input_registers(CurrentPowerRegisterAddress, count=1, device_id=1)
 
 if resp and hasattr(resp, "registers"):
     CurrentPower = resp.registers[0]  # Get the first register value

--- a/packages/modules/smarthome/nxdacxx/off.py
+++ b/packages/modules/smarthome/nxdacxx/off.py
@@ -2,7 +2,7 @@
 import sys
 import os
 import logging
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 
 log = logging.getLogger("DAC")
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
@@ -19,7 +19,7 @@ log.info('off devicenr %d ipadr %s dactyp %d' % (devicenumber, ipadr, dactyp))
 if dactyp == 2:
     client = ModbusTcpClient(ipadr, port=port)
     # DO1 ausschalten um SGready zu sperren
-    rq = client.write_coil(0, False, unit=1)
+    rq = client.write_coil(0, False, device_id=1)
 pvmodus = 0
 if os.path.isfile(file_stringpv):
     with open(file_stringpv, 'r') as f:

--- a/packages/modules/smarthome/nxdacxx/on.py
+++ b/packages/modules/smarthome/nxdacxx/on.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import sys
 import logging
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 
 log = logging.getLogger("DAC")
 bp = '/var/www/html/openWB/ramdisk/smarthome_device_'
@@ -18,7 +18,7 @@ log.info('on devicenr %d ipadr %s dactyp %d' % (devicenumber, ipadr, dactyp))
 if dactyp == 2:
     client = ModbusTcpClient(ipadr, port=port)
     # DO1 einschalten um SGready zu aktivieren
-    rq = client.write_coil(0, True, unit=1)
+    rq = client.write_coil(0, True, device_id=1)
 pvmodus = 1
 with open(file_stringpv, 'w') as f:
     f.write(str(pvmodus))

--- a/packages/modules/smarthome/nxdacxx/watt.py
+++ b/packages/modules/smarthome/nxdacxx/watt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import sys
 import os
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 from smarthome.smartret import writeret
 
@@ -86,23 +86,23 @@ if count5 == 0:
         if dactyp == 0:
             # 10 Volts are 1000
             ausgabe = int((neupower * 1000) / maxpower)
-            rq = client.write_register(1, ausgabe, unit=1)
+            rq = client.write_register(1, ausgabe, device_id=1)
         elif dactyp == 1:
             # 10 Volts are 4000
             ausgabe = int((neupower * 4000) / maxpower)
-            rq = client.write_register(0x01f4, ausgabe, unit=1)
+            rq = client.write_register(0x01f4, ausgabe, device_id=1)
         elif dactyp == 2:
             ausgabe = int((neupower * 4095) / maxpower)
             if ausgabe < 370:
                 ausgabe = 370
             #  ausgabe nicht kleiner 0,9V sonst Leistungsregelung der WP aus
-            rq = client.write_register(0, ausgabe, unit=1)
+            rq = client.write_register(0, ausgabe, device_id=1)
         elif dactyp == 3:
             ausgabe = int(((neupower * (4095-820)) / maxpower)+820)
             if ausgabe <= 820:
                 ausgabe = 0
             #  ausgabe nicht kleiner 4ma sonst Leistungsregelung der WP aus
-            rq = client.write_register(0x01f4, ausgabe, unit=1)
+            rq = client.write_register(0x01f4, ausgabe, device_id=1)
         else:
             pass
         if count1 < 3:

--- a/packages/modules/smarthome/ratiotherm/watt.py
+++ b/packages/modules/smarthome/ratiotherm/watt.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 import sys
 import os
-from pymodbus.payload import BinaryPayloadBuilder, Endian
-from pymodbus.client.sync import ModbusTcpClient
+from modules.common.pymodbus_compat import BinaryPayloadBuilder, Endian
+from pymodbus.client import ModbusTcpClient
 import logging
 from smarthome.smartret import writeret
 
@@ -82,7 +82,7 @@ if count5 == 0:
         builder.add_16bit_int(neupower)
         pay = builder.to_registers()
         client = ModbusTcpClient(ipadr, port=502)
-        client.write_register(100, pay[0], unit=1)
+        client.write_register(100, pay[0], device_id=1)
         if count1 < 3:
             log.info(" watt devicenr %d ipadr %s written %6d %#4X"
                      % (devicenumber, ipadr, pay[0], pay[0]))

--- a/packages/modules/smarthome/stiebel/off.py
+++ b/packages/modules/smarthome/stiebel/off.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 import sys
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 
 log = logging.getLogger("stiebel")
@@ -12,7 +12,7 @@ file_stringpv = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenum
 log.info('off devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)' % (devicenumber, ipadr, uberschuss))
 client = ModbusTcpClient(ipadr, port=502)
 # deactivate switch one (manual 4002)
-rq = client.write_register(4001, 0, unit=1)
+rq = client.write_register(4001, 0, device_id=1)
 log.info('off devicenr %d ipadr %s ' % (devicenumber, ipadr))
 pvmodus = 0
 with open(file_stringpv, 'w') as f:

--- a/packages/modules/smarthome/stiebel/on.py
+++ b/packages/modules/smarthome/stiebel/on.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 import sys
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 
 log = logging.getLogger("stiebel")
@@ -12,7 +12,7 @@ file_stringpv = '/var/www/html/openWB/ramdisk/smarthome_device_' + str(devicenum
 log.info('on devicenr %d ipadr %s ueberschuss %6d try to connect (modbus)' % (devicenumber, ipadr, uberschuss))
 client = ModbusTcpClient(ipadr, port=502)
 # activate switch one (manual 4002)
-rq = client.write_register(4001, 1, unit=1)
+rq = client.write_register(4001, 1, device_id=1)
 log.info('on devicenr %d ipadr %s ' % (devicenumber, ipadr))
 with open(file_stringpv, 'w') as f:
     f.write(str(1))

--- a/packages/modules/smarthome/vampair/off.py
+++ b/packages/modules/smarthome/vampair/off.py
@@ -4,7 +4,7 @@ import os
 import time
 import struct
 import codecs
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 
 log = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ with open(file_string, 'a') as f:
               % (time_string, devicenumber, ipadr, uberschuss), file=f)
 client = ModbusTcpClient(ipadr, port=502)
 start = 2322
-resp = client.read_input_registers(start, 2, unit=1)
+resp = client.read_input_registers(start, count=2, device_id=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])

--- a/packages/modules/smarthome/vampair/on.py
+++ b/packages/modules/smarthome/vampair/on.py
@@ -4,7 +4,7 @@ import os
 import time
 import struct
 import codecs
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 
 log = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ with open(file_string, 'a') as f:
               % (time_string, devicenumber, ipadr, uberschuss), file=f)
 client = ModbusTcpClient(ipadr, port=502)
 start = 2322
-resp = client.read_input_registers(start, 2, unit=1)
+resp = client.read_input_registers(start, count=2, device_id=1)
 value1 = resp.registers[0]
 all = format(value1, '04x')
 aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])

--- a/packages/modules/smarthome/vampair/watt.py
+++ b/packages/modules/smarthome/vampair/watt.py
@@ -5,7 +5,7 @@ import time
 import json
 import struct
 import codecs
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 
 log = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ if count5 == 0:
     # aktuelle Leistung lesen
     client = ModbusTcpClient(ipadr, port=502)
     start = 2322
-    resp = client.read_input_registers(start, 2, unit=1)
+    resp = client.read_input_registers(start, count=2, device_id=1)
     value1 = resp.registers[0]
     all = format(value1, '04x')
     aktpower = int(struct.unpack('>h', codecs.decode(all, 'hex'))[0])
@@ -91,7 +91,7 @@ if count5 == 0:
                          modbuswrite), file=f)
     # modbus write
     if modbuswrite == 1:
-        client.write_registers(33409, [neupower], unit=1)
+        client.write_registers(33409, [neupower], device_id=1)
         if count1 < 3:
             with open(file_string, 'a') as f:
                 log.debug('%s devicenr %s ipadr %s device written by modbus ' %

--- a/packages/modules/smarthome/viessmann/off.py
+++ b/packages/modules/smarthome/viessmann/off.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 import sys
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 
 log = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ uberschuss = int(sys.argv[3])
 log.debug(f"[Viessmann {devicenumber}] devicenr {devicenumber} ipadr {ipadr} "
           f"ueberschuss {uberschuss:6d} try to connect (modbus)")
 client = ModbusTcpClient(ipadr, port=502)
-rq = client.write_coil(16, False, unit=1)
+rq = client.write_coil(16, False, device_id=1)
 log.debug(f"[Viessmann {devicenumber}] Modbus write_coil response: {rq}")
 client.close()
 log.debug(

--- a/packages/modules/smarthome/viessmann/on.py
+++ b/packages/modules/smarthome/viessmann/on.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 import sys
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.client import ModbusTcpClient
 import logging
 
 log = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ log.debug(
     f"[Viessmann {devicenumber}] devicenr {devicenumber} ipadr {ipadr} "
     f"ueberschuss {uberschuss:6d} try to connect (modbus)")
 client = ModbusTcpClient(ipadr, port=502)
-rq = client.write_coil(16, True, unit=1)
+rq = client.write_coil(16, True, device_id=1)
 log.debug(f"[Viessmann {devicenumber}] Modbus write_coil response: {rq}")
 client.close()
 log.debug(

--- a/packages/modules/smarthome/we514/watt.py
+++ b/packages/modules/smarthome/we514/watt.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 import sys
 import json
-from pymodbus.transaction import ModbusRtuFramer
-from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.framer import FramerType
+from pymodbus.client import ModbusTcpClient
 
 # get variables from arguments
 devicenumber = str(sys.argv[1])  # SmartHome device number
@@ -23,14 +23,14 @@ CurrentPowerRegisterAddress = 0x141  # register for current power reading
 
 
 # need to specify framer to enable RTUoverTCP
-client = ModbusTcpClient(SERVER_HOST, SERVER_PORT, framer=ModbusRtuFramer)
+client = ModbusTcpClient(SERVER_HOST, port=SERVER_PORT, framer=FramerType.RTU)
 
 # KWH Total Import
-resp = client.read_holding_registers(TotalEnergyRegisterAddress, 1, unit=MODBUS_DEVICEID)
+resp = client.read_holding_registers(TotalEnergyRegisterAddress, count=1, device_id=MODBUS_DEVICEID)
 TotalEnergy = int(resp.registers[0]) * 10  # Value is in 0.01kWh, need to convert to Wh
 
 # Aktueller Verbrauch
-resp = client.read_holding_registers(CurrentPowerRegisterAddress, 1, unit=MODBUS_DEVICEID)
+resp = client.read_holding_registers(CurrentPowerRegisterAddress, count=1, device_id=MODBUS_DEVICEID)
 CurrentPower = int(resp.registers[0])
 
 answer = {"power": CurrentPower, "powerc": TotalEnergy}

--- a/packages/tools/modbus_finder.py
+++ b/packages/tools/modbus_finder.py
@@ -3,7 +3,7 @@ import time
 from typing import Callable
 
 import pymodbus
-from pymodbus.constants import Endian
+from modules.common.pymodbus_compat import Endian
 
 import sys
 sys.path.append("/var/www/html/openWB/packages")
@@ -53,12 +53,12 @@ try:
 
     print("Address;INT_16;UINT_16;INT_32;UINT_32")
     for address in range(start, end):
-        resp_INT_16 = try_read(function, address=address, types=modbus.ModbusDataType.INT_16, unit=slave_id)
-        resp_UINT_16 = try_read(function, address=address, types=modbus.ModbusDataType.UINT_16, unit=slave_id)
+        resp_INT_16 = try_read(function, address=address, types=modbus.ModbusDataType.INT_16, device_id=slave_id)
+        resp_UINT_16 = try_read(function, address=address, types=modbus.ModbusDataType.UINT_16, device_id=slave_id)
         resp_INT_32 = try_read(function, address=address, types=modbus.ModbusDataType.INT_32, wordorder=Endian.Little,
-                               unit=slave_id)
+                               device_id=slave_id)
         resp_UINT_32 = try_read(function, address=address, types=modbus.ModbusDataType.UINT_32, wordorder=Endian.Little,
-                                unit=slave_id)
+                                device_id=slave_id)
         print(f"{address};{resp_INT_16};{resp_UINT_16};{resp_INT_32};{resp_UINT_32}")
 except Exception as e:
     print("Exception " + str(e))

--- a/packages/tools/modbus_tester.py
+++ b/packages/tools/modbus_tester.py
@@ -30,14 +30,14 @@ try:
     client = modbus.ModbusTcpClient_(host, port=port)
     if func == 4:
         if length > 1:
-            resp = client.read_input_registers(start, [modbus.ModbusDataType[data_type]]*length, unit=slave_id)
+            resp = client.read_input_registers(start, [modbus.ModbusDataType[data_type]]*length, device_id=slave_id)
         else:
-            resp = client.read_input_registers(start, modbus.ModbusDataType[data_type], unit=slave_id)
+            resp = client.read_input_registers(start, modbus.ModbusDataType[data_type], device_id=slave_id)
     elif func == 3:
         if length > 1:
-            resp = client.read_holding_registers(start, [modbus.ModbusDataType[data_type]]*length, unit=slave_id)
+            resp = client.read_holding_registers(start, [modbus.ModbusDataType[data_type]]*length, device_id=slave_id)
         else:
-            resp = client.read_holding_registers(start, modbus.ModbusDataType[data_type], unit=slave_id)
+            resp = client.read_holding_registers(start, modbus.ModbusDataType[data_type], device_id=slave_id)
     else:
         print("unsupported function code: " + str(func))
         exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 typing-extensions==4.13.2
 jq==1.1.3
 paho_mqtt==1.6.1
-pymodbus==2.5.2
+pymodbus>=3.13.0
 pytest==6.2.5
 requests_mock==1.9.3
 lxml==4.9.1

--- a/runs/evse_read_modbus.py
+++ b/runs/evse_read_modbus.py
@@ -15,4 +15,4 @@ register = int(sys.argv[2])
 num = int(sys.argv[3])
 
 client = ModbusSerialClient_(str(list(Path("/dev/serial/by-path").glob("*"))[0].resolve()))
-print(client.read_holding_registers(register, [ModbusDataType.INT_16]*num, unit=unit))
+print(client.read_holding_registers(register, [ModbusDataType.INT_16]*num, device_id=unit))

--- a/runs/evse_write_modbus.py
+++ b/runs/evse_write_modbus.py
@@ -15,4 +15,4 @@ register = int(sys.argv[2])
 value = int(sys.argv[3])
 
 client = ModbusSerialClient_(str(list(Path("/dev/serial/by-path").glob("*"))[0].resolve()))
-client.write_register(register, value, unit=unit)
+client.write_register(register, value, device_id=unit)

--- a/runs/evsewritembusdev.py
+++ b/runs/evsewritembusdev.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 import sys
-from pymodbus.client.sync import ModbusSerialClient
+from pymodbus.client import ModbusSerialClient
 
 seradd = str(sys.argv[1])
 evseid = int(sys.argv[2])
 wreg = int(sys.argv[3])
 val = int(sys.argv[4])
 
-client = ModbusSerialClient(method="rtu", port=seradd, baudrate=9600, stopbits=1, bytesize=8, timeout=1)
-rq = client.write_registers(wreg, val, unit=evseid)
+client = ModbusSerialClient(seradd, baudrate=9600, stopbits=1, bytesize=8, timeout=1)
+rq = client.write_registers(wreg, val, device_id=evseid)

--- a/runs/readmodbus.py
+++ b/runs/readmodbus.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 import sys
-from pymodbus.client.sync import ModbusSerialClient
+from pymodbus.client import ModbusSerialClient
 
 seradd = str(sys.argv[1])
 modbusid = int(sys.argv[2])
 readreg = int(sys.argv[3])
 reganzahl = int(sys.argv[4])
 
-client = ModbusSerialClient(method="rtu", port=seradd, baudrate=9600, stopbits=1, bytesize=8, timeout=1)
-request = client.read_holding_registers(readreg, reganzahl, unit=modbusid)
+client = ModbusSerialClient(seradd, baudrate=9600, stopbits=1, bytesize=8, timeout=1)
+request = client.read_holding_registers(readreg, count=reganzahl, device_id=modbusid)
 if request.isError():
     print('Modbus Error:', request)
 else:


### PR DESCRIPTION
## Summary

- Migrate from pymodbus 2.5.2 to pymodbus >=3.13.0 to support Python 3.12+ (pymodbus 2.x is incompatible with Python 3.12+)
- Add compatibility shim (`pymodbus_compat.py`) for removed classes: `Endian`, `BinaryPayloadBuilder`, `BinaryPayloadDecoder`
- Update all 163 affected files with new import paths and API changes

## Changes

### API Migration (pymodbus 3.x breaking changes)

| 2.x (before) | 3.x (after) |
|---|---|
| `from pymodbus.client.sync import ModbusTcpClient` | `from pymodbus.client import ModbusTcpClient` |
| `from pymodbus.transaction import ModbusSocketFramer` | `from pymodbus.framer import FramerType` |
| `from pymodbus.constants import Endian` | `from modules.common.pymodbus_compat import Endian` |
| `from pymodbus.payload import BinaryPayloadBuilder` | `from modules.common.pymodbus_compat import BinaryPayloadBuilder` |
| `unit=<id>` | `device_id=<id>` (keyword-only) |
| `ModbusSerialClient(method="rtu", port=X)` | `ModbusSerialClient(port, framer=FramerType.RTU)` |
| `ModbusTcpClient(host, port, framer)` | `ModbusTcpClient(host, port=port, framer=framer)` (keyword-only) |
| `read_holding_registers(addr, count, unit=x)` | `read_holding_registers(addr, count=count, device_id=x)` |
| `response.getRegister(i)` | `response.registers[i]` |

### New file

- `packages/modules/common/pymodbus_compat.py` - struct-based reimplementation of `Endian`, `BinaryPayloadBuilder`, and `BinaryPayloadDecoder` (removed from pymodbus 3.x)

### 163 files changed

- `requirements.txt`: `pymodbus==2.5.2` -> `pymodbus>=3.13.0`
- Core module: `packages/modules/common/modbus.py` - constructor fixes, keyword-only args
- All device modules (100+ files): `unit=` -> `device_id=`
- Smarthome modules (20+ files): direct client fixes, keyword-only args
- Runs scripts: Serial constructor fixes
- Test mocks: `conftest.py` updated for new module paths

## Testing

Tested on Debian Trixie 13.4 with Python 3.13.5:
- `openwb2.service` starts successfully with `pymodbus 3.13.0`
- All Python files compile without syntax errors
- Web interface accessible (HTTP 200)
- `atreboot.sh` pip-installs pymodbus 3.13.0 correctly (no rollback)

## Why

pymodbus 2.5.2 is incompatible with Python 3.12+. As distributions ship newer Python versions (e.g., Debian Trixie ships Python 3.13), openWB cannot run without this migration.