### PR TITLE
Fix Sungrow iHM Register type

### DIFF
--- a/packages/modules/devices/sungrow/sungrow_ihm/counter.py
+++ b/packages/modules/devices/sungrow/sungrow_ihm/counter.py
@@ -36,7 +36,7 @@ class SungrowIHMCounter(AbstractCounter):
         power = self.__tcp_client.read_input_registers(8156, ModbusDataType.INT_32,
                                                        wordorder=Endian.Little, unit=unit) * 10
 
-        powers = self.__tcp_client.read_input_registers(8558, [ModbusDataType.UINT_32] * 3,
+        powers = self.__tcp_client.read_input_registers(8558, [ModbusDataType.INT_32] * 3,
                                                         wordorder=Endian.Little, unit=unit)
 
         frequency = self.__tcp_client.read_input_registers(8557, ModbusDataType.UINT_16, unit=unit) / 10


### PR DESCRIPTION
https://forum.openwb.de/viewtopic.php?p=143237#p143237

Die Register für powers waren in der ersten Version der Modbus Beschreibung U32 und wurden nun in der neuen Version auf S32 geändert. U32 machen natürlich auch keinen Sinn bei einem Wert der sowohl positiv als negativ sein kann, hätte mir auffallen können.