### PR TITLE
SimpleAPI add bat_power_reserve to API

### DIFF
--- a/simpleAPI/simpleAPI_mqtt.py
+++ b/simpleAPI/simpleAPI_mqtt.py
@@ -567,6 +567,10 @@ class SimpleMQTTDaemon:
                 success = self._handle_bat_mode_operation(payload)
                 if success:
                     self._clear_set_topic(topic)
+            elif operation == 'bat_power_reserve':
+                success = self._handle_bat_power_reserve_operation(payload)
+                if success:
+                    self._clear_set_topic(topic)
             else:
                 log.error(f"Unknown operation: {operation}")
 
@@ -758,6 +762,30 @@ class SimpleMQTTDaemon:
         target_topic = "openWB/set/general/chargemode_config/pv_charging/bat_mode"
         self.client.publish(target_topic, payload, qos=0, retain=True)
         log.info(f"Set bat_mode to {payload}")
+        return True
+
+    def _handle_bat_power_reserve_operation(self, payload: str) -> bool:
+        """Handle battery power reserve operation.
+
+        Sets the power (in Watts) that openWB reserves for the battery
+        during PV surplus charging, before releasing surplus to EV charging.
+        Value 0 = no reservation (equivalent to ev_mode behaviour).
+        Allows external energy managers to do proportional battery/EV sharing
+        without switching bat_mode.
+        """
+        try:
+            watts = int(payload)
+        except ValueError:
+            log.error(f"Invalid bat_power_reserve value: {payload!r}. Must be an integer (Watts).")
+            return False
+
+        if watts < 0:
+            log.error(f"Invalid bat_power_reserve value: {watts}. Must be >= 0.")
+            return False
+
+        target_topic = "openWB/set/general/chargemode_config/pv_charging/bat_power_reserve"
+        self.client.publish(target_topic, watts, qos=0, retain=True)
+        log.info(f"Set bat_power_reserve to {watts}W")
         return True
 
     def _handle_instant_charging_limit_operation(self, payload: str) -> bool:

--- a/simpleAPI/src/ParameterHandler.php
+++ b/simpleAPI/src/ParameterHandler.php
@@ -1537,6 +1537,36 @@ class ParameterHandler
     }
 
     /**
+     * Reservierte Batterie-Ladeleistung setzen (W)
+     * Setzt openWB/set/general/chargemode_config/pv_charging/bat_power_reserve
+     * Ermöglicht externes Energiemanagement der Speicherreservierung ohne UI-Eingriff.
+     */
+    private function setBatPowerReserve($value)
+    {
+        $watts = intval($value);
+
+        if ($watts < 0) {
+            return ['success' => false, 'message' => 'bat_power_reserve must be >= 0'];
+        }
+
+        try {
+            $topic = "openWB/set/general/chargemode_config/pv_charging/bat_power_reserve";
+
+            if ($this->mqttClient->setValue($topic, $watts)) {
+                return [
+                    'success' => true,
+                    'message' => "bat_power_reserve set to {$watts}W",
+                    'data'    => ['bat_power_reserve' => $watts]
+                ];
+            }
+
+            return ['success' => false, 'message' => 'Failed to set bat_power_reserve'];
+        } catch (Exception $e) {
+            return ['success' => false, 'message' => 'Error setting bat_power_reserve: ' . $e->getMessage()];
+        }
+    }
+
+    /**
      * Lese openWB/system/lastlivevaluesJson Topic 1:1 aus
      */
     private function getLastLiveValuesJson()

--- a/simpleAPI/src/ParameterHandler.php
+++ b/simpleAPI/src/ParameterHandler.php
@@ -229,6 +229,8 @@ class ParameterHandler
                     return $this->setChargepointLock($chargepointId, $value);
                 case 'bat_mode':
                     return $this->setBatMode($value);
+                case 'bat_power_reserve':
+                    return $this->setBatPowerReserve($value);
                 case 'instant_charging_limit':
                     return $this->setInstantChargingLimit($chargepointId, $value);
                 case 'instant_charging_amount':


### PR DESCRIPTION
Der bat_mode ist per simpleAPI änderbar, aber leider nicht die reservierte Ladeleistung für den Speicher im min_soc_bat_mode, mit dem PR würde man hier für externe Steuerung ohne UI Eingriff mehr Möglichkeiten haben um besser zu steuern bei Peakshaving z.B. bzw externer Logik.