### PR TITLE
Feature local consumption counter

### DIFF
--- a/data/config/mosquitto/public/default-dynamic-security.json
+++ b/data/config/mosquitto/public/default-dynamic-security.json
@@ -1476,6 +1476,12 @@
 					"topic": "openWB/system/configurable/devices_components",
 					"priority": 0,
 					"allow": true
+				},
+				{
+					"acltype": "publishClientReceive",
+					"topic": "openWB/chargepoint/+/config",
+					"priority": 0,
+					"allow": true
 				}
 			]
 		},

--- a/packages/modules/common/sdm.py
+++ b/packages/modules/common/sdm.py
@@ -50,20 +50,22 @@ class Sdm630_72(Sdm):
         (SdmRegister.EXPORTED, ModbusDataType.FLOAT_32),
     )
 
-    def __init__(self, modbus_id: int, client: modbus.ModbusTcpClient_, fault_state: FaultState) -> None:
+    def __init__(self, modbus_id: int, client: modbus.ModbusTcpClient_, fault_state: FaultState,
+                 silent_interval: float = 0.1) -> None:
         super().__init__(modbus_id, client)
         self.fault_state = fault_state
+        self.silent_interval = silent_interval
 
     def get_power(self) -> Tuple[List[float], float]:
         # smarthome legacy
-        time.sleep(0.1)
+        time.sleep(self.silent_interval)
         powers = self.client.read_input_registers(0x0C, [ModbusDataType.FLOAT_32]*3, unit=self.id)
         power = sum(powers)
         return powers, power
 
     def get_voltages(self) -> List[float]:
         # client handler
-        time.sleep(0.1)
+        time.sleep(self.silent_interval)
         return self.client.read_input_registers(0x00, [ModbusDataType.FLOAT_32]*3, unit=self.id)
 
     def get_counter_state(self) -> CounterState:
@@ -71,13 +73,13 @@ class Sdm630_72(Sdm):
         # manche können auch nur 10
         if self.fast_mode:
             try:
-                time.sleep(0.1)
+                time.sleep(self.silent_interval)
                 bulk_1 = self.client.read_input_registers_bulk(
                     SdmRegister.VOLTAGE_L1, 18, mapping=self.REG_MAPPING_BULK_1, unit=self.id)
