### PR TITLE
Add LoadManager

### DIFF
--- a/packages/control/algorithm/common.py
+++ b/packages/control/algorithm/common.py
@@ -82,6 +82,7 @@ def set_current_counterdiff(diff_current: float,
                     diffs,
                     voltages_mean(chargepoint.data.get.voltages))
         data.data.io_actions.dimming_set_import_power_left({"type": "cp", "id": chargepoint.num}, sum(diffs)*230)
+        data.data.io_actions.set_limit_loadmanager({"type": "cp", "id": chargepoint.num}, sum(diffs)*230)
 
     chargepoint.data.set.current = current
     log.info(f"LP{chargepoint.num}: Stromstärke {current}A")
@@ -156,6 +157,7 @@ def update_raw_data(preferenced_chargepoints: List[Chargepoint],
             else:
                 data.data.counter_data[counter].update_values_left(diffs, voltages_mean(chargepoint.data.get.voltages))
         data.data.io_actions.dimming_set_import_power_left({"type": "cp", "id": chargepoint.num}, sum(diffs)*230)
+        data.data.io_actions.set_limit_loadmanager({"type": "cp", "id": chargepoint.num}, sum(diffs)*230)
 
 
 def consider_less_charging_chargepoint_in_loadmanagement(cp: Chargepoint, set_current: float) -> bool:

--- a/packages/control/algorithm/common.py
+++ b/packages/control/algorithm/common.py
@@ -82,7 +82,7 @@ def set_current_counterdiff(diff_current: float,
                     diffs,
                     voltages_mean(chargepoint.data.get.voltages))
         data.data.io_actions.dimming_set_import_power_left({"type": "cp", "id": chargepoint.num}, sum(diffs)*230)
-        data.data.io_actions.set_limit_loadmanager({"type": "cp", "id": chargepoint.num}, sum(diffs)*230)
+        data.data.io_actions.set_limit_loadmanager(sum(diffs)*230)
 
     chargepoint.data.set.current = current
     log.info(f"LP{chargepoint.num}: Stromstärke {current}A")
@@ -157,7 +157,7 @@ def update_raw_data(preferenced_chargepoints: List[Chargepoint],
             else:
                 data.data.counter_data[counter].update_values_left(diffs, voltages_mean(chargepoint.data.get.voltages))
         data.data.io_actions.dimming_set_import_power_left({"type": "cp", "id": chargepoint.num}, sum(diffs)*230)
-        data.data.io_actions.set_limit_loadmanager({"type": "cp", "id": chargepoint.num}, sum(diffs)*230)
+        data.data.io_actions.set_limit_loadmanager(sum(diffs)*230)
 
 
 def consider_less_charging_chargepoint_in_loadmanagement(cp: Chargepoint, set_current: float) -> bool:

--- a/packages/control/io_device.py
+++ b/packages/control/io_device.py
@@ -4,6 +4,9 @@ from control.limiting_value import LoadmanagementLimit
 from helpermodules.constants import NO_ERROR
 from modules.io_actions.controllable_consumers.dimming.api_eebus import DimmingEebus
 from modules.io_actions.controllable_consumers.dimming.api_io import DimmingIo
+
+from modules.io_actions.controllable_consumers.load_manager.api import DimmingLoadManager
+
 from modules.io_actions.controllable_consumers.dimming_direct_control.api import DimmingDirectControl
 from modules.io_actions.controllable_consumers.ripple_control_receiver.api import RippleControlReceiver
 from modules.io_actions.generator_systems.stepwise_control.api_eebus import StepwiseControlEebus
@@ -55,7 +58,8 @@ class IoStates:
 class IoActions:
     def __init__(self):
         self.actions: Dict[int, Union[DimmingIo, DimmingEebus, DimmingDirectControl,
-                                      RippleControlReceiver, StepwiseControlEebus, StepwiseControlIo]] = {}
+                                      RippleControlReceiver, StepwiseControlEebus, StepwiseControlIo,
+                                      DimmingLoadManager]] = {}
 
     def setup(self):
         for action in self.actions.values():
@@ -100,5 +104,14 @@ class IoActions:
             if isinstance(action, (StepwiseControlEebus, StepwiseControlIo)):
                 if device_id in [component["id"] for component in action.config.configuration.devices]:
                     return action.control_stepwise()
+        else:
+            return None, LoadmanagementLimit(None, None)
+
+    def dimming_load_manager(self, device: Dict) -> Optional[float]:
+        for action in self.actions.values():
+            if isinstance(action, (DimmingLoadManager)):
+                for d in action.config.configuration.devices:
+                    if d == device:
+                        return action.dimming_get_import_power_left()
         else:
             return None, LoadmanagementLimit(None, None)

--- a/packages/control/io_device.py
+++ b/packages/control/io_device.py
@@ -107,11 +107,11 @@ class IoActions:
         else:
             return None, LoadmanagementLimit(None, None)
 
-    def dimming_load_manager(self, device: Dict) -> Tuple[Optional[float], LoadmanagementLimit]:
+    def limit_loadmanager(self, device: Dict) -> Tuple[Optional[float], LoadmanagementLimit]:
         for action in self.actions.values():
             if isinstance(action, DimmingLoadManager):
                 for d in action.config.configuration.devices:
                     if d == device:
-                        return action.dimming_get_import_power_left()
+                        return action.loadmanager_get_import_power_left()
         else:
             return None, LoadmanagementLimit(None, None)

--- a/packages/control/io_device.py
+++ b/packages/control/io_device.py
@@ -5,7 +5,7 @@ from helpermodules.constants import NO_ERROR
 from modules.io_actions.controllable_consumers.dimming.api_eebus import DimmingEebus
 from modules.io_actions.controllable_consumers.dimming.api_io import DimmingIo
 
-from modules.io_actions.controllable_consumers.load_manager.api import DimmingLoadManager
+from modules.io_actions.controllable_consumers.load_manager.api import LoadManager
 
 from modules.io_actions.controllable_consumers.dimming_direct_control.api import DimmingDirectControl
 from modules.io_actions.controllable_consumers.ripple_control_receiver.api import RippleControlReceiver
@@ -59,7 +59,7 @@ class IoActions:
     def __init__(self):
         self.actions: Dict[int, Union[DimmingIo, DimmingEebus, DimmingDirectControl,
                                       RippleControlReceiver, StepwiseControlEebus, StepwiseControlIo,
-                                      DimmingLoadManager]] = {}
+                                      LoadManager]] = {}
 
     def setup(self):
         for action in self.actions.values():
