### PR TITLE
Sungrow SDongle: adjust frequency

### DIFF
--- a/packages/modules/devices/sungrow/sungrow_sh/counter.py
+++ b/packages/modules/devices/sungrow/sungrow_sh/counter.py
@@ -47,8 +47,11 @@ class SungrowSHCounter(AbstractCounter):
             self.fault_state.no_error(self.fault_text)
 
         frequency = self.__tcp_client.read_input_registers(5035, ModbusDataType.UINT_16, unit=unit) / 10
-        if self.device_config.configuration.version == Version.SH_winet_dongle:
-            # On WiNet-S, the frequency accuracy is higher by one place
+        if self.device_config.configuration.version == Version.SH_winet_dongle and frequency > 400:
+            # On WiNet-S, the frequency accuracy is sometimes higher by one place
+            # For some SDongle Firmware Versions it is not. Frequency should roughly
+            # range between 40 and 60. Therefore, if the value is above 400, we assume
+            # it is actually 10 times higher than it should be and adjust it accordingly.  
             frequency /= 10
 
         power_factor = self.__tcp_client.read_input_registers(5034, ModbusDataType.INT_16, unit=unit) / 1000

--- a/packages/modules/devices/sungrow/sungrow_sh/counter.py
+++ b/packages/modules/devices/sungrow/sungrow_sh/counter.py
@@ -47,11 +47,11 @@ class SungrowSHCounter(AbstractCounter):
             self.fault_state.no_error(self.fault_text)
 
         frequency = self.__tcp_client.read_input_registers(5035, ModbusDataType.UINT_16, unit=unit) / 10
-        if self.device_config.configuration.version == Version.SH_winet_dongle and frequency > 400:
+        if self.device_config.configuration.version == Version.SH_winet_dongle and frequency >= 400:
             # On WiNet-S, the frequency accuracy is sometimes higher by one place
             # For some SDongle Firmware Versions it is not. Frequency should roughly
             # range between 40 and 60. Therefore, if the value is above 400, we assume
-            # it is actually 10 times higher than it should be and adjust it accordingly.  
+            # it is actually 10 times higher than it should be and adjust it accordingly.
             frequency /= 10
 
         power_factor = self.__tcp_client.read_input_registers(5034, ModbusDataType.INT_16, unit=unit) / 1000


### PR DESCRIPTION
Ticket #66002369
Ab und zu gibt es Tickets bei denen der SDongle die Frequenz um den Faktor 10 zu niedrig ausgibt. Betroffen ist hier der WiNet-S. Ob das Verhalten beim S2 ebenfalls auftritt ist nicht geklärt.
Ansatz ist den Frequenzwert nur durch den Faktor 10 zu teilen wenn es wirklich "nötig" ist.

Wenn man sehr großzügig annimmt, dass sich die Frequenz im Bereich 40-60Hz bewegen kann erfolgt die Anpassung durch Faktor bei Frequenzen über 400Hz (Wert 10 mal höher als er sein sollte)