-                time.sleep(0.1)
+                time.sleep(self.silent_interval)
                 power_factors = self.client.read_input_registers(
                     SdmRegister.POWER_FACTOR_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-                time.sleep(0.1)
+                time.sleep(self.silent_interval)
                 bulk_2 = self.client.read_input_registers_bulk(
                     SdmRegister.FREQUENCY, 6, mapping=self.REG_MAPPING_BULK_2, unit=self.id)
                 resp = {**bulk_1, **bulk_2}
@@ -90,23 +92,23 @@ class Sdm630_72(Sdm):
             # im gleichen Durchlauf noch im slow mode versuchen, sonst schlägt der Hardware-Check fehl
             log.debug("Auslesung des Zählers im Kompatibilitäts-Modus")
             resp = {}
-            time.sleep(0.1)
+            time.sleep(self.silent_interval)
             resp[SdmRegister.VOLTAGE_L1] = self.client.read_input_registers(
                 SdmRegister.VOLTAGE_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-            time.sleep(0.1)
+            time.sleep(self.silent_interval)
             resp[SdmRegister.CURRENT_L1] = self.client.read_input_registers(
                 SdmRegister.CURRENT_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-            time.sleep(0.1)
+            time.sleep(self.silent_interval)
             resp[SdmRegister.POWER_L1] = self.client.read_input_registers(
                 SdmRegister.POWER_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-            time.sleep(0.1)
+            time.sleep(self.silent_interval)
             power_factors = self.client.read_input_registers(
                 SdmRegister.POWER_FACTOR_L1, [ModbusDataType.FLOAT_32]*3, unit=self.id)
-            time.sleep(0.1)
+            time.sleep(self.silent_interval)
             # frequency noch mit auslesen klappt nicht
             resp[SdmRegister.IMPORTED], resp[SdmRegister.EXPORTED] = self.client.read_input_registers(
                 SdmRegister.IMPORTED, [ModbusDataType.FLOAT_32]*2, unit=self.id)
-            time.sleep(0.1)
+            time.sleep(self.silent_interval)
             resp[SdmRegister.FREQUENCY] = self.client.read_input_registers(
                 SdmRegister.FREQUENCY, ModbusDataType.FLOAT_32, unit=self.id)
 

--- a/packages/modules/common/serial_modbus_devices.py
+++ b/packages/modules/common/serial_modbus_devices.py
@@ -1,0 +1,16 @@
+import logging
+from pathlib import Path
+
+
+log = logging.getLogger(__name__)
+
+BUS_SOURCES = ("/dev/ttyUSB0", "/dev/ttyUSB1", "/dev/ttyACM0", "/dev/serial0")
+
+
+def get_serial_modbus_devices():
+    tty_devices = list(Path("/dev/serial/by-path").glob("*"))
+    log.debug("tty_devices"+str(tty_devices))
+    resolved_devices = [str(file.resolve()) for file in tty_devices]
+    log.debug("resolved_devices"+str(resolved_devices))
+    counter = len(resolved_devices)
+    return resolved_devices, counter

--- a/packages/modules/devices/elgris/elgris/elgris.py
+++ b/packages/modules/devices/elgris/elgris/elgris.py
@@ -10,3 +10,4 @@ class Elgris(Sdm630_72):
         self.serial_number = ""
         self.fault_state = fault_state
         self.fast_mode = True
+        self.silent_interval = 0.1

--- a/packages/modules/devices/openwb/openwb_flex_local/config.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/config.py
@@ -1,19 +1,10 @@
 from ..vendor import vendor_descriptor
 from modules.common.component_setup import ComponentSetup
-from modules.common.serial_modbus_devices import get_serial_modbus_devices, BUS_SOURCES
-import logging
-log = logging.getLogger(__name__)
 
 
 class FlexLocalConfiguration:
     def __init__(self) -> None:
-        device, count = get_serial_modbus_devices()
-        if count == 1 and device[0] in BUS_SOURCES:
-            self.port = device[0]
-            log.debug(f"Verbrauchszähler mit lokaler Auslesung nutzt Port {self.port}")
-        else:
-            self.port = "UNKNOWN"
-            log.debug(f"Verbrauchszähler mit lokaler Auslesung konnte Port nicht ermitteln, gefundene Ports: {device}")
+        pass
 
 
 class FlexLocalSetup:

--- a/packages/modules/devices/openwb/openwb_flex_local/config.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/config.py
@@ -1,10 +1,19 @@
-from modules.common.component_setup import ComponentSetup
 from ..vendor import vendor_descriptor
+from modules.common.component_setup import ComponentSetup
+from modules.common.serial_modbus_devices import get_serial_modbus_devices, BUS_SOURCES
+import logging
+log = logging.getLogger(__name__)
 
 
 class FlexLocalConfiguration:
     def __init__(self) -> None:
-        self.port = '/dev/ttyACM0'
+        device, count = get_serial_modbus_devices()
+        if count == 1 and device[0] in BUS_SOURCES:
+            self.port = device[0]
+            log.debug(f"Verbrauchszähler mit lokaler Auslesung nutzt Port {self.port}")
+        else:
+            self.port = "UNKNOWN"
+            log.debug(f"Verbrauchszähler mit lokaler Auslesung konnte Port nicht ermitteln, gefundene Ports: {device}")
 
 
 class FlexLocalSetup:
@@ -28,7 +37,7 @@ class LocalConsumptionCounterConfiguration:
 
 class LocalConsumptionCounterSetup(ComponentSetup[LocalConsumptionCounterConfiguration]):
     def __init__(self,
-                 name: str = "openWB Lokaler-Verbrauchszähler",
+                 name: str = "openWB Lokaler Verbrauchszähler",
                  type: str = "consumption_counter",
                  id: int = 0,
                  configuration: LocalConsumptionCounterConfiguration = None) -> None:

--- a/packages/modules/devices/openwb/openwb_flex_local/config.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/config.py
@@ -1,0 +1,35 @@
+from modules.common.component_setup import ComponentSetup
+from ..vendor import vendor_descriptor
+
+
+class FlexLocalConfiguration:
+    def __init__(self) -> None:
+        self.port = '/dev/ttyACM0'
+
+
+class FlexLocalSetup:
+    def __init__(self,
+                 name: str = "Verbrauchszähler mit lokaler Auslesung",
+                 type: str = "openwb_flex_local",
+                 id: int = 0,
+                 configuration: FlexLocalConfiguration = None) -> None:
+        self.name = name
+        self.type = type
+        self.vendor = vendor_descriptor.configuration_factory().type
+        self.id = id
+        self.configuration = configuration or FlexLocalConfiguration()
+
+
+class LocalConsumptionCounterConfiguration:
+    def __init__(self, id: int = 1, type: str = "sdm630") -> None:
+        self.id = id
+        self.type = type
+
+
+class LocalConsumptionCounterSetup(ComponentSetup[LocalConsumptionCounterConfiguration]):
+    def __init__(self,
+                 name: str = "openWB Lokaler-Verbrauchszähler",
+                 type: str = "consumption_counter",
+                 id: int = 0,
+                 configuration: LocalConsumptionCounterConfiguration = None) -> None:
+        super().__init__(name, type, id, configuration or LocalConsumptionCounterConfiguration())

--- a/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from typing import TypedDict, Any
+
+from modules.common import modbus
+from modules.common.abstract_device import AbstractCounter
+from modules.common.component_type import ComponentDescriptor
+from modules.common.fault_state import ComponentInfo, FaultState
+from modules.common.simcount import SimCounter
+from modules.common.store import get_counter_value_store
+from modules.devices.openwb.openwb_flex_local.config import LocalConsumptionCounterSetup
+from modules.devices.openwb.openwb_flex_local.versions import consumption_counter_factory
+
+
+class KwargsDict(TypedDict):
+    device_id: int
+    client: modbus.ModbusSerialClient_
+
+
+class LocalConsumptionCounter(AbstractCounter):
+    def __init__(self, component_config: LocalConsumptionCounterSetup, **kwargs: Any) -> None:
+        self.component_config = component_config
+        self.kwargs: KwargsDict = kwargs
+
+    def initialize(self) -> None:
+        self.__device_id: int = self.kwargs['device_id']
+        self.__serial_client: modbus.ModbusSerialClient_ = self.kwargs['client']
+        factory = consumption_counter_factory(self.component_config.configuration.type)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
+        if self.component_config.configuration.type == "sdm630":
+            self.__client = factory(self.component_config.configuration.id, self.__serial_client,
+                                    self.fault_state, silent_interval=0.06)
+        else:
+            self.__client = factory(self.component_config.configuration.id, self.__serial_client, self.fault_state)
+        self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
+        self.store = get_counter_value_store(self.component_config.id)
+        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
+
+    def update(self) -> None:
+        with self.__serial_client:
+            counter_state = self.__client.get_counter_state()
+            if self.component_config.configuration.type == "b23":
+                counter_state.exported = self.__client.get_exported()
+            else:
+                counter_state.exported = 0
+
+        self.store.set(counter_state)
+
+
+component_descriptor = ComponentDescriptor(configuration_factory=LocalConsumptionCounterSetup)

--- a/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
@@ -6,7 +6,7 @@ from modules.common.abstract_device import AbstractCounter
 from modules.common.component_type import ComponentDescriptor
 from modules.common.fault_state import ComponentInfo, FaultState
 from modules.common.simcount import SimCounter
-from modules.common.store import get_counter_value_store
+from modules.common.store import get_component_value_store
 from modules.devices.openwb.openwb_flex_local.config import LocalConsumptionCounterSetup
 from modules.devices.openwb.openwb_flex_local.versions import consumption_counter_factory
 
@@ -32,7 +32,7 @@ class LocalConsumptionCounter(AbstractCounter):
         else:
             self.__client = factory(self.component_config.configuration.id, self.__serial_client, self.fault_state)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.store = get_counter_value_store(self.component_config.id)
+        self.store = get_component_value_store(self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:

--- a/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
@@ -23,6 +23,10 @@ class LocalConsumptionCounter(AbstractCounter):
 
     def initialize(self) -> None:
         self.__device_id: int = self.kwargs['device_id']
+
+        if self.kwargs['client'] is None:
+            raise Exception("Verbrauchszähler mit lokaler Auslesung konnte Port nicht ermitteln, ")
+
         self.__serial_client: modbus.ModbusSerialClient_ = self.kwargs['client']
         factory = consumption_counter_factory(self.component_config.configuration.type)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
@@ -33,7 +37,6 @@ class LocalConsumptionCounter(AbstractCounter):
             self.__client = factory(self.component_config.configuration.id, self.__serial_client, self.fault_state)
         self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
         self.store = get_component_value_store(self.component_config.id)
-        self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
 
     def update(self) -> None:
         with self.__serial_client:

--- a/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
@@ -25,7 +25,7 @@ class LocalConsumptionCounter(AbstractCounter):
         self.__device_id: int = self.kwargs['device_id']
 
         if self.kwargs['client'] is None:
-            raise Exception("Verbrauchszähler mit lokaler Auslesung konnte Port nicht ermitteln, ")
+            raise Exception("USB-Adapter für die lokale Auslesung unbekannt oder nicht eingesteckt.")
 
         self.__serial_client: modbus.ModbusSerialClient_ = self.kwargs['client']
         factory = consumption_counter_factory(self.component_config.configuration.type)

--- a/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/consumption_counter.py
@@ -35,8 +35,8 @@ class LocalConsumptionCounter(AbstractCounter):
                                     self.fault_state, silent_interval=0.06)
         else:
             self.__client = factory(self.component_config.configuration.id, self.__serial_client, self.fault_state)
-        self.sim_counter = SimCounter(self.__device_id, self.component_config.id, prefix="bezug")
-        self.store = get_component_value_store(self.component_config.id)
+        self.sim_counter = SimCounter(self.__device_id, self.component_config.id, self.component_config.type)
+        self.store = get_component_value_store(self.component_config.type, self.component_config.id)
 
     def update(self) -> None:
         with self.__serial_client:

--- a/packages/modules/devices/openwb/openwb_flex_local/device.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/device.py
@@ -8,6 +8,7 @@ from modules.common.configurable_device import ConfigurableDevice, ComponentFact
 from modules.common.modbus import ModbusSerialClient_
 from modules.devices.openwb.openwb_flex_local.config import FlexLocalSetup, LocalConsumptionCounterSetup
 from modules.devices.openwb.openwb_flex_local.consumption_counter import LocalConsumptionCounter
+from modules.common.serial_modbus_devices import get_serial_modbus_devices, BUS_SOURCES
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +26,16 @@ def create_device(device_config: FlexLocalSetup):
 
     def initializer():
         nonlocal client
-        client = ModbusSerialClient_(device_config.configuration.port)
+
+        device, count = get_serial_modbus_devices()
+        if count == 1 and device[0] in BUS_SOURCES:
+            port = device[0]
+            log.debug(f"Verbrauchszähler mit lokaler Auslesung nutzt Port {port}")
+        else:
+            port = "UNKNOWN"
+            log.debug(f"Verbrauchszähler mit lokaler Auslesung konnte Port nicht ermitteln, gefundene Ports: {device}")
+
+        client = ModbusSerialClient_(port)
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/openwb/openwb_flex_local/device.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/device.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from helpermodules.utils.run_command import run_command
+from modules.common.abstract_device import DeviceDescriptor
+from modules.common.component_context import SingleComponentUpdateContext
+from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
+from modules.common.modbus import ModbusSerialClient_
+from modules.devices.openwb.openwb_flex_local.config import FlexLocalSetup, LocalConsumptionCounterSetup
+from modules.devices.openwb.openwb_flex_local.consumption_counter import LocalConsumptionCounter
+
+log = logging.getLogger(__name__)
+
+
+def create_device(device_config: FlexLocalSetup):
+    client = None
+
+    def create_consumption_counter_component(component_config: LocalConsumptionCounterSetup):
+        return LocalConsumptionCounter(component_config, device_id=device_config.id, client=client)
+
+    def update_components(components: Iterable[LocalConsumptionCounter]):
+        for component in components:
+            with SingleComponentUpdateContext(component.fault_state):
+                component.update()
+
+    def initializer():
+        nonlocal client
+        client = ModbusSerialClient_(device_config.configuration.port)
+
+    def error_handler():
+        run_command([f"{Path(__file__).resolve().parents[4]}/modules/common/restart_protoss_admin"])
+
+    return ConfigurableDevice(
+        device_config=device_config,
+        initializer=initializer,
+        error_handler=error_handler,
+        component_factory=ComponentFactoryByType(
+            consumption_counter=create_consumption_counter_component,
+        ),
+        component_updater=MultiComponentUpdater(update_components)
+    )
+
+
+device_descriptor = DeviceDescriptor(configuration_factory=FlexLocalSetup)

--- a/packages/modules/devices/openwb/openwb_flex_local/device.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/device.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 import logging
-from pathlib import Path
 from typing import Iterable
 
-from helpermodules.utils.run_command import run_command
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_context import SingleComponentUpdateContext
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
@@ -29,13 +27,9 @@ def create_device(device_config: FlexLocalSetup):
         nonlocal client
         client = ModbusSerialClient_(device_config.configuration.port)
 
-    def error_handler():
-        run_command([f"{Path(__file__).resolve().parents[4]}/modules/common/restart_protoss_admin"])
-
     return ConfigurableDevice(
         device_config=device_config,
         initializer=initializer,
-        error_handler=error_handler,
         component_factory=ComponentFactoryByType(
             consumption_counter=create_consumption_counter_component,
         ),

--- a/packages/modules/devices/openwb/openwb_flex_local/device.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/device.py
@@ -31,11 +31,11 @@ def create_device(device_config: FlexLocalSetup):
         if count == 1 and device[0] in BUS_SOURCES:
             port = device[0]
             log.debug(f"Verbrauchszähler mit lokaler Auslesung nutzt Port {port}")
+            client = ModbusSerialClient_(port)
         else:
             port = "UNKNOWN"
             log.debug(f"Verbrauchszähler mit lokaler Auslesung konnte Port nicht ermitteln, gefundene Ports: {device}")
-
-        client = ModbusSerialClient_(port)
+            client = None
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/openwb/openwb_flex_local/device.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/device.py
@@ -48,4 +48,5 @@ def create_device(device_config: FlexLocalSetup):
 
 
 device_descriptor = DeviceDescriptor(configuration_factory=FlexLocalSetup,
-                                     compatibility_device_note="Es können maximal 8 Zähler gleichzeitig ausgelesen werden.")
+                                     compatibility_device_note="Es können maximal 8 Zähler "
+                                     "gleichzeitig ausgelesen werden.")

--- a/packages/modules/devices/openwb/openwb_flex_local/device.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/device.py
@@ -47,4 +47,5 @@ def create_device(device_config: FlexLocalSetup):
     )
 
 
-device_descriptor = DeviceDescriptor(configuration_factory=FlexLocalSetup)
+device_descriptor = DeviceDescriptor(configuration_factory=FlexLocalSetup,
+                                     compatibility_device_note="Es können maximal 8 Zähler gleichzeitig ausgelesen werden.")

--- a/packages/modules/devices/openwb/openwb_flex_local/versions.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/versions.py
@@ -1,0 +1,55 @@
+from typing import Type, Union
+
+from modules.common import b23, lovato
+from modules.common import mpm3pm
+from modules.common import sdm
+
+
+def kit_counter_version_factory(
+        version: int) -> Type[Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm.Sdm630_72, b23.B23]]:
+    if version == 0:
+        return mpm3pm.Mpm3pm
+    elif version == 1:
+        return lovato.Lovato
+    elif version == 2:
+        return sdm.Sdm630_72
+    elif version == 3:
+        return b23.B23
+    else:
+        raise ValueError("Version "+str(version) + " unbekannt.")
+
+
+def kit_inverter_version_factory(
+        version: int) -> Type[Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm.Sdm630_72, sdm.Sdm120]]:
+    if version == 0:
+        return mpm3pm.Mpm3pm
+    elif version == 1:
+        return lovato.Lovato
+    elif version == 2:
+        return sdm.Sdm630_72
+    elif version == 3:
+        return sdm.Sdm120
+    else:
+        raise ValueError("Version "+str(version) + " unbekannt.")
+
+
+def kit_bat_version_factory(version: int) -> Type[Union[mpm3pm.Mpm3pm, sdm.Sdm630_72, sdm.Sdm120]]:
+    if version == 0:
+        return mpm3pm.Mpm3pm
+    elif version == 1:
+        return sdm.Sdm120
+    elif version == 2:
+        return sdm.Sdm630_72
+    else:
+        raise ValueError("Version "+str(version) + " unbekannt.")
+
+
+def consumption_counter_factory(type: str) -> Type[Union[sdm.Sdm120, sdm.Sdm630_72, b23.B23]]:
+    if type == "sdm120":
+        return sdm.Sdm120
+    elif type == "sdm630":
+        return sdm.Sdm630_72
+    elif type == "b23":
+        return b23.B23
+    else:
+        raise ValueError(f"Version {type} unbekannt.")

--- a/packages/modules/devices/openwb/openwb_flex_local/versions.py
+++ b/packages/modules/devices/openwb/openwb_flex_local/versions.py
@@ -1,47 +1,7 @@
 from typing import Type, Union
 
-from modules.common import b23, lovato
-from modules.common import mpm3pm
+from modules.common import b23
 from modules.common import sdm
-
-
-def kit_counter_version_factory(
-        version: int) -> Type[Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm.Sdm630_72, b23.B23]]:
-    if version == 0:
-        return mpm3pm.Mpm3pm
-    elif version == 1:
-        return lovato.Lovato
-    elif version == 2:
-        return sdm.Sdm630_72
-    elif version == 3:
-        return b23.B23
-    else:
-        raise ValueError("Version "+str(version) + " unbekannt.")
-
-
-def kit_inverter_version_factory(
-        version: int) -> Type[Union[mpm3pm.Mpm3pm, lovato.Lovato, sdm.Sdm630_72, sdm.Sdm120]]:
-    if version == 0:
-        return mpm3pm.Mpm3pm
-    elif version == 1:
-        return lovato.Lovato
-    elif version == 2:
-        return sdm.Sdm630_72
-    elif version == 3:
-        return sdm.Sdm120
-    else:
-        raise ValueError("Version "+str(version) + " unbekannt.")
-
-
-def kit_bat_version_factory(version: int) -> Type[Union[mpm3pm.Mpm3pm, sdm.Sdm630_72, sdm.Sdm120]]:
-    if version == 0:
-        return mpm3pm.Mpm3pm
-    elif version == 1:
-        return sdm.Sdm120
-    elif version == 2:
-        return sdm.Sdm630_72
-    else:
-        raise ValueError("Version "+str(version) + " unbekannt.")
 
 
 def consumption_counter_factory(type: str) -> Type[Union[sdm.Sdm120, sdm.Sdm630_72, b23.B23]]:

