### PR TITLE
modbusserver: allow reset of RFID-Token

### DIFF
--- a/packages/helpermodules/modbusserver.py
+++ b/packages/helpermodules/modbusserver.py
@@ -147,6 +147,7 @@ try:
                 71: lambda value: Pub().pub(f"{cp_topic}set_current", value / 100),
                 80: lambda value: Pub().pub(f"{cp_topic}phases_to_use", value),
                 81: lambda value: Pub().pub(f"{cp_topic}trigger_phase_switch", value),
+                97: lambda value: Pub().pub("openWB/set/internal_chargepoint/last_tag", None) if value == 1 else log.warning(f"Ungültiger Wert für last_tag: {value}"),
                 98: lambda value: Pub().pub(f"{cp_topic}cp_interruption_duration", value),
                 99: lambda _: Pub().pub("openWB/set/command/modbus_server/todo",
                                         {"command": "systemUpdate", "data": {}})

--- a/packages/helpermodules/modbusserver.py
+++ b/packages/helpermodules/modbusserver.py
@@ -147,7 +147,8 @@ try:
                 71: lambda value: Pub().pub(f"{cp_topic}set_current", value / 100),
                 80: lambda value: Pub().pub(f"{cp_topic}phases_to_use", value),
                 81: lambda value: Pub().pub(f"{cp_topic}trigger_phase_switch", value),
-                97: lambda value: Pub().pub("openWB/set/internal_chargepoint/last_tag", None) if value == 1 else log.warning(f"Ungültiger Wert für last_tag: {value}"),
+                97: lambda value: Pub().pub("openWB/set/internal_chargepoint/last_tag", None) if value == 1 
+                    else log.warning(f"Ungültiger Wert für last_tag: {value}"),
                 98: lambda value: Pub().pub(f"{cp_topic}cp_interruption_duration", value),
                 99: lambda _: Pub().pub("openWB/set/command/modbus_server/todo",
                                         {"command": "systemUpdate", "data": {}})

--- a/packages/helpermodules/modbusserver.py
+++ b/packages/helpermodules/modbusserver.py
@@ -147,8 +147,8 @@ try:
                 71: lambda value: Pub().pub(f"{cp_topic}set_current", value / 100),
                 80: lambda value: Pub().pub(f"{cp_topic}phases_to_use", value),
                 81: lambda value: Pub().pub(f"{cp_topic}trigger_phase_switch", value),
-                97: lambda value: Pub().pub("openWB/set/internal_chargepoint/last_tag", None) if value == 1 
-                    else log.warning(f"Ungültiger Wert für last_tag: {value}"),
+                97: lambda value: Pub().pub("openWB/set/internal_chargepoint/last_tag", None) if value == 1
+                else log.warning(f"Ungültiger Wert für last_tag: {value}"),
                 98: lambda value: Pub().pub(f"{cp_topic}cp_interruption_duration", value),
                 99: lambda _: Pub().pub("openWB/set/command/modbus_server/todo",
                                         {"command": "systemUpdate", "data": {}})


### PR DESCRIPTION
fixes #3503 

Dokumentation unter https://wiki.openwb.de/doku.php?id=openwb:vc:2.2.0:api#mqtt-api_for_openwb_software2_im_secondary_mode muss dann entsprechend angepasst werden. Soweit ich das sehe, kann ich das nicht selbst ;)
in der Tabelle der Modbusregister muss hier zB folgendes eingefügt werden:

10197 | sint16 | Write | Reset RFID Token | 1 = reset RFID-Tag after successful handling | 1