@@ -107,11 +107,18 @@ class IoActions:
         else:
             return None, LoadmanagementLimit(None, None)
 
-    def limit_loadmanager(self, device: Dict) -> Tuple[Optional[float], LoadmanagementLimit]:
+    def get_limit_loadmanager(self, device: Dict) -> Tuple[Optional[float], Optional[float], LoadmanagementLimit]:
         for action in self.actions.values():
-            if isinstance(action, DimmingLoadManager):
+            if isinstance(action, LoadManager):
                 for d in action.config.configuration.devices:
                     if d == device:
                         return action.loadmanager_get_import_power_left()
         else:
-            return None, LoadmanagementLimit(None, None)
+            return None, None, LoadmanagementLimit(None, None)
+
+    def set_limit_loadmanager(self, device: Dict, used_power: float) -> Optional[float]:
+        for action in self.actions.values():
+            if isinstance(action, LoadManager):
+                for d in action.config.configuration.devices:
+                    if d == device:
+                        return action.loadmanager_set_import_power_left(used_power, used_power/230)

--- a/packages/control/io_device.py
+++ b/packages/control/io_device.py
@@ -107,9 +107,9 @@ class IoActions:
         else:
             return None, LoadmanagementLimit(None, None)
 
-    def dimming_load_manager(self, device: Dict) -> Optional[float]:
+    def dimming_load_manager(self, device: Dict) -> Tuple[Optional[float], LoadmanagementLimit]:
         for action in self.actions.values():
-            if isinstance(action, (DimmingLoadManager)):
+            if isinstance(action, DimmingLoadManager):
                 for d in action.config.configuration.devices:
                     if d == device:
                         return action.dimming_get_import_power_left()

--- a/packages/control/io_device.py
+++ b/packages/control/io_device.py
@@ -107,18 +107,14 @@ class IoActions:
         else:
             return None, LoadmanagementLimit(None, None)
 
-    def get_limit_loadmanager(self, device: Dict) -> Tuple[Optional[float], Optional[float], LoadmanagementLimit]:
+    def get_limit_loadmanager(self) -> Tuple[Optional[float], Optional[float], LoadmanagementLimit]:
         for action in self.actions.values():
             if isinstance(action, LoadManager):
-                for d in action.config.configuration.devices:
-                    if d == device:
-                        return action.loadmanager_get_import_power_left()
+                return action.loadmanager_get_import_power_left()
         else:
             return None, None, LoadmanagementLimit(None, None)
 
-    def set_limit_loadmanager(self, device: Dict, used_power: float) -> Optional[float]:
+    def set_limit_loadmanager(self, used_power: float) -> Optional[float]:
         for action in self.actions.values():
             if isinstance(action, LoadManager):
-                for d in action.config.configuration.devices:
-                    if d == device:
-                        return action.loadmanager_set_import_power_left(used_power, used_power/230)
+                return action.loadmanager_set_import_power_left(used_power, used_power/230)

--- a/packages/control/limiting_value.py
+++ b/packages/control/limiting_value.py
@@ -8,6 +8,7 @@ class LimitingValue(Enum):
     POWER = ", da die maximale Leistung an Zähler {} erreicht ist."
     UNBALANCED_LOAD = ", da die maximale Schieflast an Zähler {} erreicht ist."
     LOADMANAGER = ", da der Lastmanager die Ladeleistung begrenzt."
+    LOADMANAGER_ERROR = ", da aufgrund eines Fehlers im Lastmanager die Ladeleistung auf die maximale Leistung im Fehlerfall begrenzt wird."
     DIMMING = ", da die Dimmung die Ladeleistung begrenzt."
     DIMMING_VIA_DIRECT_CONTROL = ", da die Dimmung per Direkt-Steuerung die Ladeleistung auf 4,2 kW begrenzt."
     RIPPLE_CONTROL_RECEIVER = (", da der Ladepunkt durch den RSE-Kontakt auf {}% der konfigurierten Anschlussleistung "

--- a/packages/control/limiting_value.py
+++ b/packages/control/limiting_value.py
@@ -8,7 +8,8 @@ class LimitingValue(Enum):
     POWER = ", da die maximale Leistung an Zähler {} erreicht ist."
     UNBALANCED_LOAD = ", da die maximale Schieflast an Zähler {} erreicht ist."
     LOADMANAGER = ", da der Lastmanager die Ladeleistung begrenzt."
-    LOADMANAGER_ERROR = ", da aufgrund eines Fehlers im Lastmanager die Ladeleistung auf die maximale Leistung im Fehlerfall begrenzt wird."
+    LOADMANAGER_ERROR = (", da aufgrund eines Fehlers im Lastmanager die Ladeleistung auf die maximale Leistung "
+                         "im Fehlerfall begrenzt wird.")
     DIMMING = ", da die Dimmung die Ladeleistung begrenzt."
     DIMMING_VIA_DIRECT_CONTROL = ", da die Dimmung per Direkt-Steuerung die Ladeleistung auf 4,2 kW begrenzt."
     RIPPLE_CONTROL_RECEIVER = (", da der Ladepunkt durch den RSE-Kontakt auf {}% der konfigurierten Anschlussleistung "

--- a/packages/control/limiting_value.py
+++ b/packages/control/limiting_value.py
@@ -7,6 +7,7 @@ class LimitingValue(Enum):
     CURRENT = ", da der Maximal-Strom an Zähler {} erreicht ist."
     POWER = ", da die maximale Leistung an Zähler {} erreicht ist."
     UNBALANCED_LOAD = ", da die maximale Schieflast an Zähler {} erreicht ist."
+    LOADMANAGER = ", da der Lastmanager die Ladeleistung begrenzt."
     DIMMING = ", da die Dimmung die Ladeleistung begrenzt."
     DIMMING_VIA_DIRECT_CONTROL = ", da die Dimmung per Direkt-Steuerung die Ladeleistung auf 4,2 kW begrenzt."
     RIPPLE_CONTROL_RECEIVER = (", da der Ladepunkt durch den RSE-Kontakt auf {}% der konfigurierten Anschlussleistung "

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -194,25 +194,19 @@ class Loadmanagement:
 
         if loadmanager_power_left is not None and loadmanager_current_left is not None:
             if sum(available_currents)*230 > loadmanager_power_left:
-                # --REDU
-                # wie viel phasen sind im Einsatz?
                 phases = 3-available_currents.count(0)
-                # Wie viel ist jede Phase zu hoch
                 overload_per_phase = (sum(available_currents) - loadmanager_power_left/230)/phases
-                # Ziehe das für jede Phase ab, die im Einsatz ist.
                 available_currents = [c - overload_per_phase if c > 0 else 0 for c in available_currents]
                 log.debug(
-                    f"#######_Reduzierung der Ströme auf {sum(available_currents)*230}W durch den Lastmanager. "
+                    f"Reduzierung der Leistung auf {sum(available_currents)*230}W durch den Lastmanager. "
                     f"(Leistungsgrenze: {loadmanager_power_left}W)")
                 return available_currents, limit
-            elif sum(available_currents) > loadmanager_current_left:
-                # --REDU
+            if sum(available_currents) > loadmanager_current_left:
                 phases = 3 - available_currents.count(0)
                 overload_per_phase = (sum(available_currents) - loadmanager_current_left) / phases
                 available_currents = [max(c - overload_per_phase, 0) if c > 0 else 0 for c in available_currents]
                 log.debug(
-                    f"#######_Reduzierung der Ströme auf {available_currents}A durch den Lastmanager. "
+                    f"Reduzierung der Ströme auf {available_currents}A durch den Lastmanager. "
                     f"(Stromgrenze: {loadmanager_current_left}A)")
                 return available_currents, limit
-        # muss nix reduzieren. Passt alles so
         return available_currents, limit

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -193,13 +193,14 @@ class Loadmanagement:
             "type": "cp", "id": cp.num})
 
         if loadmanager_power_left is not None and loadmanager_current_left is not None:
-            if sum(available_currents)*230 > loadmanager_power_left:
+            if sum(available_currents)*voltages_mean(cp.data.get.voltages) > loadmanager_power_left:
                 phases = 3-available_currents.count(0)
-                overload_per_phase = (sum(available_currents) - loadmanager_power_left/230)/phases
+                overload_per_phase = (sum(available_currents) -
+                                      loadmanager_power_left/voltages_mean(cp.data.get.voltages))/phases
                 available_currents = [c - overload_per_phase if c > 0 else 0 for c in available_currents]
                 log.debug(
-                    f"Reduzierung der Leistung auf {sum(available_currents)*230}W durch den Lastmanager. "
-                    f"(Leistungsgrenze: {loadmanager_power_left}W)")
+                    f"Reduzierung der Leistung auf {sum(available_currents)*voltages_mean(cp.data.get.voltages)}W "
+                    f"durch den Lastmanager. (Leistungsgrenze: {loadmanager_power_left}W)")
                 return available_currents, limit
             if sum(available_currents) > loadmanager_current_left:
                 phases = 3 - available_currents.count(0)

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -189,11 +189,11 @@ class Loadmanagement:
                            available_currents: List[float],
                            cp: Chargepoint) -> Tuple[List[float], LoadmanagementLimit]:
 