--- a/packages/modules/internal_chargepoint_handler/clients.py
+++ b/packages/modules/internal_chargepoint_handler/clients.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 from typing import List, NamedTuple, Optional, Tuple, Union
 from helpermodules.logger import ModifyLoglevelContext
 from modules.chargepoints.internal_openwb.config import InternalChargepointMode
@@ -11,10 +10,9 @@ from modules.common import mpm3pm, sdm
 from modules.common import evse
 from modules.common import b23
 
+from modules.common.serial_modbus_devices import get_serial_modbus_devices, BUS_SOURCES
+
 log = logging.getLogger(__name__)
-
-
-BUS_SOURCES = ("/dev/ttyUSB0", "/dev/ttyUSB1", "/dev/ttyACM0", "/dev/serial0")
 
 MeterClient = Union[mpm3pm.Mpm3pm, sdm.Sdm630_72, b23.B23]
 MeterType = Union[type[mpm3pm.Mpm3pm], type[sdm.Sdm630_72], type[b23.B23]]
@@ -115,11 +113,8 @@ def get_modbus_client(mode: InternalChargepointMode,
                       created_client_handler: Optional[ClientHandler] = None,
                       fault_state: Optional[FaultState] = None) -> Tuple[Union[ModbusSerialClient_, ModbusTcpClient_],
                                                                          List[int]]:
