### PR TITLE
Improve Peakfilter: filter energy exceeding 50 years

### DIFF
--- a/packages/modules/common/utils/peak_filter.py
+++ b/packages/modules/common/utils/peak_filter.py
@@ -53,6 +53,18 @@ class PeakFilter:
             exported: Optional[float] = None,
     ) -> tuple[Optional[float], Optional[float]]:
         if max_power > 0:
+            # filtere den Zählerstand wenn er größer ist als die maximal mögliche Energiemenge
+            # in 50 Jahren 
+            # max. Leistung × 24 h/Tag × 365 Tage/Jahr × 50 Jahre
+            max_energy = max_power * 24 * 365 * 50
+            if imported is not None and imported > max_energy:
+                log.debug(f"PeakFilter: Unplausibler importierter Zählerstand: {imported / 1000}kWh. "
+                          f"Maximal mögliche Energiemenge in 50 Jahren: {max_energy / 1000}kWh.")
+                imported = None
+            if exported is not None and exported > max_energy:
+                log.debug(f"PeakFilter: Unplausibler exportierter Zählerstand: {exported / 1000}kWh. "
+                          f"Maximal mögliche Energiemenge in 50 Jahren: {max_energy / 1000}kWh.")
+                exported = None
             # Die erlaubte Abweichung ist doppelt so groß wie die mögliche
             # Energiemenge pro Intervall bei maximaler Leistung
             control_interval = data.data.general_data.data.control_interval

--- a/packages/modules/common/utils/peak_filter.py
+++ b/packages/modules/common/utils/peak_filter.py
@@ -87,7 +87,7 @@ class PeakFilter:
                                              "Warte einen Regelintervall.")
             elif (allowed_deviation > 0 and
                     ((total_energy - previous_total_energy) > allowed_deviation or
-                    (total_energy - previous_total_energy) < 0)):
+                     (total_energy - previous_total_energy) < 0)):
                 log.debug(f"PeakFilter: Unplausibler Zählerwert: {total_energy / 1000}kWh. "
                           f"Differenz zum vorherigen Wert: {total_energy - previous_total_energy}Wh. "
                           f"erlaubte Differenz: {round(allowed_deviation, 2)}Wh.")

--- a/packages/modules/common/utils/peak_filter.py
+++ b/packages/modules/common/utils/peak_filter.py
@@ -53,27 +53,18 @@ class PeakFilter:
             exported: Optional[float] = None,
     ) -> tuple[Optional[float], Optional[float]]:
         if max_power > 0:
-            # filtere den Zählerstand wenn er größer ist als die maximal mögliche Energiemenge
-            # in 50 Jahren
+            # maximal mögliche Energiemenge in 50 Jahren:
             # max. Leistung × 24 h/Tag × 365 Tage/Jahr × 50 Jahre
             max_energy = max_power * 24 * 365 * 50
-            if imported is not None and imported > max_energy:
-                log.debug(f"PeakFilter: Unplausibler importierter Zählerstand: {imported / 1000}kWh. "
-                          f"Maximal mögliche Energiemenge in 50 Jahren: {max_energy / 1000}kWh.")
-                imported = None
-            if exported is not None and exported > max_energy:
-                log.debug(f"PeakFilter: Unplausibler exportierter Zählerstand: {exported / 1000}kWh. "
-                          f"Maximal mögliche Energiemenge in 50 Jahren: {max_energy / 1000}kWh.")
-                exported = None
             # Die erlaubte Abweichung ist doppelt so groß wie die mögliche
             # Energiemenge pro Intervall bei maximaler Leistung
             control_interval = data.data.general_data.data.control_interval
             allowed_deviation = 2 * (control_interval / 3600) * max_power
 
-            imp = self.check_total_energy(imported, self.imported, allowed_deviation)
+            imp = self.check_total_energy(imported, self.imported, allowed_deviation, max_energy)
             self.imported = imported
 