-        loadmanager_power_left, limit = data.data.io_actions.dimming_load_manager({"type": "cp", "id": cp.num})
+        loadmanager_power_left, limit = data.data.io_actions.limit_loadmanager({"type": "cp", "id": cp.num})
         if loadmanager_power_left is not None:
             if sum(available_currents)*230 > loadmanager_power_left:
                 phases = 3-available_currents.count(0)
                 overload_per_phase = (sum(available_currents) - loadmanager_power_left/230)/phases
                 available_currents = [c - overload_per_phase if c > 0 else 0 for c in available_currents]
-                log.debug(f"Reduzierung der Ströme durch den LoadManager: {available_currents}A")
+                log.debug(f"Reduzierung der Ströme durch den Lastmanager: {available_currents}A")
         return available_currents, limit

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -188,11 +188,12 @@ class Loadmanagement:
     def _limit_loadmanager(self,
                            available_currents: List[float],
                            cp: Chargepoint) -> Tuple[List[float], LoadmanagementLimit]:
-        dimming_power_left, limit = data.data.io_actions.dimming_load_manager({"type": "cp", "id": cp.num})
-        if dimming_power_left is not None:
-            if sum(available_currents)*230 > dimming_power_left:
+
+        loadmanager_power_left, limit = data.data.io_actions.dimming_load_manager({"type": "cp", "id": cp.num})
+        if loadmanager_power_left is not None:
+            if sum(available_currents)*230 > loadmanager_power_left:
                 phases = 3-available_currents.count(0)
-                overload_per_phase = (sum(available_currents) - dimming_power_left/230)/phases
+                overload_per_phase = (sum(available_currents) - loadmanager_power_left/230)/phases
                 available_currents = [c - overload_per_phase if c > 0 else 0 for c in available_currents]
-                log.debug(f"Reduzierung der Ströme durch die Dimmung: {available_currents}A")
+                log.debug(f"Reduzierung der Ströme durch den LoadManager: {available_currents}A")
         return available_currents, limit

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -189,11 +189,30 @@ class Loadmanagement:
                            available_currents: List[float],
                            cp: Chargepoint) -> Tuple[List[float], LoadmanagementLimit]:
 
-        loadmanager_power_left, limit = data.data.io_actions.limit_loadmanager({"type": "cp", "id": cp.num})
-        if loadmanager_power_left is not None:
+        loadmanager_power_left, loadmanager_current_left, limit = data.data.io_actions.get_limit_loadmanager({
+            "type": "cp", "id": cp.num})
+
+        if loadmanager_power_left is not None and loadmanager_current_left is not None:
             if sum(available_currents)*230 > loadmanager_power_left:
+                # --REDU
+                # wie viel phasen sind im Einsatz?
                 phases = 3-available_currents.count(0)
+                # Wie viel ist jede Phase zu hoch
                 overload_per_phase = (sum(available_currents) - loadmanager_power_left/230)/phases
+                # Ziehe das für jede Phase ab, die im Einsatz ist.
                 available_currents = [c - overload_per_phase if c > 0 else 0 for c in available_currents]
-                log.debug(f"Reduzierung der Ströme durch den Lastmanager: {available_currents}A")
+                log.debug(
+                    f"#######_Reduzierung der Ströme auf {sum(available_currents)*230}W durch den Lastmanager. "
+                    f"(Leistungsgrenze: {loadmanager_power_left}W)")
+                return available_currents, limit
+            elif sum(available_currents) > loadmanager_current_left:
+                # --REDU
+                phases = 3 - available_currents.count(0)
+                overload_per_phase = (sum(available_currents) - loadmanager_current_left) / phases
+                available_currents = [max(c - overload_per_phase, 0) if c > 0 else 0 for c in available_currents]
+                log.debug(
+                    f"#######_Reduzierung der Ströme auf {available_currents}A durch den Lastmanager. "
+                    f"(Stromgrenze: {loadmanager_current_left}A)")
+                return available_currents, limit
+        # muss nix reduzieren. Passt alles so
         return available_currents, limit

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -26,6 +26,9 @@ class Loadmanagement:
             available_currents, new_limit = self._limit_by_dimming(available_currents, cp)
             limit = new_limit if new_limit.limiting_value is not None else limit
 
