### PR TITLE
Improve PeakFilter

### DIFF
--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -17,11 +17,9 @@ class InverterValueStoreRamdisk(ValueStore[InverterState]):
 
     def set(self, inverter_state: InverterState):
         self.__pv.power.write(int(inverter_state.power))
-        self.__pv.energy.write(inverter_state.exported)
-        self.__pv.energy_k.write(
-            inverter_state.exported if inverter_state.exported is None
-            else inverter_state.exported / 1000
-        )
+        if inverter_state.exported is not None:
+            self.__pv.energy.write(inverter_state.exported)
+            self.__pv.energy_k.write(inverter_state.exported / 1000)
         if inverter_state.currents:
             self.__pv.currents.write(inverter_state.currents)
 

--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -18,7 +18,10 @@ class InverterValueStoreRamdisk(ValueStore[InverterState]):
     def set(self, inverter_state: InverterState):
         self.__pv.power.write(int(inverter_state.power))
         self.__pv.energy.write(inverter_state.exported)
-        self.__pv.energy_k.write(inverter_state.exported / 1000)
+        self.__pv.energy_k.write(
+            inverter_state.exported if inverter_state.exported is None 
+            else inverter_state.exported / 1000
+        )
         if inverter_state.currents:
             self.__pv.currents.write(inverter_state.currents)
 

--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -20,6 +20,8 @@ class InverterValueStoreRamdisk(ValueStore[InverterState]):
         if inverter_state.exported is not None:
             self.__pv.energy.write(inverter_state.exported)
             self.__pv.energy_k.write(inverter_state.exported / 1000)
+        else:
+            log.debug("Kein gültiger Zählerstand. Wert wird nicht aktualisiert.")
         if inverter_state.currents:
             self.__pv.currents.write(inverter_state.currents)
 

--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -69,8 +69,11 @@ class PurgeInverterState:
                 for bat in hybrid:
                     bat_get = data.data.bat_data[bat].data.get
                     power -= bat_get.power
-
-                    exported += bat_get.imported - bat_get.exported - imported
+                    if (bat_get.imported is not None and bat_get.exported is not None and
+                       imported is not None and exported is not None):
+                        exported += bat_get.imported - bat_get.exported - imported
+                    else:
+                        exported = None
 
             if state.dc_power is not None:
                 # Manche Systeme werden auch aus dem Netz geladen, um einen Mindest-SoC zu halten.

--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -19,7 +19,7 @@ class InverterValueStoreRamdisk(ValueStore[InverterState]):
         self.__pv.power.write(int(inverter_state.power))
         self.__pv.energy.write(inverter_state.exported)
         self.__pv.energy_k.write(
-            inverter_state.exported if inverter_state.exported is None 
+            inverter_state.exported if inverter_state.exported is None
             else inverter_state.exported / 1000
         )
         if inverter_state.currents:

--- a/packages/modules/common/utils/peak_filter.py
+++ b/packages/modules/common/utils/peak_filter.py
@@ -82,9 +82,6 @@ class PeakFilter:
                 log.debug(f"PeakFilter: Unplausibler Zählerwert: {total_energy / 1000}kWh. "
                           f"Differenz zum vorherigen Wert: {total_energy - previous_total_energy}Wh. "
                           f"erlaubte Differenz: {round(allowed_deviation, 2)}Wh.")
-                self.fault_state.warning(f"Peakfilter: {total_energy / 1000}kWh. "
-                                         "Die Energie erscheint höher, als laut Anlagenkonfiguration plausibel "
-                                         "ist. Erneute Prüfung im nächsten Regelintervall.")
             else:
                 log.debug(f"PeakFilter: Zählerwert: {total_energy}Wh innerhalb der zulässigen Grenzen. "
                           f"Differenz zum vorherigen Wert: {total_energy - previous_total_energy}Wh.")


### PR DESCRIPTION
Einige Wechselrichter haben bei Zählerständen grobe Auflösung im Register was wiederholt trotz valider Werte Peaks auslöst (Werte bilden Treppchen).
Solche validen Peaks werden eine Regelschleife später übernommen - in der ersten Regelschleife werden sie auf None gesetzt.
Bei Hybridsystemen werden die Werte in _inverter.py nochmal nachbearbeitet. Hier führt None zu einer Exception was dann dazu führt, dass alle Werte (auch aktuelle Leistung) verworfen werden.
Erkennbar ist dass Problem an kleinen, zyklischen Einbrüchen im Graphen.
Meldung im Forum: https://forum.openwb.de/viewtopic.php?p=143030#p143030
https://github.com/openWB/core/pull/3333#issuecomment-4506069231 behandelt das Problem der häufigen Fehlermeldungen - wird hier aber auch berücksichtigt