### PR TITLE
Improve PV-Kit

### DIFF
--- a/packages/modules/devices/openwb/openwb_flex/inverter.py
+++ b/packages/modules/devices/openwb/openwb_flex/inverter.py
@@ -47,16 +47,18 @@ class PvKitFlex(AbstractInverter):
         version = self.component_config.configuration.version
         if version == 1:
             power = sum(counter_state.powers)
-        if power > 10:
-            power = power*-1
+        power = power*-1
         if isinstance(self.__client, Lovato) or isinstance(self.__client, Sdm120):
             self.peak_filter.check_values(power)
-            _, exported = self.sim_counter.sim_count(power)
+            imported, exported = self.sim_counter.sim_count(power)
         else:
-            _, exported = self.peak_filter.check_values(power, None, counter_state.exported)
+            imported, exported = self.peak_filter.check_values(power,
+                                                               counter_state.imported,
+                                                               counter_state.exported)
 
         inverter_state = InverterState(
             power=power,
+            imported=imported,
             exported=exported,
             currents=counter_state.currents,
             serial_number=counter_state.serial_number


### PR DESCRIPTION
https://github.com/orgs/openWB/projects/4/views/9?pane=issue&itemId=195398239&issue=openWB%7Cinternal-projects%7C323

- Leistung >10W nicht mehr automatisch invertieren. Behebt Probleme bei einigen Wechselrichtern die Nachts Erzeugung statt Eigenverbrauch angezeigt haben..
Einbaurichtung des Kits wird damit noch wichtiger (Aktuell funktionieren beide Richtungen - bei falschem Einbau wird aber kein Exportwert erfasst)

- Import Wert hinzufügen