### PR TITLE
improve messages

### DIFF
--- a/packages/helpermodules/exceptions/registry.py
+++ b/packages/helpermodules/exceptions/registry.py
@@ -25,7 +25,7 @@ class ExceptionRegistry:
     def translate_exception(self, exception: Exception) -> Tuple[str, FaultStateLevel]:
         entry = self.find_registry_entry(exception)
         if entry is None:
-            return str(exception.args), FaultStateLevel.ERROR
+            return str(exception.args[0]), FaultStateLevel.ERROR
         if isinstance(entry.handler, str):
             return entry.handler, FaultStateLevel.ERROR
         result = entry.handler(exception)

--- a/packages/helpermodules/exceptions/registry.py
+++ b/packages/helpermodules/exceptions/registry.py
@@ -25,7 +25,7 @@ class ExceptionRegistry:
     def translate_exception(self, exception: Exception) -> Tuple[str, FaultStateLevel]:
         entry = self.find_registry_entry(exception)
         if entry is None:
-            return "{} {}".format(type(exception), exception.args), FaultStateLevel.ERROR
+            return str(exception.args), FaultStateLevel.ERROR
         if isinstance(entry.handler, str):
             return entry.handler, FaultStateLevel.ERROR
         result = entry.handler(exception)

--- a/packages/helpermodules/exceptions/registry_test.py
+++ b/packages/helpermodules/exceptions/registry_test.py
@@ -32,7 +32,7 @@ class ErrorF(ErrorD):
 
 
 @pytest.mark.parametrize("exception,expected_message", [
-    [ErrorRoot, "<class 'helpermodules.exceptions.registry_test.ErrorRoot'> ('ErrorRoot',)"],
+    [ErrorRoot, "ErrorRoot"],
     [ErrorB, "B"],
     [ErrorC, "A"],
     [ErrorD, "B"],

--- a/packages/helpermodules/utils/error_handling.py
+++ b/packages/helpermodules/utils/error_handling.py
@@ -33,13 +33,13 @@ class ErrorTimerContext:
                 # keine Werte mehr gepublished.
                 return False
             else:
-                log.error(exception)
+                log.exception(exception)
                 return True
         return True
 
     def error_counter_exceeded(self) -> bool:
         if self.error_timestamp is not None and timecheck.check_timestamp(self.error_timestamp, self.timeout) is False:
-            log.error(self.__exceeded_msg)
+            log.exception(self.__exceeded_msg)
             return True
         else:
             return False

--- a/packages/helpermodules/utils/error_handling.py
+++ b/packages/helpermodules/utils/error_handling.py
@@ -8,16 +8,7 @@ from helpermodules.pub import Pub
 
 log = logging.getLogger(__name__)
 
-CP_ERROR = ("Anhaltender Fehler beim Auslesen des Ladepunkts. Soll-Stromstärke, Lade- und Stecker-Status wird "
-            "zurückgesetzt.")
-
-INTERNAL_ERROR_HINT = ("Liebe Kunden, das Log ist zur Auswertung durch Support-Mitarbeiter der openWB GmbH gedacht. "
-                       "Meldungen, die hier erscheinen können wie Fehlermeldungen aussehen, sind aber oft ganz normal. "
-                       "Beispielsweise führen wir Abfragen der internen Hardware mehrere tausend mal pro Stunde aus "
-                       "(wir gehen bis ans Limit der seriellen Kommunikation um eine möglichst feine Auflösung zu "
-                       "erreichen), eine Abfrage-Fehlerquote von 1-2% ist dabei normal. Wirklich relevante "
-                       "Fehlermeldungen erscheinen in der grafischen Nutzeroberfläche an prominenter Stelle. Bitte "
-                       "belastet unseren Support nicht mit Fragen nach euch unbekannten Log-Meldungen.")
+CP_ERROR = "Soll-Stromstärke, Lade- und Stecker-Status wird zurückgesetzt."
 
 
 class ErrorTimerContext:
@@ -42,7 +33,7 @@ class ErrorTimerContext:
                 # keine Werte mehr gepublished.
                 return False
             else:
-                log.error(f"{exception}\n{INTERNAL_ERROR_HINT}")
+                log.error(exception)
                 return True
         return True
 

--- a/packages/modules/common/hardware_check.py
+++ b/packages/modules/common/hardware_check.py
@@ -15,19 +15,15 @@ EVSE_MIN_FIRMWARE = 7
 MAX_ATTEMPTS = 3
 RETRY_DELAY_SECONDS = 0.3
 
-OPEN_TICKET = (" Bitte nehme bei anhaltenden Problemen über die Support-Funktion in den Einstellungen Kontakt mit " +
-               "uns auf.")
-RS485_ADAPTER_BROKEN = ("Auslesen von Zähler UND Evse nicht möglich. Vermutlich ist {} defekt oder zwei "
-                        "Busteilnehmer haben die gleiche Modbus-ID. Bitte die Zähler-ID prüfen.")
-USB_ADAPTER_BROKEN = RS485_ADAPTER_BROKEN.format('der USB-Adapter')
-LAN_ADAPTER_BROKEN = (f"{RS485_ADAPTER_BROKEN.format('der LAN-Konverter abgestürzt,')} "
-                      "Bitte den openWB series2 satellit stromlos machen.")
-METER_PROBLEM = "Der Zähler konnte nicht ausgelesen werden. Vermutlich ist der Zähler falsch konfiguriert oder defekt."
-METER_BROKEN_VOLTAGES = "Die Spannungen des Zählers konnten nicht korrekt ausgelesen werden: {}V Der Zähler ist defekt."
+RS485_ADAPTER_BROKEN = "Erneutes Auslesen des {}"
+USB_ADAPTER_BROKEN = RS485_ADAPTER_BROKEN.format('USB-Adapters')
+LAN_ADAPTER_BROKEN = RS485_ADAPTER_BROKEN.format('LAN-Konverters')
+METER_PROBLEM = "Erneutes Auslesen des Zählers"
+METER_BROKEN_VOLTAGES = "Erneutes Auslesen der Spannungen am Zähler"
 METER_NO_SERIAL_NUMBER = ("Die Seriennummer des Zählers für das Ladelog kann nicht ausgelesen werden. Wenn Du die "
                           "Seriennummer für Abrechnungszwecke benötigst, wende Dich bitte an unseren Support. Die "
                           "Funktionalität wird dadurch nicht beeinträchtigt!")
-EVSE_BROKEN = "Auslesen der EVSE nicht möglich. Vermutlich ist die EVSE defekt oder hat eine unbekannte Modbus-ID. "
+EVSE_BROKEN = "Erneutes Auslesen der EVSE"
 
 
 def check_meter_values(counter_state: CounterState, fault_state: Optional[FaultState] = None) -> None:
@@ -110,18 +106,18 @@ class SeriesHardwareCheckMixin:
         if meter_check_passed is False:
             if evse_check_passed is False:
                 if isinstance(self.client, ModbusTcpClient_):
-                    raise Exception(LAN_ADAPTER_BROKEN + OPEN_TICKET)
+                    raise Exception(LAN_ADAPTER_BROKEN)
                 else:
-                    raise Exception(USB_ADAPTER_BROKEN + OPEN_TICKET)
+                    raise Exception(USB_ADAPTER_BROKEN)
             else:
-                raise Exception(meter_error_msg + OPEN_TICKET)
+                raise Exception(meter_error_msg)
         elif evse_check_passed and meter_check_passed and meter_error_msg is not None:
-            fault_state.warning(meter_error_msg + OPEN_TICKET)
+            fault_state.warning(meter_error_msg)
         if evse_check_passed is False:
             if meter_error_msg is not None:
-                raise Exception(EVSE_BROKEN + " " + meter_error_msg + OPEN_TICKET)
+                raise Exception(EVSE_BROKEN + " " + meter_error_msg)
             else:
-                raise Exception(EVSE_BROKEN + OPEN_TICKET)
+                raise Exception(EVSE_BROKEN)
         return evse_state, counter_state
 
     def check_meter(self: ClientHandlerProtocol) -> Tuple[bool, Optional[str], CounterState]:

--- a/packages/modules/common/hardware_check.py
+++ b/packages/modules/common/hardware_check.py
@@ -19,7 +19,7 @@ RS485_ADAPTER_BROKEN = "Erneutes Auslesen des {}"
 USB_ADAPTER_BROKEN = RS485_ADAPTER_BROKEN.format('USB-Adapters')
 LAN_ADAPTER_BROKEN = RS485_ADAPTER_BROKEN.format('LAN-Konverters')
 METER_PROBLEM = "Erneutes Auslesen des Zählers"
-METER_BROKEN_VOLTAGES = "Erneutes Auslesen der Spannungen am Zähler"
+METER_BROKEN_VOLTAGES = "Erneutes Auslesen der Spannungen am Zähler: {}V"
 METER_NO_SERIAL_NUMBER = ("Die Seriennummer des Zählers für das Ladelog kann nicht ausgelesen werden. Wenn Du die "
                           "Seriennummer für Abrechnungszwecke benötigst, wende Dich bitte an unseren Support. Die "
                           "Funktionalität wird dadurch nicht beeinträchtigt!")

--- a/packages/modules/common/hardware_check_test.py
+++ b/packages/modules/common/hardware_check_test.py
@@ -8,7 +8,7 @@ from modules.common import hardware_check
 from modules.common.component_state import CounterState, EvseState
 from modules.common.evse import Evse
 from modules.common.hardware_check import (
-    EVSE_BROKEN, LAN_ADAPTER_BROKEN, METER_BROKEN_VOLTAGES, METER_PROBLEM, OPEN_TICKET, USB_ADAPTER_BROKEN,
+    EVSE_BROKEN, LAN_ADAPTER_BROKEN, METER_BROKEN_VOLTAGES, METER_PROBLEM, USB_ADAPTER_BROKEN,
     SeriesHardwareCheckMixin, _check_meter_values)
 from modules.common.modbus import NO_CONNECTION, ModbusSerialClient_, ModbusTcpClient_
 from modules.conftest import SAMPLE_IP, SAMPLE_PORT
@@ -21,7 +21,7 @@ from modules.internal_chargepoint_handler.clients import ClientHandler
     [pytest.param(Exception("Modbus"), None, [230]*3, None, False, ModbusSerialClient_, EVSE_BROKEN,
                   id="EVSE defekt"),
      pytest.param(Exception("Modbus"), None, [230, 0, 230], None, False, ModbusSerialClient_,
-                  EVSE_BROKEN + " " + METER_BROKEN_VOLTAGES.format([230, 0, 230]) + OPEN_TICKET,
+                  EVSE_BROKEN + " " + METER_BROKEN_VOLTAGES.format([230, 0, 230]),
                   id="EVSE defekt und Zähler eine Phase defekt"),
      pytest.param(None, Exception("Modbus"), None, None, None,
                   ModbusSerialClient_, METER_PROBLEM, id="Zähler falsch konfiguriert"),


### PR DESCRIPTION
- [x] Fehler im Log ausgeben - im UI erst nach 60s
- [x] EVSE defekt
- [x] RS485 Adapter defekt
- [ ] LAN-Adapter defekt
- [x] Zähler defekt
- [x] Spannung am Zähler fehlt: Warnung, wird sofort ausgegeben