### PR TITLE
Implement control pilot interruption retry

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -305,8 +305,10 @@ class Chargepoint(ChargepointRfidMixin):
                                 name=f"cp{self.chargepoint_module.config.id}")):
                             cp.timestamp_last_cp_retry = create_timestamp()
                             reason = "Ladestart" if started_now else "Auto lädt trotz Freigabe nicht"
-                            message = ("Control-Pilot-Unterbrechung (" + reason + ") für " + str(
-                                charging_ev.ev_template.data.control_pilot_interruption_duration) + "s.")
+                            message = (
+                                "Control-Pilot-Unterbrechung (" + reason + ") für " +
+                                str(charging_ev.ev_template.data.control_pilot_interruption_duration) + "s."
+                            )
                             self.set_state_and_log(message)
                 else:
                     message = "CP-Unterbrechung nicht möglich, da der Ladepunkt keine CP-Unterbrechung unterstützt."

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -294,9 +294,9 @@ class Chargepoint(ChargepointRfidMixin):
                         self.data.set.current != 0 and
                         self.data.get.charge_state is False and
                         control_parameter.timestamp_charge_start is not None and
-                        check_timestamp(control_parameter.timestamp_last_cp_retry or
-                                         control_parameter.timestamp_charge_start,
-                                         retry_interval) is False
+                        check_timestamp(
+                            control_parameter.timestamp_last_cp_retry or control_parameter.timestamp_charge_start,
+                            retry_interval) is False
                     )
                     if started_now or stuck:
                         # Die CP-Unterbrechung erfolgt in Threads, da diese länger als ein Zyklus dauert.

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -311,9 +311,9 @@ class Chargepoint(ChargepointRfidMixin):
                                 str(charging_ev.ev_template.data.control_pilot_interruption_duration) + "s."
                             )
                             self.set_state_and_log(message)
-                        else:
-                            message = "CP-Unterbrechung nicht möglich, da der Ladepunkt keine CP-Unterbrechung unterstützt."
-                            self.set_state_and_log(message)
+                else:
+                    message = "CP-Unterbrechung nicht möglich, da der Ladepunkt keine CP-Unterbrechung unterstützt."
+                    self.set_state_and_log(message)
         except Exception:
             log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num))
 

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -284,7 +284,7 @@ class Chargepoint(ChargepointRfidMixin):
             # Unterstützt der Ladepunkt die CP-Unterbrechung und benötigt das Auto eine CP-Unterbrechung?
             if charging_ev.ev_template.data.control_pilot_interruption:
                 if self.data.config.control_pilot_interruption_hw:
-                    cp = self.data.control_parameter
+                    control_parameter = self.data.control_parameter
                     retry_interval = charging_ev.ev_template.data.control_pilot_interruption_retry_interval
                     # Wird die Ladung gestartet?
                     started_now = self.data.set.current_prev == 0 and self.data.set.current != 0
@@ -293,9 +293,10 @@ class Chargepoint(ChargepointRfidMixin):
                         retry_interval > 0 and
                         self.data.set.current != 0 and
                         self.data.get.charge_state is False and
-                        cp.timestamp_charge_start is not None and
-                        check_timestamp(cp.timestamp_last_cp_retry or cp.timestamp_charge_start,
-                                        retry_interval) is False
+                        control_parameter.timestamp_charge_start is not None and
+                        check_timestamp(control_parameter.timestamp_last_cp_retry or
+                                         control_parameter.timestamp_charge_start,
+                                         retry_interval) is False
                     )
                     if started_now or stuck:
                         # Die CP-Unterbrechung erfolgt in Threads, da diese länger als ein Zyklus dauert.
@@ -303,16 +304,16 @@ class Chargepoint(ChargepointRfidMixin):
                                 target=self.chargepoint_module.interrupt_cp,
                                 args=(charging_ev.ev_template.data.control_pilot_interruption_duration,),
                                 name=f"cp{self.chargepoint_module.config.id}")):
-                            cp.timestamp_last_cp_retry = create_timestamp()
+                            control_parameter.timestamp_last_cp_retry = create_timestamp()
                             reason = "Ladestart" if started_now else "Auto lädt trotz Freigabe nicht"
                             message = (
                                 "Control-Pilot-Unterbrechung (" + reason + ") für " +
                                 str(charging_ev.ev_template.data.control_pilot_interruption_duration) + "s."
                             )
                             self.set_state_and_log(message)
-                else:
-                    message = "CP-Unterbrechung nicht möglich, da der Ladepunkt keine CP-Unterbrechung unterstützt."
-                    self.set_state_and_log(message)
+                        else:
+                            message = "CP-Unterbrechung nicht möglich, da der Ladepunkt keine CP-Unterbrechung unterstützt."
+                            self.set_state_and_log(message)
         except Exception:
             log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num))
 

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -295,7 +295,7 @@ class Chargepoint(ChargepointRfidMixin):
                         self.data.get.charge_state is False and
                         cp.timestamp_charge_start is not None and
                         check_timestamp(cp.timestamp_last_cp_retry or cp.timestamp_charge_start,
-                                         retry_interval) is False
+                                        retry_interval) is False
                     )
                     if started_now or stuck:
                         # Die CP-Unterbrechung erfolgt in Threads, da diese länger als ein Zyklus dauert.

--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -284,15 +284,29 @@ class Chargepoint(ChargepointRfidMixin):
             # Unterstützt der Ladepunkt die CP-Unterbrechung und benötigt das Auto eine CP-Unterbrechung?
             if charging_ev.ev_template.data.control_pilot_interruption:
                 if self.data.config.control_pilot_interruption_hw:
