### PR TITLE
docs: update raspios 11 download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Bei fertig erworbenen openWB ist die Software bereits vorinstalliert.
 Software:
 
 - Installiertes Raspberry Pi OS auf einem Raspberry Pi 3b oder besser.
-- Raspberry Pi OS Lite installieren. Aktuell wird in der Version 2.1 nur **Debian 11 "Bullseye"** (derzeit "oldstable") unterstützt.
-<https://downloads.raspberrypi.org/raspios_oldstable_lite_armhf/>
+- Raspberry Pi OS Lite installieren. Aktuell wird nur **Debian 11 "Bullseye"** unterstützt.
+<https://downloads.raspberrypi.org/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2025-05-07/>
 - alternativ kann auch ein x86_64 System (Hardware oder als VM) mit installiertem **Debian 11 "Bullseye"** als Basis verwendet werden.
-- Eine Installation unter **Debian 12 "Bookworm"** wird noch nicht unterstützt!
+- Eine Installation unter **Debian 12 "Bookworm" oder Debian 13 "Trixie"** wird noch nicht unterstützt!
 - Bitte beachten das **Debian 11 "Bullseye"** nur mit erheblichem Aufwand mit einem Raspberry Pi 5 kompatibel ist. Wir empfehlen die Nutzung von einem Raspberry Pi 3b.
 
 In der Shell folgendes eingeben:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Software:
 - Raspberry Pi OS Lite installieren. Aktuell wird nur **Debian 11 "Bullseye"** unterstützt.
 <https://downloads.raspberrypi.org/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2025-05-07/>
 - alternativ kann auch ein x86_64 System (Hardware oder als VM) mit installiertem **Debian 11 "Bullseye"** als Basis verwendet werden.
-- Eine Installation unter **Debian 12 "Bookworm" oder Debian 13 "Trixie"** wird noch nicht unterstützt!
+- Eine Installation unter neueren Versionen (**Debian 12 "Bookworm"** oder aktueller) wird noch nicht unterstützt!
 - Bitte beachten das **Debian 11 "Bullseye"** nur mit erheblichem Aufwand mit einem Raspberry Pi 5 kompatibel ist. Wir empfehlen die Nutzung von einem Raspberry Pi 3b.
 
 In der Shell folgendes eingeben:


### PR DESCRIPTION
Mittlerweile ist die Bookworm-Variante oldstable (und bullseye oldoldstable). Wer daher nicht aufpasst und die aktuelle Version vom hinterlegten Link herunterlädt ist dann nach der Installation frustriert ;-)

Außerdem wurde auf Version 2.1 verwiesen, es gilt aber auch für 2.2, daher habe ich die Versionsnummer ebenfalls entfernt. 