+            available_currents, new_limit = self._limit_loadmanager(available_currents, cp)
+            limit = new_limit if new_limit.limiting_value is not None else limit
+
             available_currents, new_limit = self._limit_by_ripple_control_receiver(available_currents, cp)
             limit = new_limit if new_limit.limiting_value is not None else limit
         except ValueError as e:
@@ -180,4 +183,16 @@ class Loadmanagement:
             available_currents = [max(min(max_current*value - cp.data.set.target_current, c), 0)
                                   if c > 0 else 0 for c in available_currents]
             log.debug(f"Reduzierung durch RSE-Kontakt auf {value*100}%, maximal {max_current*value}A")
+        return available_currents, limit
+
+    def _limit_loadmanager(self,
+                           available_currents: List[float],
+                           cp: Chargepoint) -> Tuple[List[float], LoadmanagementLimit]:
+        dimming_power_left, limit = data.data.io_actions.dimming_load_manager({"type": "cp", "id": cp.num})
+        if dimming_power_left is not None:
+            if sum(available_currents)*230 > dimming_power_left:
+                phases = 3-available_currents.count(0)
+                overload_per_phase = (sum(available_currents) - dimming_power_left/230)/phases
+                available_currents = [c - overload_per_phase if c > 0 else 0 for c in available_currents]
+                log.debug(f"Reduzierung der Ströme durch die Dimmung: {available_currents}A")
         return available_currents, limit

--- a/packages/control/loadmanagement.py
+++ b/packages/control/loadmanagement.py
@@ -189,8 +189,7 @@ class Loadmanagement:
                            available_currents: List[float],
                            cp: Chargepoint) -> Tuple[List[float], LoadmanagementLimit]:
 
-        loadmanager_power_left, loadmanager_current_left, limit = data.data.io_actions.get_limit_loadmanager({
-            "type": "cp", "id": cp.num})
+        loadmanager_power_left, loadmanager_current_left, limit = data.data.io_actions.get_limit_loadmanager()
 
         if loadmanager_power_left is not None and loadmanager_current_left is not None:
             if sum(available_currents)*voltages_mean(cp.data.get.voltages) > loadmanager_power_left:

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -851,6 +851,8 @@ class SetData:
             self.process_pv_topic(msg)
         elif "openWB/set/mqtt/vehicle/" in msg.topic:
             self.process_vehicle_topic(msg)
+        elif "openWB/set/mqtt/loadmanager/" in msg.topic:
+            self.loadmanager_topic(msg)
 
     def process_optional_topic(self, msg: mqtt.MQTTMessage):
         """ Handler für die Optionalen-Topics
@@ -1214,3 +1216,19 @@ class SetData:
 
     def _get_ramdisk_path(self) -> Path:
         return Path(__file__).resolve().parents[2]/"ramdisk"
+
+    def loadmanager_topic(self, msg: mqtt.MQTTMessage):
+        """ Handler für die LoadMananger-Topics
+
+         Parameters
+        ----------
+        msg:
+            enthält Topic und Payload
+        """
+        try:
+            if "openWB/set/mqtt/loadmanager/set/loadmanager" in msg.topic:
+                self._validate_value(msg, "json")
+            else:
+                self.__unknown_topic(msg)
+        except Exception:
+            log.exception(f"Fehler im setdata-Modul: Topic {msg.topic}, Value: {msg.payload}")

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -1226,7 +1226,7 @@ class SetData:
             enthält Topic und Payload
         """
         try:
-            if "openWB/set/mqtt/loadmanager/set/loadmanager" in msg.topic:
+            if re.search("^openWB/set/mqtt/loadmanager/[0-9]+/set/loadmanager$", msg.topic) is not None:
                 self._validate_value(msg, "json")
             else:
                 self.__unknown_topic(msg)

--- a/packages/helpermodules/setdata.py
+++ b/packages/helpermodules/setdata.py
@@ -1218,7 +1218,7 @@ class SetData:
         return Path(__file__).resolve().parents[2]/"ramdisk"
 
     def loadmanager_topic(self, msg: mqtt.MQTTMessage):
-        """ Handler für die LoadMananger-Topics
+        """ Handler für die LoadManager-Topics
 
          Parameters
         ----------

--- a/packages/modules/io_actions/controllable_consumers/load_manager/api.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/api.py
@@ -13,14 +13,16 @@ from modules.common.abstract_device import DeviceDescriptor
 log = logging.getLogger(__name__)
 
 
-class DimmingLoadManager(AbstractIoAction):
+class LoadManager(AbstractIoAction):
     def __init__(self, config: LoadManagerSetup):
         self.config = config
         self.import_power_left = None
+        self.import_current_left = None
         super().__init__()
 
     def setup(self) -> None:
         if check_fault_state_io_device(self.config.configuration.io_device):
+            log.warning("Fehler des IO-Geräts: Lastmanager aktiviert für Failsafe-Modus.")
             max_power = self.config.configuration.max_power_on_failure
             max_current = self.config.configuration.max_current_on_failure
         else:
@@ -29,8 +31,7 @@ class DimmingLoadManager(AbstractIoAction):
             max_current = data.data.io_states[f"io_states{self.config.configuration.io_device}"
                                               ].data.get.analog_input[AnalogInputMapping.MAX_CURRENT.name]
         self.import_power_left = max_power
-
-        # Wie verrechne ich power und current?
+        self.import_current_left = max_current
 
     def loadmanager_get_import_power_left(self) -> Tuple[Optional[float], LoadmanagementLimit]:
         if check_fault_state_io_device(self.config.configuration.io_device):
@@ -38,11 +39,24 @@ class DimmingLoadManager(AbstractIoAction):
                 LimitingValue.CONTROLLABLE_CONSUMERS_ERROR.value.format(get_io_name_by_id(
                     self.config.configuration.io_device)),
                 LimitingValue.CONTROLLABLE_CONSUMERS_ERROR))
