### PR TITLE
fix 1p3p phase switch

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -830,7 +830,8 @@ class Chargepoint(ChargepointRfidMixin):
                 "Keine Phasenumschaltung, da die maximale Anzahl an Fehlversuchen erreicht wurde. ")
             return True
         elif (data.data.general_data.data.chargemode_config.pv_charging.retry_failed_phase_switches is False and
-              self.data.set.log.imported_since_plugged != 0):
+              (self.data.control_parameter.failed_phase_switches > 0 or
+              self.data.set.log.imported_since_plugged != 0)):
             # vor Ladestart trotzdem umschalten
             return True
         else:

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -830,9 +830,7 @@ class Chargepoint(ChargepointRfidMixin):
                 "Keine Phasenumschaltung, da die maximale Anzahl an Fehlversuchen erreicht wurde. ")
             return True
         elif (data.data.general_data.data.chargemode_config.pv_charging.retry_failed_phase_switches is False and
-              (self.data.control_parameter.failed_phase_switches > 0 or
-              self.data.set.log.imported_since_plugged != 0)):
-            # vor Ladestart trotzdem umschalten
+              self.data.control_parameter.failed_phase_switches > 0):
             return True
         else:
             return False

--- a/packages/control/chargepoint/get_phases_test.py
+++ b/packages/control/chargepoint/get_phases_test.py
@@ -188,7 +188,7 @@ def test_set_phases(monkeypatch, cp: Chargepoint, params: SetPhasesParams):
 )
 def test_hw_supports_phase_switch(cp: Chargepoint,
                                   auto_phase_switch_hw: bool,
-                                  evse_signaling: str,
+                                  evse_signaling: EvseSignaling,
                                   prevent_phase_switch: bool,
                                   imported_since_plugged: float,
                                   expected: bool):