-    tty_devices = list(Path("/dev/serial/by-path").glob("*"))
-    log.debug("tty_devices"+str(tty_devices))
-    resolved_devices = [str(file.resolve()) for file in tty_devices]
-    log.debug("resolved_devices"+str(resolved_devices))
-    counter = len(resolved_devices)
+    resolved_devices, counter = get_serial_modbus_devices()
+
     if counter == 0:
         # Wenn kein USB-Gerät gefunden wird, wird der Modbus-Anschluss der AddOn-Platine genutzt (/dev/serial0)
         serial_client = ModbusSerialClient_("/dev/serial0")

--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -32,6 +32,8 @@ class Loadvars:
                 self._update_values_of_level_buttom_top(level, not_finished_threads)
                 wait_for_module_update_completed(self.event_module_update_completed, topic)
                 data.data.copy_module_data()
+
+            self._set_timeout_fault_for_timed_out_device_components(not_finished_threads)
             self._update_values_virtual_counter_uncounted_consumption(not_finished_threads)
             wait_for_module_update_completed(self.event_module_update_completed, topic)
             data.data.copy_module_data()
@@ -61,6 +63,27 @@ class Loadvars:
             except Exception:
                 log.exception(f"Fehler im loadvars-Modul bei Element {cp.num}")
         return joined_thread_handler(modules_threads, data.data.general_data.data.control_interval/3)