-            exp = self.check_total_energy(exported, self.exported, allowed_deviation)
+            exp = self.check_total_energy(exported, self.exported, allowed_deviation, max_energy)
             self.exported = exported
             return imp, exp
         return imported, exported
@@ -82,10 +73,14 @@ class PeakFilter:
         self,
         total_energy: Optional[float],
         previous_total_energy: Optional[float],
-        allowed_deviation: float
+        allowed_deviation: float,
+        max_energy: float
     ) -> Optional[float]:
         if total_energy is not None:
-            if previous_total_energy is None:
+            if total_energy > max_energy:
+                log.debug(f"PeakFilter: Unplausibler Zählerwert: {total_energy / 1000}kWh. "
+                          f"Maximal mögliche Energiemenge in 50 Jahren: {max_energy / 1000}kWh.")
+            elif previous_total_energy is None:
                 if allowed_deviation > 0:
                     self.fault_state.warning("PeakFilter: Vorheriger Wert None (Startup), "
                                              f"aktueller Zählerwert: {total_energy / 1000 }kWh. "

--- a/packages/modules/common/utils/peak_filter.py
+++ b/packages/modules/common/utils/peak_filter.py
@@ -85,7 +85,9 @@ class PeakFilter:
                     self.fault_state.warning("PeakFilter: Vorheriger Wert None (Startup), "
                                              f"aktueller Zählerwert: {total_energy / 1000 }kWh. "
                                              "Warte einen Regelintervall.")
-            elif allowed_deviation > 0 and (total_energy - previous_total_energy) > allowed_deviation:
+            elif (allowed_deviation > 0 and \
+                    ((total_energy - previous_total_energy) > allowed_deviation or
+                    (total_energy - previous_total_energy) < 0)):
                 log.debug(f"PeakFilter: Unplausibler Zählerwert: {total_energy / 1000}kWh. "
                           f"Differenz zum vorherigen Wert: {total_energy - previous_total_energy}Wh. "
                           f"erlaubte Differenz: {round(allowed_deviation, 2)}Wh.")

--- a/packages/modules/common/utils/peak_filter.py
+++ b/packages/modules/common/utils/peak_filter.py
@@ -54,7 +54,7 @@ class PeakFilter:
     ) -> tuple[Optional[float], Optional[float]]:
         if max_power > 0:
             # filtere den Zählerstand wenn er größer ist als die maximal mögliche Energiemenge
-            # in 50 Jahren 
+            # in 50 Jahren
             # max. Leistung × 24 h/Tag × 365 Tage/Jahr × 50 Jahre
             max_energy = max_power * 24 * 365 * 50
             if imported is not None and imported > max_energy:

--- a/packages/modules/common/utils/peak_filter.py
+++ b/packages/modules/common/utils/peak_filter.py
@@ -85,7 +85,7 @@ class PeakFilter:
                     self.fault_state.warning("PeakFilter: Vorheriger Wert None (Startup), "
                                              f"aktueller Zählerwert: {total_energy / 1000 }kWh. "
                                              "Warte einen Regelintervall.")