@@ -208,9 +208,9 @@ def test_hw_supports_phase_switch(cp: Chargepoint,
 @pytest.mark.parametrize(
     "retry_failed_phase_switches, failed_phase_switches, expected",
     [
-        pytest.param(True, 3, True, id="retry-enabled-limit-reached"),
-        pytest.param(True, 2, False, id="retry-enabled-at-limit"),
-        pytest.param(False, 1, True, id="retry-disabled-failed"),
+        pytest.param(True, Chargepoint.MAX_FAILED_PHASE_SWITCHES+1, True, id="retry-enabled-limit-reached"),
+        pytest.param(True, Chargepoint.MAX_FAILED_PHASE_SWITCHES, False, id="retry-enabled-at-limit"),
+        pytest.param(False, Chargepoint.MAX_FAILED_PHASE_SWITCHES-1, True, id="retry-disabled-failed"),
         pytest.param(False, 0, False, id="retry-disabled-not-failed"),
     ],
 )

--- a/packages/control/chargepoint/get_phases_test.py
+++ b/packages/control/chargepoint/get_phases_test.py
@@ -4,10 +4,12 @@ from typing import Optional
 import pytest
 
 from control.chargepoint.chargepoint import Chargepoint
+from control.chargepoint.chargepoint_state import ChargepointState
 from control.chargepoint.chargepoint_template import CpTemplate, get_chargepoint_template_default
 from control.ev.ev import Ev
 from control.general import General
 from control import data
+from modules.chargepoints.openwb_pro.chargepoint_module import EvseSignaling
 
 
 @pytest.fixture
@@ -172,3 +174,95 @@ def test_set_phases(monkeypatch, cp: Chargepoint, params: SetPhasesParams):
 
     # evaluation
     assert phases == params.expected_phases
+
+
+@pytest.mark.parametrize(
+       "auto_phase_switch_hw, evse_signaling, prevent_phase_switch, imported_since_plugged, expected",
+       [
+              pytest.param(True, EvseSignaling.PWM, False, 10, True, id="supported-without-prevent-flag"),
+              pytest.param(False, EvseSignaling.PWM, False, 10, False, id="hardware-disabled"),
+              pytest.param(True, EvseSignaling.HLC, False, 10, False, id="hlc-signaling"),
+              pytest.param(True, EvseSignaling.PWM, True, 10, False, id="prevent-phase-switch-after-start"),
+              pytest.param(True, EvseSignaling.PWM, True, 0, True, id="prevent-phase-switch-before-start"),
+       ],
+)
+def test_hw_supports_phase_switch(cp: Chargepoint,
+                                                          auto_phase_switch_hw: bool,
+                                                          evse_signaling: str,
+                                                          prevent_phase_switch: bool,
+                                                          imported_since_plugged: float,
+                                                          expected: bool):
+       # setup
+       cp.data.config.auto_phase_switch_hw = auto_phase_switch_hw
+       cp.data.get.evse_signaling = evse_signaling
+       cp.data.set.charging_ev_data.ev_template.data.prevent_phase_switch = prevent_phase_switch
+       cp.data.set.log.imported_since_plugged = imported_since_plugged
+
+       # execution
+       result = cp.hw_supports_phase_switch()
+
+       # evaluation
+       assert result is expected
+
+
+@pytest.mark.parametrize(
+       "retry_failed_phase_switches, failed_phase_switches, expected",
+       [
+              pytest.param(True, 3, True, id="retry-enabled-limit-reached"),
+              pytest.param(True, 2, False, id="retry-enabled-at-limit"),
+              pytest.param(False, 1, True, id="retry-disabled-failed"),
+              pytest.param(False, 0, False, id="retry-disabled-not-failed"),
+       ],
+)
+def test_failed_phase_switches_reached(cp: Chargepoint,
+                                       retry_failed_phase_switches: bool,
+                                       failed_phase_switches: int,
+                                       expected: bool):
+       # setup
+       data.data.general_data.data.chargemode_config.pv_charging.retry_failed_phase_switches = (
+              retry_failed_phase_switches
+       )
+       cp.data.control_parameter.failed_phase_switches = failed_phase_switches
+
+       # execution
+       result = cp.failed_phase_switches_reached()
+
+       # evaluation
+       assert result is expected
+
+
+@pytest.mark.parametrize(
+       "hw_supports_phase_switch, charge_state, state, failed_phase_switches_reached, expected",
+       [
+              pytest.param(True, True, ChargepointState.CHARGING_ALLOWED, False, True,
+                                    id="charging-allowed-and-ready"),
+              pytest.param(True, True, ChargepointState.PHASE_SWITCH_DELAY, False, True,
+                                    id="phase-switch-delay-and-ready"),
+              pytest.param(False, True, ChargepointState.CHARGING_ALLOWED, False, False,
+                                    id="no-hardware-support"),
+              pytest.param(True, False, ChargepointState.CHARGING_ALLOWED, False, False,
+                                    id="not-charging"),
+              pytest.param(True, True, ChargepointState.SWITCH_OFF_DELAY, False, False,
+                                    id="state-not-allowed"),
+              pytest.param(True, True, ChargepointState.CHARGING_ALLOWED, True, False,
+                                    id="failed-switch-limit-reached"),
+       ],
+)
+def test_cp_state_hw_support_phase_switch(monkeypatch,
+                                                                        cp: Chargepoint,
+                                                                        hw_supports_phase_switch: bool,
+                                                                        charge_state: bool,
+                                                                        state: ChargepointState,
+                                                                        failed_phase_switches_reached: bool,
+                                                                        expected: bool):
+       # setup
+       cp.data.get.charge_state = charge_state
+       cp.data.control_parameter.state = state
+       monkeypatch.setattr(cp, "hw_supports_phase_switch", Mock(return_value=hw_supports_phase_switch))
+       monkeypatch.setattr(cp, "failed_phase_switches_reached", Mock(return_value=failed_phase_switches_reached))
+
+       # execution
+       result = cp.cp_state_hw_support_phase_switch()
+
+       # evaluation
+       assert result is expected

--- a/packages/control/chargepoint/get_phases_test.py
+++ b/packages/control/chargepoint/get_phases_test.py
@@ -177,92 +177,92 @@ def test_set_phases(monkeypatch, cp: Chargepoint, params: SetPhasesParams):
 
 
 @pytest.mark.parametrize(
-       "auto_phase_switch_hw, evse_signaling, prevent_phase_switch, imported_since_plugged, expected",
-       [
-              pytest.param(True, EvseSignaling.PWM, False, 10, True, id="supported-without-prevent-flag"),
-              pytest.param(False, EvseSignaling.PWM, False, 10, False, id="hardware-disabled"),
-              pytest.param(True, EvseSignaling.HLC, False, 10, False, id="hlc-signaling"),
-              pytest.param(True, EvseSignaling.PWM, True, 10, False, id="prevent-phase-switch-after-start"),
-              pytest.param(True, EvseSignaling.PWM, True, 0, True, id="prevent-phase-switch-before-start"),
-       ],
+    "auto_phase_switch_hw, evse_signaling, prevent_phase_switch, imported_since_plugged, expected",
+    [
+        pytest.param(True, EvseSignaling.PWM, False, 10, True, id="supported-without-prevent-flag"),
+        pytest.param(False, EvseSignaling.PWM, False, 10, False, id="hardware-disabled"),
+        pytest.param(True, EvseSignaling.HLC, False, 10, False, id="hlc-signaling"),
+        pytest.param(True, EvseSignaling.PWM, True, 10, False, id="prevent-phase-switch-after-start"),
+        pytest.param(True, EvseSignaling.PWM, True, 0, True, id="prevent-phase-switch-before-start"),
+    ],
 )
 def test_hw_supports_phase_switch(cp: Chargepoint,
-                                                          auto_phase_switch_hw: bool,
-                                                          evse_signaling: str,
-                                                          prevent_phase_switch: bool,
-                                                          imported_since_plugged: float,
-                                                          expected: bool):
-       # setup
-       cp.data.config.auto_phase_switch_hw = auto_phase_switch_hw
-       cp.data.get.evse_signaling = evse_signaling
-       cp.data.set.charging_ev_data.ev_template.data.prevent_phase_switch = prevent_phase_switch
-       cp.data.set.log.imported_since_plugged = imported_since_plugged
+                                  auto_phase_switch_hw: bool,
+                                  evse_signaling: str,
+                                  prevent_phase_switch: bool,
+                                  imported_since_plugged: float,
+                                  expected: bool):
+    # setup
+    cp.data.config.auto_phase_switch_hw = auto_phase_switch_hw
+    cp.data.get.evse_signaling = evse_signaling
+    cp.data.set.charging_ev_data.ev_template.data.prevent_phase_switch = prevent_phase_switch
+    cp.data.set.log.imported_since_plugged = imported_since_plugged
 
