### PR TITLE
Consumer cards in carousel - small screen mobile view

### DIFF
--- a/packages/modules/web_themes/koala/source/src/components/ConsumerCard.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ConsumerCard.vue
@@ -148,7 +148,8 @@ const onOff = computed({
 
 <style scoped lang="scss">
 .card-width {
-  width: 100%;
+  width: 22em;
+  max-width: 100%;
   border: none;
   border-left: 4px solid var(--q-consumer);
   border-radius: 15px;

--- a/packages/modules/web_themes/koala/source/src/components/ConsumerInformation.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ConsumerInformation.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="consumer-grid-wrapper">
+  <BaseCarousel v-if="smallScreen" :items="consumerIds">
+    <template #item="{ item }">
+      <ConsumerCard :consumer-id="item" full-height />
+    </template>
+  </BaseCarousel>
+
+  <div v-else class="consumer-grid-wrapper">
     <div class="consumer-grid">
       <ConsumerCard
         v-for="item in consumerIds"
@@ -13,13 +19,19 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useQuasar } from 'quasar';
 import { useMqttStore } from 'src/stores/mqtt-store';
 
+import BaseCarousel from 'src/components/BaseCarousel.vue';
 import ConsumerCard from 'src/components/ConsumerCard.vue';
+
+const $q = useQuasar();
 
 const mqttStore = useMqttStore();
 
 const consumerIds = computed(() => mqttStore.consumerIds);
+
+const smallScreen = computed(() => $q.screen.width < 700);
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
Auf mobilen Geräten und bei kleinen Bildschirmgrößen werden die Verbraucherkarten in einem Karussell dargestellt, sodass der Benutzer zwischen ihnen seitlich wischen kann. Auf Desktop-Geräten werden die Karten hingegen umbrochen, sodass möglichst viele Karten im verfügbaren Platz angezeigt werden können.