+                    cp = self.data.control_parameter
+                    retry_interval = charging_ev.ev_template.data.control_pilot_interruption_retry_interval
                     # Wird die Ladung gestartet?
-                    if self.data.set.current_prev == 0 and self.data.set.current != 0:
+                    started_now = self.data.set.current_prev == 0 and self.data.set.current != 0
+                    # Ladung angefordert, Auto lädt aber trotz gültigem Signal seit geraumer Zeit nicht.
+                    stuck = (
+                        retry_interval > 0 and
+                        self.data.set.current != 0 and
+                        self.data.get.charge_state is False and
+                        cp.timestamp_charge_start is not None and
+                        check_timestamp(cp.timestamp_last_cp_retry or cp.timestamp_charge_start,
+                                         retry_interval) is False
+                    )
+                    if started_now or stuck:
                         # Die CP-Unterbrechung erfolgt in Threads, da diese länger als ein Zyklus dauert.
                         if thread_handler(Thread(
                                 target=self.chargepoint_module.interrupt_cp,
                                 args=(charging_ev.ev_template.data.control_pilot_interruption_duration,),
                                 name=f"cp{self.chargepoint_module.config.id}")):
-                            message = "Control-Pilot-Unterbrechung für " + str(
-                                charging_ev.ev_template.data.control_pilot_interruption_duration) + "s."
+                            cp.timestamp_last_cp_retry = create_timestamp()
+                            reason = "Ladestart" if started_now else "Auto lädt trotz Freigabe nicht"
+                            message = ("Control-Pilot-Unterbrechung (" + reason + ") für " + str(
+                                charging_ev.ev_template.data.control_pilot_interruption_duration) + "s.")
                             self.set_state_and_log(message)
                 else:
                     message = "CP-Unterbrechung nicht möglich, da der Ladepunkt keine CP-Unterbrechung unterstützt."

--- a/packages/control/chargepoint/control_parameter.py
+++ b/packages/control/chargepoint/control_parameter.py
@@ -26,6 +26,8 @@ class ControlParameter:
     template_phases: int = field(default=None, metadata={"topic": "control_parameter/template_phases"})
     timestamp_charge_start: Optional[float] = field(
         default=None, metadata={"topic": "control_parameter/timestamp_charge_start"})
+    timestamp_last_cp_retry: Optional[float] = field(
+        default=None, metadata={"topic": "control_parameter/timestamp_last_cp_retry"})
     timestamp_chargemode_changed: Optional[float] = field(
         default=None, metadata={"topic": "control_parameter/timestamp_chargemode_changed"})
     timestamp_last_phase_switch: float = field(

--- a/packages/control/ev/ev_template.py
+++ b/packages/control/ev/ev_template.py
@@ -13,6 +13,7 @@ class EvTemplateData:
     prevent_charge_stop: bool = False
     control_pilot_interruption: bool = False
     control_pilot_interruption_duration: int = 4
+    control_pilot_interruption_retry_interval: int = 0
     average_consump: float = 17000
     min_current: int = 6
     max_current_single_phase: int = 16

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -3470,7 +3470,7 @@ class UpdateConfig:
                     return modified_topics
         self._loop_all_received_topics(upgrade)
         self._append_datastore_version(136)
-        
+
     def upgrade_datastore_137(self) -> None:
         def upgrade(topic: str, payload) -> Optional[dict]:
             if re.search("openWB/vehicle/template/ev_template/[0-9]+$", topic) is not None:
@@ -3481,5 +3481,3 @@ class UpdateConfig:
                     return {topic: payload}
         self._loop_all_received_topics(upgrade)
         self._append_datastore_version(137)
-
-

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -58,7 +58,7 @@ NO_MODULE = {"type": None, "configuration": {}}
 
 class UpdateConfig:
 
-    DATASTORE_VERSION = 136
+    DATASTORE_VERSION = 137
 
     valid_topic = [
         "^openWB/bat/config/bat_control_activated$",
@@ -125,6 +125,7 @@ class UpdateConfig:
         "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_chargemode_changed$",
         "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_last_phase_switch$",
         "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_switch_on_off$",
+        "^openWB/chargepoint/[0-9]+/control_parameter/timestamp_last_cp_retry$",
         "^openWB/chargepoint/[0-9]+/get/charge_state$",
         "^openWB/chargepoint/[0-9]+/get/currents$",
         "^openWB/chargepoint/[0-9]+/get/current_branch$",
@@ -3469,3 +3470,16 @@ class UpdateConfig:
                     return modified_topics
         self._loop_all_received_topics(upgrade)
         self._append_datastore_version(136)
+        
+    def upgrade_datastore_137(self) -> None:
+        def upgrade(topic: str, payload) -> Optional[dict]:
+            if re.search("openWB/vehicle/template/ev_template/[0-9]+$", topic) is not None:
+                payload = decode_payload(payload)
+                if "control_pilot_interruption_retry_interval" not in payload:
+                    payload["control_pilot_interruption_retry_interval"] = \
+                        EvTemplateData().control_pilot_interruption_retry_interval
+                    return {topic: payload}
+        self._loop_all_received_topics(upgrade)
+        self._append_datastore_version(137)
+
+


### PR DESCRIPTION
UI: https://github.com/openWB/openwb-ui-settings/pull/1028

Fälle wie hier https://github.com/openWB/core/discussions/3579#discussioncomment-17795949 das Fahrzeuge leider nicht starten obwohl ein Strom permanent vorgegeben ist sind bei manchen Fahrzeug leider häufiger. Abhilfe könnte eine CP Unterbrechung schaffen die einstellbar regelmäßig versucht wird und nicht nur bei Änderung der Ladestromvorgabe wie bisher.