-       # execution
-       result = cp.hw_supports_phase_switch()
+    # execution
+    result = cp.hw_supports_phase_switch()
 
-       # evaluation
-       assert result is expected
+    # evaluation
+    assert result is expected
 
 
 @pytest.mark.parametrize(
-       "retry_failed_phase_switches, failed_phase_switches, expected",
-       [
-              pytest.param(True, 3, True, id="retry-enabled-limit-reached"),
-              pytest.param(True, 2, False, id="retry-enabled-at-limit"),
-              pytest.param(False, 1, True, id="retry-disabled-failed"),
-              pytest.param(False, 0, False, id="retry-disabled-not-failed"),
-       ],
+    "retry_failed_phase_switches, failed_phase_switches, expected",
+    [
+        pytest.param(True, 3, True, id="retry-enabled-limit-reached"),
+        pytest.param(True, 2, False, id="retry-enabled-at-limit"),
+        pytest.param(False, 1, True, id="retry-disabled-failed"),
+        pytest.param(False, 0, False, id="retry-disabled-not-failed"),
+    ],
 )
 def test_failed_phase_switches_reached(cp: Chargepoint,
                                        retry_failed_phase_switches: bool,
                                        failed_phase_switches: int,
                                        expected: bool):
-       # setup
-       data.data.general_data.data.chargemode_config.pv_charging.retry_failed_phase_switches = (
-              retry_failed_phase_switches
-       )
-       cp.data.control_parameter.failed_phase_switches = failed_phase_switches
+    # setup
+    data.data.general_data.data.chargemode_config.pv_charging.retry_failed_phase_switches = (
+        retry_failed_phase_switches
+    )
+    cp.data.control_parameter.failed_phase_switches = failed_phase_switches
 
-       # execution
-       result = cp.failed_phase_switches_reached()
+    # execution
+    result = cp.failed_phase_switches_reached()
 
