### PR TITLE
solakon: fix registers

### DIFF
--- a/packages/modules/devices/solakon/solakon_one/bat.py
+++ b/packages/modules/devices/solakon/solakon_one/bat.py
@@ -32,9 +32,10 @@ class SolakonOneBat(AbstractBat):
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
 
-        # AC Leistung am Stecker, Batterie aus dem Netz aufladen hat positive Werte,
+        # Reg 39134 AC Leistung am Stecker, Batterie aus dem Netz aufladen hat positive Werte,
         # Leistung aus der Batterie und/oder aus PV ins Netz abgeben hat negative Werte
-        power = self.client.read_holding_registers(39134, ModbusDataType.INT_32, unit=unit) * -1
+        # Reg 39237 Battery Combined Power
+        power = self.client.read_holding_registers(39237, ModbusDataType.INT_32, unit=unit)
         # SoC Ladezustand der Batterie in %
         soc = self.client.read_holding_registers(39424, ModbusDataType.INT_16, unit=unit)
         # gesamte DC Ladung der Batterie in Wh

--- a/packages/modules/devices/solakon/solakon_one/inverter.py
+++ b/packages/modules/devices/solakon/solakon_one/inverter.py
@@ -29,14 +29,19 @@ class SolakonOneInverter(AbstractInverter):
 
     def update(self) -> None:
         unit = self.component_config.configuration.modbus_id
-        # Gesamte DC PV Leistung aller vier MPPT in W
-        power = self.client.read_holding_registers(39118, ModbusDataType.INT_32, unit=unit) * -1
-        # Gesamte DC PV Produktion in Wh
-        exported = self.client.read_holding_registers(39601, ModbusDataType.UINT_32, unit=unit) * 10
 
-        _, exported = self.peak_filter.check_values(power, None, exported)
+        # Reg 39134 AC Leistung am Stecker, Batterie aus dem Heimnetz aufladen hat positive Werte,
+        # Leistung aus der Batterie und/oder aus PV ins Heimnetz abgeben hat negative Werte
+        power = self.client.read_holding_registers(39134, ModbusDataType.INT_32, unit=unit) * -1
+
+        # Gesamte Energie am Wechselrichter in Wh
+        exported = self.client.read_holding_registers(39621, ModbusDataType.UINT_32, unit=unit) * 10
+        imported = self.client.read_holding_registers(39625, ModbusDataType.UINT_32, unit=unit) * 10
+
+        imported, exported = self.peak_filter.check_values(power, imported, exported)
         inverter_state = InverterState(
             power=power,
+            imported=imported,
             exported=exported
         )
         self.store.set(inverter_state)


### PR DESCRIPTION
Hybridwechselrichter mit PV - Erzeugung größer als maximaler Ausgangsleistung
Hybridkonfiguration in UI zwingend erforderlich

Speicher:
39134 - Active Power (AC Leistung am Stecker) ersetzt durch 
39237 - Battery Combined Power

PV:
39118 - PV DC Leistung ersetzt durch
39134 - AC Leistung am Stecker

39601 - PV DC Zählerstand (PV total power) ersetzt/ ergänzt durch
39625 - Enter total power 
39621 - Output total power