-        return self.import_power_left, LoadmanagementLimit(LimitingValue.DIMMING.value, LimitingValue.DIMMING)
+        return self.import_power_left, self.import_current_left,  LoadmanagementLimit(LimitingValue.LOADMANAGER.value,
+                                                                                      LimitingValue.LOADMANAGER)
+
+    def loadmanager_set_import_power_left(self, used_power: float, used_current: float) -> None:
+        if check_fault_state_io_device(self.config.configuration.io_device):
+            return (self.import_power_left, LoadmanagementLimit(
+                LimitingValue.CONTROLLABLE_CONSUMERS_ERROR.value.format(get_io_name_by_id(
+                    self.config.configuration.io_device)),
+                LimitingValue.CONTROLLABLE_CONSUMERS_ERROR))
+        self.import_power_left -= used_power
+        self.import_current_left -= used_current
+        log.debug(
+            f"verbleibende Dimm-Leistung: {self.import_power_left}W, verbleibender Strom: {self.import_current_left}A")
+        return self.import_power_left
 
 
 def create_action(config: LoadManagerSetup, parent_device_type: str):
-    return DimmingLoadManager(config=config)
+    return LoadManager(config=config)
 
 
 device_descriptor = DeviceDescriptor(configuration_factory=LoadManagerSetup)

--- a/packages/modules/io_actions/controllable_consumers/load_manager/api.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/api.py
@@ -3,7 +3,6 @@ from typing import Optional, Tuple
 from control import data
 from control.limiting_value import LimitingValue, LoadmanagementLimit
 from modules.common.abstract_io import AbstractIoAction
-from modules.common.utils.component_parser import get_io_name_by_id
 from modules.io_actions.common import check_fault_state_io_device
 from modules.io_actions.controllable_consumers.load_manager.config import LoadManagerSetup
 from modules.io_devices.load_manager.config import AnalogInputMapping
@@ -28,31 +27,24 @@ class LoadManager(AbstractIoAction):
         else:
             max_power = data.data.io_states[f"io_states{self.config.configuration.io_device}"
                                             ].data.get.analog_input[AnalogInputMapping.MAX_POWER.name]
-            max_current = data.data.io_states[f"io_states{self.config.configuration.io_device}"
-                                              ].data.get.analog_input[AnalogInputMapping.MAX_CURRENT.name]
+            max_current = sum(data.data.io_states[f"io_states{self.config.configuration.io_device}"
+                                                  ].data.get.analog_input[AnalogInputMapping.MAX_CURRENT.name])
         self.import_power_left = max_power
         self.import_current_left = max_current
 
-    def loadmanager_get_import_power_left(self) -> Tuple[Optional[float], LoadmanagementLimit]:
+    def loadmanager_get_import_power_left(self) -> Tuple[Optional[float], Optional[float], LoadmanagementLimit]:
         if check_fault_state_io_device(self.config.configuration.io_device):
-            return (self.import_power_left, LoadmanagementLimit(
-                LimitingValue.CONTROLLABLE_CONSUMERS_ERROR.value.format(get_io_name_by_id(
-                    self.config.configuration.io_device)),
-                LimitingValue.CONTROLLABLE_CONSUMERS_ERROR))
+            return (self.import_power_left, self.import_current_left, LoadmanagementLimit(
+                LimitingValue.LOADMANAGER_ERROR.value,
+                LimitingValue.LOADMANAGER_ERROR))
         return self.import_power_left, self.import_current_left,  LoadmanagementLimit(LimitingValue.LOADMANAGER.value,
                                                                                       LimitingValue.LOADMANAGER)
 
     def loadmanager_set_import_power_left(self, used_power: float, used_current: float) -> None:
-        if check_fault_state_io_device(self.config.configuration.io_device):
-            return (self.import_power_left, LoadmanagementLimit(
-                LimitingValue.CONTROLLABLE_CONSUMERS_ERROR.value.format(get_io_name_by_id(
-                    self.config.configuration.io_device)),
-                LimitingValue.CONTROLLABLE_CONSUMERS_ERROR))
         self.import_power_left -= used_power
         self.import_current_left -= used_current
         log.debug(
             f"verbleibende Dimm-Leistung: {self.import_power_left}W, verbleibender Strom: {self.import_current_left}A")
-        return self.import_power_left
 
 
 def create_action(config: LoadManagerSetup, parent_device_type: str):

--- a/packages/modules/io_actions/controllable_consumers/load_manager/api.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/api.py
@@ -2,8 +2,6 @@ import logging
 from typing import Optional, Tuple
 from control import data
 from control.limiting_value import LimitingValue, LoadmanagementLimit
-from helpermodules.pub import Pub
-from dataclass_utils import asdict
 from modules.common.abstract_io import AbstractIoAction
 from modules.common.utils.component_parser import get_io_name_by_id
 from modules.io_actions.common import check_fault_state_io_device
@@ -20,28 +18,18 @@ class DimmingLoadManager(AbstractIoAction):
     def __init__(self, config: LoadManagerSetup):
         self.config = config
         self.import_power_left = None
-        control_command_log.info("Dimmen per LoadManager.")
-
-        fixed_import_power = 0
-        for device in self.config.configuration.devices:
-            if device["type"] != "cp":
-                fixed_import_power += 4200
-        log.debug(f"Dimmen per LoadManager: Fest vergebene Mindestleistung: {fixed_import_power}W")
-        if fixed_import_power != self.config.configuration.fixed_import_power:
-            self.config.configuration.fixed_import_power = fixed_import_power
-            Pub().pub(f"openWB/set/io/action/{self.config.id}/config", asdict(self.config))
-
+        control_command_log.info("Begrenzung per Lastmanager.")
         super().__init__()
 
     def setup(self) -> None:
         if check_fault_state_io_device(self.config.configuration.io_device):
-            max_power = self.config.configuration.fixed_import_power
+            max_power = self.config.configuration.max_power_on_failure
         else:
             max_power = data.data.io_states[f"io_states{self.config.configuration.io_device}"
                                             ].data.get.analog_input[AnalogInputMapping.MAX_POWER.name]
         self.import_power_left = max_power
 
