### PR TITLE
fix: support kmsprint for display detection

### DIFF
--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -239,20 +239,28 @@ chmod 666 "$LOGFILE"
 	"$OPENWBBASEDIR/runs/cleanPythonCache.sh"
 
 	# detect connected displays
-	# set default to "true" as fallback if "tvservice" is missing
+	# set default to "true" as fallback if no cli tools are available
 	displayDetected="true"
-	if which tvservice >/dev/null; then
-		echo "detected 'tvservice', query for connected displays"
-		output=$(tvservice -l)
-		echo "$output"
-		if [[ ! $output =~ "HDMI" ]] && [[ ! $output =~ "LCD" ]]; then
+	displayDetectionOutput=""
+	# Modern versions of Raspberry Pi OS use the KMS/DRM graphics stack
+	# and tvservice will just print 'tvservice is not supported when using the vc4-kms-v3d driver.'
+	if which kmsprint >/dev/null; then
+			echo "detected 'kmsprint', query for connected displays"
+			displayDetectionOutput=$(kmsprint) 
+	elif which tvservice >/dev/null; then
+			echo "detected 'tvservice', query for connected displays"
+			displayDetectionOutput=$(tvservice -l)
+	else
+			echo "'kmsprint' and 'tvservice' not found, assuming a display is present"
+	fi
+	if [ ! -z "$displayDetectionOutput" ]; then
+			echo "$displayDetectionOutput"
+	fi
+	if [[ ! "$displayDetectionOutput" =~ "HDMI" ]] && [[ ! "$displayDetectionOutput" =~ "LCD" ]]; then
 			echo "no display detected"
 			displayDetected="false"
-		else
-			echo "detected HDMI or LCD display(s)"
-		fi
 	else
-		echo "'tvservice' not found, assuming a display is present"
+			echo "detected HDMI or LCD display(s)"
 	fi
 	echo "displayDetected: $displayDetected"
 	forceDisplaySetup=0

--- a/runs/atreboot.sh
+++ b/runs/atreboot.sh
@@ -245,22 +245,22 @@ chmod 666 "$LOGFILE"
 	# Modern versions of Raspberry Pi OS use the KMS/DRM graphics stack
 	# and tvservice will just print 'tvservice is not supported when using the vc4-kms-v3d driver.'
 	if which kmsprint >/dev/null; then
-			echo "detected 'kmsprint', query for connected displays"
-			displayDetectionOutput=$(kmsprint) 
+		echo "detected 'kmsprint', query for connected displays"
+		displayDetectionOutput=$(kmsprint) 
 	elif which tvservice >/dev/null; then
-			echo "detected 'tvservice', query for connected displays"
-			displayDetectionOutput=$(tvservice -l)
+		echo "detected 'tvservice', query for connected displays"
+		displayDetectionOutput=$(tvservice -l)
 	else
-			echo "'kmsprint' and 'tvservice' not found, assuming a display is present"
+		echo "'kmsprint' and 'tvservice' not found, assuming a display is present"
 	fi
 	if [ ! -z "$displayDetectionOutput" ]; then
-			echo "$displayDetectionOutput"
+		echo "$displayDetectionOutput"
 	fi
 	if [[ ! "$displayDetectionOutput" =~ "HDMI" ]] && [[ ! "$displayDetectionOutput" =~ "LCD" ]]; then
-			echo "no display detected"
-			displayDetected="false"
+		echo "no display detected"
+		displayDetected="false"
 	else
-			echo "detected HDMI or LCD display(s)"
+		echo "detected HDMI or LCD display(s)"
 	fi
 	echo "displayDetected: $displayDetected"
 	forceDisplaySetup=0


### PR DESCRIPTION
After a fresh installation of the latest Raspberry Pi OS **bullseye** (https://downloads.raspberrypi.org/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2025-05-07/) with an OpenWB Pro+, and executing the official install script, the integrated display is not detected.

This is caused as the `atreboot.sh` script is using the deprecated tvservice which just prints
```sh
openwb@openwb-2:~ $ tvservice -l
tvservice is not supported when using the vc4-kms-v3d driver.
Similar features are available with standard linux tools
such as kmsprint from kms++-utils
```
and therefore assumes there is no display connected. This PR tries to use the modern `kmsprint` first and additionally should make it more compatible for upcoming bookworm and trixie support.