-            elif (allowed_deviation > 0 and \
+            elif (allowed_deviation > 0 and
                     ((total_energy - previous_total_energy) > allowed_deviation or
                     (total_energy - previous_total_energy) < 0)):
                 log.debug(f"PeakFilter: Unplausibler Zählerwert: {total_energy / 1000}kWh. "

--- a/packages/modules/common/utils/test_peak_filter.py
+++ b/packages/modules/common/utils/test_peak_filter.py
@@ -73,9 +73,12 @@ cases = [
     Params("Imp/ Exp Speicher - Werte invalide", ComponentType.BAT, 1000, 500, 400, 1300, 800, None, None),
     Params("Imp/ Exp Speicher - Import invalide", ComponentType.BAT, 1000, 500, 400, 1300, 505, None, 505),
     Params("Imp/ Exp Speicher - Export invalide", ComponentType.BAT, 1000, 500, 400, 1005, 800, 1005, None),
+    Params("Imp/ Exp Speicher - Import > 50Y", ComponentType.BAT, 500000000, 500, 400, 500000000, 505, None, 505),
     Params("Imp/ Exp Speicher - Export > 50Y", ComponentType.BAT, 1000, 500000000, 400, 1005, 500000000, 1005, None),
-    Params("Imp/ Exp Speicher - Export ~ 40Y", ComponentType.BAT,
+    Params("Imp/ Exp Speicher - Export ~ 45Y", ComponentType.BAT,
            1000, 400000000, 400, 1005, 400000000, 1005, 400000000),
+    Params("Imp/ Exp Speicher - Import > 50Y", ComponentType.BAT,
+           400000000, 500, 400, 400000000, 505, 400000000, 505)
 ]
 
 

--- a/packages/modules/common/utils/test_peak_filter.py
+++ b/packages/modules/common/utils/test_peak_filter.py
@@ -77,7 +77,7 @@ cases = [
     Params("Imp/ Exp Speicher - Export > 50Y", ComponentType.BAT, 1000, 500000000, 400, 1005, 500000000, 1005, None),
     Params("Imp/ Exp Speicher - Export ~ 45Y", ComponentType.BAT,
            1000, 400000000, 400, 1005, 400000000, 1005, 400000000),
-    Params("Imp/ Exp Speicher - Import > 50Y", ComponentType.BAT,
+    Params("Imp/ Exp Speicher - Import ~ 45Y", ComponentType.BAT,
            400000000, 500, 400, 400000000, 505, 400000000, 505)
 ]
 

--- a/packages/modules/common/utils/test_peak_filter.py
+++ b/packages/modules/common/utils/test_peak_filter.py
@@ -74,7 +74,8 @@ cases = [
     Params("Imp/ Exp Speicher - Import invalide", ComponentType.BAT, 1000, 500, 400, 1300, 505, None, 505),
     Params("Imp/ Exp Speicher - Export invalide", ComponentType.BAT, 1000, 500, 400, 1005, 800, 1005, None),
     Params("Imp/ Exp Speicher - Export > 50Y", ComponentType.BAT, 1000, 500000000, 400, 1005, 500000000, 1005, None),
-    Params("Imp/ Exp Speicher - Export ~ 40Y", ComponentType.BAT, 1000, 400000000, 400, 1005, 400000000, 1005, 400000000),
+    Params("Imp/ Exp Speicher - Export ~ 40Y", ComponentType.BAT,
+           1000, 400000000, 400, 1005, 400000000, 1005, 400000000),
 ]
 
 

--- a/packages/modules/common/utils/test_peak_filter.py
+++ b/packages/modules/common/utils/test_peak_filter.py
@@ -73,6 +73,8 @@ cases = [
     Params("Imp/ Exp Speicher - Werte invalide", ComponentType.BAT, 1000, 500, 400, 1300, 800, None, None),
     Params("Imp/ Exp Speicher - Import invalide", ComponentType.BAT, 1000, 500, 400, 1300, 505, None, 505),
     Params("Imp/ Exp Speicher - Export invalide", ComponentType.BAT, 1000, 500, 400, 1005, 800, 1005, None),
+    Params("Imp/ Exp Speicher - Export > 50Y", ComponentType.BAT, 1000, 500000000, 400, 1005, 500000000, 1005, None),
+    Params("Imp/ Exp Speicher - Export ~ 40Y", ComponentType.BAT, 1000, 400000000, 400, 1005, 400000000, 1005, 400000000),
 ]
 
 


### PR DESCRIPTION
Zählerstande filtern die größer sind als die maximal mögliche Energiemenge in 50 Jahren

Formel:
max. Leistung × 24 h/Tag × 365 Tage/Jahr × 50 Jahre