-    def dimming_get_import_power_left(self) -> Tuple[Optional[float], LoadmanagementLimit]:
+    def loadmanager_get_import_power_left(self) -> Tuple[Optional[float], LoadmanagementLimit]:
         if check_fault_state_io_device(self.config.configuration.io_device):
             return (self.import_power_left, LoadmanagementLimit(
                 LimitingValue.CONTROLLABLE_CONSUMERS_ERROR.value.format(get_io_name_by_id(

--- a/packages/modules/io_actions/controllable_consumers/load_manager/api.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/api.py
@@ -1,0 +1,57 @@
+import logging
+from typing import Optional, Tuple
+from control import data
+from control.limiting_value import LimitingValue, LoadmanagementLimit
+from helpermodules.pub import Pub
+from dataclass_utils import asdict
+from modules.common.abstract_io import AbstractIoAction
+from modules.common.utils.component_parser import get_io_name_by_id
+from modules.io_actions.common import check_fault_state_io_device
+from modules.io_actions.controllable_consumers.load_manager.config import LoadManagerSetup
+from modules.io_devices.load_manager.config import AnalogInputMapping
+
+from modules.common.abstract_device import DeviceDescriptor
+
+log = logging.getLogger(__name__)
+control_command_log = logging.getLogger("steuve_control_command")
+
+
+class DimmingLoadManager(AbstractIoAction):
+    def __init__(self, config: LoadManagerSetup):
+        self.config = config
+        self.import_power_left = None
+        control_command_log.info("Dimmen per LoadManager.")
+
+        fixed_import_power = 0
+        for device in self.config.configuration.devices:
+            if device["type"] != "cp":
+                fixed_import_power += 4200
+        log.debug(f"Dimmen per LoadManager: Fest vergebene Mindestleistung: {fixed_import_power}W")
+        if fixed_import_power != self.config.configuration.fixed_import_power:
+            self.config.configuration.fixed_import_power = fixed_import_power
+            Pub().pub(f"openWB/set/io/action/{self.config.id}/config", asdict(self.config))
+
+        super().__init__()
+
+    def setup(self) -> None:
+        if check_fault_state_io_device(self.config.configuration.io_device):
+            self.import_power_left = self.config.configuration.fixed_import_power
+        else:
+            max_power = data.data.io_states[f"io_states{self.config.configuration.io_device}"
+                                            ].data.get.analog_input[AnalogInputMapping.MAX_POWER.name]
+            self.import_power_left = max_power
+
+    def dimming_get_import_power_left(self) -> Tuple[Optional[float], LoadmanagementLimit]:
+        if check_fault_state_io_device(self.config.configuration.io_device):
+            return (self.import_power_left, LoadmanagementLimit(
+                LimitingValue.CONTROLLABLE_CONSUMERS_ERROR.value.format(get_io_name_by_id(
+                    self.config.configuration.io_device)),
+                LimitingValue.CONTROLLABLE_CONSUMERS_ERROR))
+        return self.import_power_left, LoadmanagementLimit(LimitingValue.DIMMING.value, LimitingValue.DIMMING)
+
+
+def create_action(config: LoadManagerSetup, parent_device_type: str):
+    return DimmingLoadManager(config=config)
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=LoadManagerSetup)

--- a/packages/modules/io_actions/controllable_consumers/load_manager/api.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/api.py
@@ -35,11 +35,11 @@ class DimmingLoadManager(AbstractIoAction):
 
     def setup(self) -> None:
         if check_fault_state_io_device(self.config.configuration.io_device):
-            self.import_power_left = self.config.configuration.fixed_import_power
+            max_power = self.config.configuration.fixed_import_power
         else:
             max_power = data.data.io_states[f"io_states{self.config.configuration.io_device}"
                                             ].data.get.analog_input[AnalogInputMapping.MAX_POWER.name]
-            self.import_power_left = max_power
+        self.import_power_left = max_power
 
     def dimming_get_import_power_left(self) -> Tuple[Optional[float], LoadmanagementLimit]:
         if check_fault_state_io_device(self.config.configuration.io_device):

--- a/packages/modules/io_actions/controllable_consumers/load_manager/api.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/api.py
@@ -11,23 +11,26 @@ from modules.io_devices.load_manager.config import AnalogInputMapping
 from modules.common.abstract_device import DeviceDescriptor
 
 log = logging.getLogger(__name__)
-control_command_log = logging.getLogger("steuve_control_command")
 
 
 class DimmingLoadManager(AbstractIoAction):
     def __init__(self, config: LoadManagerSetup):
         self.config = config
         self.import_power_left = None
-        control_command_log.info("Begrenzung per Lastmanager.")
         super().__init__()
 
     def setup(self) -> None:
         if check_fault_state_io_device(self.config.configuration.io_device):
             max_power = self.config.configuration.max_power_on_failure
+            max_current = self.config.configuration.max_current_on_failure
         else:
             max_power = data.data.io_states[f"io_states{self.config.configuration.io_device}"
                                             ].data.get.analog_input[AnalogInputMapping.MAX_POWER.name]
+            max_current = data.data.io_states[f"io_states{self.config.configuration.io_device}"
+                                              ].data.get.analog_input[AnalogInputMapping.MAX_CURRENT.name]
         self.import_power_left = max_power
+
+        # Wie verrechne ich power und current?
 
     def loadmanager_get_import_power_left(self) -> Tuple[Optional[float], LoadmanagementLimit]:
         if check_fault_state_io_device(self.config.configuration.io_device):

--- a/packages/modules/io_actions/controllable_consumers/load_manager/config.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/config.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+from dataclass_utils.factories import empty_io_pattern_boolean_factory, empty_list_factory
+from modules.io_actions.groups import ActionGroup
+
+
+@dataclass
+class LoadManagerConfig:
+    io_device: Optional[int] = None
+    input_pattern: List[Dict] = field(default_factory=empty_io_pattern_boolean_factory)
+    devices: List[Dict] = field(default_factory=empty_list_factory)
+    # [{"type": "cp", "id": 0},
+    # {"type": "io", "id": 1, "digital_output": "SofortLa"}]
+    max_import_power: int = 0
+    fixed_import_power: float = 0  # don't show in UI
+
+
+class LoadManagerSetup:
+    def __init__(self,
+                 name: str = "Dimmen per Loadmanager",
+                 type: str = "load_manager",
+                 id: int = 0,
+                 configuration: LoadManagerConfig = None):
+        self.name = name
+        self.id = id
+        self.configuration = configuration or LoadManagerConfig()
+        self.type = type
+        self.group = ActionGroup.CONTROLLABLE_CONSUMERS.value

--- a/packages/modules/io_actions/controllable_consumers/load_manager/config.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/config.py
@@ -13,6 +13,7 @@ class LoadManagerConfig:
     # {"type": "io", "id": 1, "digital_output": "SofortLa"}]
     max_import_power: int = 0
     max_power_on_failure: float = 0
+    max_current_on_failure: float = 0
 
 
 class LoadManagerSetup:

--- a/packages/modules/io_actions/controllable_consumers/load_manager/config.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/config.py
@@ -12,12 +12,12 @@ class LoadManagerConfig:
     # [{"type": "cp", "id": 0},
     # {"type": "io", "id": 1, "digital_output": "SofortLa"}]
     max_import_power: int = 0
-    fixed_import_power: float = 0  # don't show in UI
+    max_power_on_failure: float = 0
 
 
 class LoadManagerSetup:
     def __init__(self,
-                 name: str = "Dimmen per Loadmanager",
+                 name: str = "Begrenzung per Lastmanager",
                  type: str = "load_manager",
                  id: int = 0,
                  configuration: LoadManagerConfig = None):

--- a/packages/modules/io_actions/controllable_consumers/load_manager/config.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/config.py
@@ -8,9 +8,7 @@ from modules.io_actions.groups import ActionGroup
 class LoadManagerConfig:
     io_device: Optional[int] = None
     input_pattern: List[Dict] = field(default_factory=empty_io_pattern_boolean_factory)
-    devices: List[Dict] = field(default_factory=empty_list_factory)
-    # [{"type": "cp", "id": 0},
-    # {"type": "io", "id": 1, "digital_output": "SofortLa"}]
+
     max_import_power: int = 0
     max_power_on_failure: float = 0
     max_current_on_failure: float = 0

--- a/packages/modules/io_actions/controllable_consumers/load_manager/config.py
+++ b/packages/modules/io_actions/controllable_consumers/load_manager/config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
-from dataclass_utils.factories import empty_io_pattern_boolean_factory, empty_list_factory
+from dataclass_utils.factories import empty_io_pattern_boolean_factory
 from modules.io_actions.groups import ActionGroup
 
 

--- a/packages/modules/io_devices/load_manager/api.py
+++ b/packages/modules/io_devices/load_manager/api.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from helpermodules import timecheck
 from helpermodules.broker import BrokerClient
 from helpermodules.utils.topic_parser import decode_payload
 from modules.common.abstract_device import DeviceDescriptor
@@ -29,9 +30,16 @@ def create_io(config: LoadManager):
 
         if received_topics.get("openWB/mqtt/loadmanager/set/loadmanager"):
             payload = received_topics["openWB/mqtt/loadmanager/set/loadmanager"]
+
+            timestamp = float(payload["timestamp"])
+            if timestamp > 1e10:
+                timestamp /= 1000
+            if timecheck.create_timestamp() - timestamp > 60:
+                raise Exception(f"Lastmanager-Daten sind veraltet (Timestamp: {timestamp}).")
+
             io_state.analog_input.update({AnalogInputMapping.MAX_POWER.name: payload["max_power"]})
             io_state.analog_input.update({AnalogInputMapping.MAX_CURRENT.name: payload["max_current"]})
-            io_state.analog_input.update({AnalogInputMapping.TIMESTAMP.name: payload["timestamp"]})
+            io_state.analog_input.update({AnalogInputMapping.TIMESTAMP.name: timestamp})
         return io_state
 
     def initializer():

--- a/packages/modules/io_devices/load_manager/api.py
+++ b/packages/modules/io_devices/load_manager/api.py
@@ -34,8 +34,11 @@ def create_io(config: LoadManager):
             timestamp = float(payload["timestamp"])
             if timestamp > 1e10:
                 timestamp /= 1000
-            if timecheck.create_timestamp() - timestamp > 60:
-                raise Exception(f"Lastmanager-Daten sind veraltet (Timestamp: {timestamp}).")
+            age_s = timecheck.create_timestamp() - timestamp
+            # < = deaktiviert
+            if age_s < 60:
+                log.warning("Lastmanager-Daten veraltet: age=%.1fs, timestamp=%s", age_s, timestamp)
+                raise RuntimeError(f"Lastmanager-Daten sind veraltet: age={age_s:.1f}s, timestamp={timestamp}.")
 
             io_state.analog_input.update({AnalogInputMapping.MAX_POWER.name: payload["max_power"]})
             io_state.analog_input.update({AnalogInputMapping.MAX_CURRENT.name: payload["max_current"]})

--- a/packages/modules/io_devices/load_manager/api.py
+++ b/packages/modules/io_devices/load_manager/api.py
@@ -17,7 +17,6 @@ control_command_log = logging.getLogger("steuve_control_command")
 def create_io(config: LoadManager):
     received_topics = {}
     broker = None
-    thread_exception = None  # Shared state für Thread-Exceptions
 
     def read():
         broker.start_finite_loop()

--- a/packages/modules/io_devices/load_manager/api.py
+++ b/packages/modules/io_devices/load_manager/api.py
@@ -20,10 +20,6 @@ def create_io(config: LoadManager):
     thread_exception = None  # Shared state für Thread-Exceptions
 
     def read():
-        nonlocal broker
-        nonlocal received_topics
-        nonlocal thread_exception
-
         broker.start_finite_loop()
         log.debug(f"Empfange MQTT Daten für LoadManager {config.id}: {received_topics}")
         io_state = IoState()

--- a/packages/modules/io_devices/load_manager/api.py
+++ b/packages/modules/io_devices/load_manager/api.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import logging
+
+from helpermodules.broker import BrokerClient
+from helpermodules.utils.topic_parser import decode_payload
+from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_state import IoState
+from modules.common.configurable_io import ConfigurableIo
+from modules.io_devices.load_manager.config import AnalogInputMapping
+from modules.io_devices.load_manager.config import LoadManager
+
+log = logging.getLogger(__name__)
+control_command_log = logging.getLogger("steuve_control_command")
+
+
+def create_io(config: LoadManager):
+    received_topics = {}
+    broker = None
+    thread_exception = None  # Shared state für Thread-Exceptions
+
+    def read():
+        nonlocal broker
+        nonlocal received_topics
+        nonlocal thread_exception
+
+        broker.start_finite_loop()
+        log.debug(f"Empfange MQTT Daten für LoadManager {config.id}: {received_topics}")
+        io_state = IoState()
+        io_state.analog_input = getattr(io_state, "analog_input", None) or {}
+        io_state.analog_output = getattr(io_state, "analog_output", None) or {}
+        io_state.digital_input = getattr(io_state, "digital_input", None) or {}
+        io_state.digital_output = getattr(io_state, "digital_output", None) or {}
+
+        if received_topics.get("openWB/mqtt/loadmanager/set/loadmanager"):
+            payload = received_topics["openWB/mqtt/loadmanager/set/loadmanager"]
+            io_state.analog_input.update({AnalogInputMapping.MAX_POWER.name: payload["max_power"]})
+            io_state.analog_input.update({AnalogInputMapping.MAX_CURRENT.name: payload["max_current"]})
+            io_state.analog_input.update({AnalogInputMapping.TIMESTAMP.name: payload["timestamp"]})
+        return io_state
+
+    def initializer():
+        nonlocal broker
+        nonlocal received_topics
+
+        def on_connect(client, userdata, flags, rc):
+            client.subscribe("openWB/mqtt/loadmanager/#")
+
+        def on_message(client, userdata, message):
+            received_topics.update({message.topic: decode_payload(message.payload)})
+
+        received_topics = {}
+        broker = BrokerClient("subscribeMqttLoadmanager",
+                              on_connect, on_message)
+
+    return ConfigurableIo(config=config, component_reader=read, component_writer=lambda: None, initializer=initializer)
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=LoadManager)

--- a/packages/modules/io_devices/load_manager/api.py
+++ b/packages/modules/io_devices/load_manager/api.py
@@ -28,16 +28,13 @@ def create_io(config: LoadManager):
         io_state.digital_input = getattr(io_state, "digital_input", None) or {}
         io_state.digital_output = getattr(io_state, "digital_output", None) or {}
 
-        if received_topics.get("openWB/mqtt/loadmanager/set/loadmanager"):
-            payload = received_topics["openWB/mqtt/loadmanager/set/loadmanager"]
+        if received_topics.get(f"openWB/mqtt/loadmanager/{config.id}/set/loadmanager"):
+            payload = received_topics[f"openWB/mqtt/loadmanager/{config.id}/set/loadmanager"]
 
             timestamp = float(payload["timestamp"])
-            if timestamp > 1e10:
-                timestamp /= 1000
             age_s = timecheck.create_timestamp() - timestamp
             # < = deaktiviert
-            if age_s < 60:
-                log.warning("Lastmanager-Daten veraltet: age=%.1fs, timestamp=%s", age_s, timestamp)
+            if age_s > 60:
                 raise RuntimeError(f"Lastmanager-Daten sind veraltet: age={age_s:.1f}s, timestamp={timestamp}.")
 
             io_state.analog_input.update({AnalogInputMapping.MAX_POWER.name: payload["max_power"]})
@@ -50,7 +47,7 @@ def create_io(config: LoadManager):
         nonlocal received_topics
 
         def on_connect(client, userdata, flags, rc):
-            client.subscribe("openWB/mqtt/loadmanager/#")
+            client.subscribe(f"openWB/mqtt/loadmanager/{config.id}/#")
 
         def on_message(client, userdata, message):
             received_topics.update({message.topic: decode_payload(message.payload)})

--- a/packages/modules/io_devices/load_manager/api.py
+++ b/packages/modules/io_devices/load_manager/api.py
@@ -20,7 +20,7 @@ def create_io(config: LoadManager):
 
     def read():
         broker.start_finite_loop()
-        log.debug(f"Empfange MQTT Daten für LoadManager {config.id}: {received_topics}")
+        log.debug(f"Empfange MQTT Daten für Lastmanager {config.id}: {received_topics}")
         io_state = IoState()
         io_state.analog_input = getattr(io_state, "analog_input", None) or {}
         io_state.analog_output = getattr(io_state, "analog_output", None) or {}

--- a/packages/modules/io_devices/load_manager/config.py
+++ b/packages/modules/io_devices/load_manager/config.py
@@ -1,0 +1,41 @@
+from enum import Enum
+from typing import Dict, Union
+from modules.common.io_setup import IoDeviceSetup
+
+
+class AnalogInputMapping(Enum):
+    MAX_POWER = "max_power"
+    MAX_CURRENT = "max_current"
+    TIMESTAMP = "timestamp"
+
+
+class LoadManagerConfiguration:
+    def __init__(self) -> None:
+        pass
+
+
+def init_input():
+    return {"analog": {pin.name: None for pin in AnalogInputMapping}}
+
+
+def init_output():
+    return {"analog": {}}
+
+
+class LoadManager(IoDeviceSetup[LoadManagerConfiguration]):
+    def __init__(self,
+                 name: str = "OpenWB LoadManager",
+                 type: str = "load_manager",
+                 id: Union[int, str] = 0,
+                 configuration: LoadManagerConfiguration = None,
+                 input: Dict[str, Dict[int, float]] = None,
+                 output: Dict[str, Dict[int, float]] = None) -> None:
+        self.name = name
+        self.type = type
+        self.id = id
+        self.configuration = configuration or LoadManagerConfiguration()
+        if input is None:
+            input = init_input()
+        if output is None:
+            output = init_output()
+        super().__init__(name, type, id, configuration or LoadManagerConfiguration(), input=input, output=output)

--- a/packages/modules/io_devices/load_manager/config.py
+++ b/packages/modules/io_devices/load_manager/config.py
@@ -24,7 +24,7 @@ def init_output():
 
 class LoadManager(IoDeviceSetup[LoadManagerConfiguration]):
     def __init__(self,
-                 name: str = "OpenWB LoadManager",
+                 name: str = "openWB Lastmanager",
                  type: str = "load_manager",
                  id: Union[int, str] = 0,
                  configuration: LoadManagerConfiguration = None,


### PR DESCRIPTION
https://github.com/openWB/openwb-ui-settings/pull/1007

## Aufbau

### GUI

* Eingabe der maximalen Bezugsleistung im Fehlerfall
* Eingabe des maximal zulässigen Stroms (Ampere) im Fehlerfall
* Auswahl der zu verwendenden Ladepunkte

### MQTT-Topic

`openWB/set/mqtt/loadmanager/set/{id}/loadmanager`

### Beispiel-Payload

```json
{
  "max_power": 1000,
  "max_current": [6, 6, 6],
  "timestamp": 1783596593.635847
}
```

## Funktionsweise

### Lastmanagement

Der Lastmanager berechnet die verbleibend verfügbare Leistung und den maximal zulässigen Strom.

Dabei erfolgt die Begrenzung in folgender Reihenfolge:

1. Prüfung der Leistungsgrenze (über MQTT vorgegeben `max_power`).

   * Ist die Grenze erreicht oder überschritten, wird die Leistung entsprechend reduziert.

2. Prüfung der Stromgrenze (über MQTT vorgegeben `max_current`).

   * Ist die Grenze erreicht oder überschritten, wird der Strom entsprechend reduziert.
   
4. Sind weder Leistungs- noch Stromgrenze erreicht, wird keine Reduzierung durchgeführt.

### Fehlerfall

Wenn der `timestamp` älter als 60 Sekunden ist:

* Es wird eine `RuntimeError` ausgelöst.
* Es werden die konfigurierte maximale Bezugsleistung und die maximalen Amperewerte für den Fehlerfall verwendet.