+
+    def _set_timeout_fault_for_timed_out_device_components(self, not_finished_threads: List[str]) -> None:
+        """Diese Funktion prüft, ob es Komponenten gibt, die nicht innerhalb des Timeouts abgearbeitet werden konnten und setzt enstsprechend den FaultState."""
+        for item in data.data.system_data.values():
+            if isinstance(item, AbstractDevice):
+                for t in not_finished_threads:
+                    if t == f"device{item.device_config.id}":
+                        for comp in item.components.values():
+                            # Ab hier bin ich in der einer Komponente, die zu einem Gerät gehört, das nicht fertig ist.
+                            module_data = getattr(
+                                data.data, f"{type_to_topic_mapping(comp.component_config.type)}_data")
+                            if module_data[f"{type_to_topic_mapping(comp.component_config.type)}{comp.component_config.id}"].data.get.fault_state == 2:
+                                log.error(f"Fehlerstatus in Komponente {comp.component_config.name}. "
+                                          "Werte werden nicht aktualisiert.")
+                                # Komponente hat bereits einen Faultstate und wird nicht weiter beachtet
+                                continue
+                            else:
+                                # Komponenent hat keinen FaultState -> Faultstate wird gesetzt
+                                comp.fault_state.error(f"nicht alle Komponente des device{item.device_config.id} konnte des innerhalb des Timeouts abgearbeitet werden."
+                                                       f"Daten vom {comp.component_config.name} wurden nicht aktualisiert")
+                                comp.fault_state.store_error()
 
     def _update_values_of_level_buttom_top(self, elements, not_finished_threads: List[str]) -> None:
         """Threads, um von der niedrigsten Ebene der Hierarchie beginnend Werte ggf. miteinander zu verrechnen und zu

--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -65,7 +65,8 @@ class Loadvars:
         return joined_thread_handler(modules_threads, data.data.general_data.data.control_interval/3)
 
     def _set_timeout_fault_for_timed_out_device_components(self, not_finished_threads: List[str]) -> None:
-        """Diese Funktion prüft, ob es Komponenten gibt, die nicht innerhalb des Timeouts abgearbeitet werden konnten und setzt enstsprechend den FaultState."""
+        """Diese Funktion prüft, ob es Komponenten gibt, die nicht innerhalb des Timeouts abgearbeitet werden konnten
+        und setzt enstsprechend den FaultState."""
         for item in data.data.system_data.values():
             if isinstance(item, AbstractDevice):
                 for t in not_finished_threads:
@@ -74,15 +75,19 @@ class Loadvars:
                             # Ab hier bin ich in der einer Komponente, die zu einem Gerät gehört, das nicht fertig ist.
                             module_data = getattr(
                                 data.data, f"{type_to_topic_mapping(comp.component_config.type)}_data")
-                            if module_data[f"{type_to_topic_mapping(comp.component_config.type)}{comp.component_config.id}"].data.get.fault_state == 2:
+                            if module_data[
+                                f"{type_to_topic_mapping(comp.component_config.type)}{comp.component_config.id}"
+                            ].data.get.fault_state == 2:
                                 log.error(f"Fehlerstatus in Komponente {comp.component_config.name}. "
                                           "Werte werden nicht aktualisiert.")
                                 # Komponente hat bereits einen Faultstate und wird nicht weiter beachtet
                                 continue
                             else:
                                 # Komponenent hat keinen FaultState -> Faultstate wird gesetzt
-                                comp.fault_state.error(f"nicht alle Komponente des device{item.device_config.id} konnte des innerhalb des Timeouts abgearbeitet werden."
-                                                       f"Daten vom {comp.component_config.name} wurden nicht aktualisiert")
+                                comp.fault_state.error(f"nicht alle Komponente des device{item.device_config.id} "
+                                                       f"konnten innerhalb des Timeouts abgearbeitet werden."
+                                                       f"Daten vom {comp.component_config.name}"
+                                                       "werden nicht aktualisiert")
                                 comp.fault_state.store_error()
 
     def _update_values_of_level_buttom_top(self, elements, not_finished_threads: List[str]) -> None:

--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -85,8 +85,8 @@ class Loadvars:
                             else:
                                 # Komponenent hat keinen FaultState -> Faultstate wird gesetzt
                                 comp.fault_state.error(f"nicht alle Komponente des device{item.device_config.id} "
-                                                       f"konnten innerhalb des Timeouts abgearbeitet werden."
-                                                       f"Daten vom {comp.component_config.name}"
+                                                       f"konnten innerhalb des Timeouts abgearbeitet werden. "
+                                                       f"Daten vom {comp.component_config.name} "
                                                        "werden nicht aktualisiert")
                                 comp.fault_state.store_error()
 


### PR DESCRIPTION
https://github.com/openWB/openwb-ui-settings/pull/1013

Damit die Github check-action durchläuft, muss ein Test angepasst werden:
https://github.com/openWB/core/pull/3662

## Aufbau
### Neues Gerät
- Fügt das neue Gerät: `Verbrauchszähler mit lokaler Auslegung` hinzu.
### Neue Komponente
- Fügt die Komponente `openWB Lokaler Verbrauchszähler` hinzu.
## GUI
### Gerät
- Keine Konfigurationsmöglichkeiten.
- Der verwendete USB-Port wird fest im Code gesetzt.
### Komponente
- Das Zählermodell ist fest vorgegeben, da derzeit nur der `SDM630_72` unterstützt wird.
- Die Modbus-ID muss konfiguriert werden.
## Funktionsweise
Die Implementierung orientiert sich am bestehenden ConsumptionCounter aus openwb_flex.

### Unterschiede:
- Die Modbus-Kommunikation erfolgt seriell statt über TCP.
- Das silent_interval ist konfigurierbar.

### Silent_Intervall
- ConsumptionCounter (openwb_flex): Standardwert `0.1`
- Lokaler ConsumptionCounter: Standardwert `0.06`

## Testergebnisse

Getestet mit einem realen Aufbau aus 10 Zählern.

### `silent_interval = 0.06` (60 ms)

* Auslesen von 10 Zählern: funktioniert nicht
  * `device2` konnte nicht innerhalb des konfigurierten Timeouts abgearbeitet werden.
* Auslesen von 9 Zählern: funktioniert sporadisch
* Auslesen von 8 Zählern: funktioniert zuverlässig

### `silent_interval = 0.03` (30 ms)

* Auslesen von 10 Zählern: funktioniert zuverlässig