-       # evaluation
-       assert result is expected
+    # evaluation
+    assert result is expected
 
 
 @pytest.mark.parametrize(
-       "hw_supports_phase_switch, charge_state, state, failed_phase_switches_reached, expected",
-       [
-              pytest.param(True, True, ChargepointState.CHARGING_ALLOWED, False, True,
-                                    id="charging-allowed-and-ready"),
-              pytest.param(True, True, ChargepointState.PHASE_SWITCH_DELAY, False, True,
-                                    id="phase-switch-delay-and-ready"),
-              pytest.param(False, True, ChargepointState.CHARGING_ALLOWED, False, False,
-                                    id="no-hardware-support"),
-              pytest.param(True, False, ChargepointState.CHARGING_ALLOWED, False, False,
-                                    id="not-charging"),
-              pytest.param(True, True, ChargepointState.SWITCH_OFF_DELAY, False, False,
-                                    id="state-not-allowed"),
-              pytest.param(True, True, ChargepointState.CHARGING_ALLOWED, True, False,
-                                    id="failed-switch-limit-reached"),
-       ],
+    "hw_supports_phase_switch, charge_state, state, failed_phase_switches_reached, expected",
+    [
+        pytest.param(True, True, ChargepointState.CHARGING_ALLOWED, False, True,
+                     id="charging-allowed-and-ready"),
+        pytest.param(True, True, ChargepointState.PHASE_SWITCH_DELAY, False, True,
+                     id="phase-switch-delay-and-ready"),
+        pytest.param(False, True, ChargepointState.CHARGING_ALLOWED, False, False,
+                     id="no-hardware-support"),
+        pytest.param(True, False, ChargepointState.CHARGING_ALLOWED, False, False,
+                     id="not-charging"),
+        pytest.param(True, True, ChargepointState.SWITCH_OFF_DELAY, False, False,
+                     id="state-not-allowed"),
+        pytest.param(True, True, ChargepointState.CHARGING_ALLOWED, True, False,
+                     id="failed-switch-limit-reached"),
+    ],
 )
 def test_cp_state_hw_support_phase_switch(monkeypatch,
-                                                                        cp: Chargepoint,
-                                                                        hw_supports_phase_switch: bool,
-                                                                        charge_state: bool,
-                                                                        state: ChargepointState,
-                                                                        failed_phase_switches_reached: bool,
-                                                                        expected: bool):
-       # setup
-       cp.data.get.charge_state = charge_state
-       cp.data.control_parameter.state = state
-       monkeypatch.setattr(cp, "hw_supports_phase_switch", Mock(return_value=hw_supports_phase_switch))
-       monkeypatch.setattr(cp, "failed_phase_switches_reached", Mock(return_value=failed_phase_switches_reached))
+                                          cp: Chargepoint,
+                                          hw_supports_phase_switch: bool,
+                                          charge_state: bool,
+                                          state: ChargepointState,
+                                          failed_phase_switches_reached: bool,
+                                          expected: bool):
+    # setup
+    cp.data.get.charge_state = charge_state
+    cp.data.control_parameter.state = state
+    monkeypatch.setattr(cp, "hw_supports_phase_switch", Mock(return_value=hw_supports_phase_switch))
+    monkeypatch.setattr(cp, "failed_phase_switches_reached", Mock(return_value=failed_phase_switches_reached))
 
-       # execution
-       result = cp.cp_state_hw_support_phase_switch()
+    # execution
+    result = cp.cp_state_hw_support_phase_switch()
 
-       # evaluation
-       assert result is expected
+    # evaluation
+    assert result is expected


### PR DESCRIPTION
fix for #3589 

Ticket #66006520; https://github.com/openWB/core/discussions/3446#discussioncomment-17660534

Wiederholte Phasenumschaltung wird nicht beachtet und stattdessen unendlich oft umgeschaltet.

Wiederholte Umschaltung deaktiviert:

- [x] Umschaltung vor Ladestart
- [x] Ladestart ohne Umschaltung
- [x] Ladestart mit falscher Phasenzahl
- [x] Umschaltung während der Ladung vom Lademodus

Wiederholte Umschaltung aktiviert, Fehlversuche nicht erreicht:

- [x] Umschaltung vor Ladestart
- [x] Ladestart ohne Umschaltung
- [x] Ladestart mit falscher Phasenzahl
- [x] Umschaltung während der Ladung vom Lademodus

Wiederholte Umschaltung aktiviert, Fehlversuche erreicht:

- [x] Ladestart mit falscher Phasenzahl: schaltet nicht um
- [x] Umschaltung während der Ladung vom Lademodus: schaltet um

Automatische Phasenumschaltung:

- [x] 1p3p
- [x] 3p1p