### PR TITLE
Renault cleanup and fix

### DIFF
--- a/packages/modules/vehicles/renault/api.py
+++ b/packages/modules/vehicles/renault/api.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import json
-import urllib
 import logging
 from modules.common.component_state import CarState
 from modules.common import req
@@ -17,81 +15,50 @@ KAMEREON_API_KEY = 'YjkKtHmGfaceeuExUDKGxrLZGGvtVS0J'
 
 def fetch_soc(config: RenaultConfiguration) -> CarState:
     country_data = {'country': config.country}
-    # Step 1- skipped
-    # Step 2
-    payload = {'loginID': config.user_id, 'password': config. password, 'apiKey': GIGYA_API}
-    gigya_session = req.get_http_session().post(f"{GIGYA_ROOTURL}/accounts.login", data=payload).json()
 
-    # Step 3
+    # Gigya-Login: Zugangsdaten gegen Session-Cookie tauschen
+    payload = {'loginID': config.user_id, 'password': config.password, 'apiKey': GIGYA_API}
+    gigya_session = req.get_http_session().post(f"{GIGYA_ROOTURL}/accounts.login", data=payload).json()
     gigyacookievalue = gigya_session['sessionInfo']['cookieValue']
+
+    # Account-Infos abrufen (liefert personId)
     payload = {'login_token': gigyacookievalue, 'apiKey': GIGYA_API}
     gigya_account = req.get_http_session().post(f"{GIGYA_ROOTURL}/accounts.getAccountInfo", data=payload).json()
 
-    # Step 4
+    # JWT für Kamereon-API anfordern
     payload = {'login_token': gigyacookievalue, 'apiKey': GIGYA_API,
                'fields': 'data.personId,data.gigyaDataCenter', 'expiration': 900}
     gigya_jwt = req.get_http_session().post(f"{GIGYA_ROOTURL}/accounts.getJWT", data=payload).json()
-
-    # Step 5
     gigya_jwttoken = gigya_jwt['id_token']
-    kamereonpersonid = gigya_account['data']['personId']
-    kamereon_per = req.get_http_session().get(f"{KAMEREON_ROOTURL}/commerce/v1/persons/{kamereonpersonid}",
-                                              headers={'x-gigya-id_token': gigya_jwttoken, 'apikey': KAMEREON_API_KEY},
-                                              data=country_data).json()
 
-    # Step 6 - skipped
-    # Step 7 - vehicles
+    # Kamereon-Account anhand der personId ermitteln
+    kamereonpersonid = gigya_account['data']['personId']
+    headers = {'x-gigya-id_token': gigya_jwttoken, 'apikey': KAMEREON_API_KEY}
+    kamereon_per = req.get_http_session().get(f"{KAMEREON_ROOTURL}/commerce/v1/persons/{kamereonpersonid}",
+                                              headers=headers, params=country_data).json()
     kamereonaccountid = kamereon_per['accounts'][0]['accountId']
     log.debug(f"account id {kamereonaccountid}")
-    # vehic = req.get_http_session().get(f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/vehicles",
-    #                                    headers={'x-gigya-id_token': gigya_jwttoken, 'apikey': KAMEREON_API_KEY},
-    #                                    data=country_data).json()
-    # wirft requests.exceptions.HTTPError: 400 Client Error: Bad Request for url
 
-    data = urllib.parse.urlencode(country_data)
-    data = data.encode('Big5')
-    reg = urllib.request.Request(KAMEREON_ROOTURL + '/commerce/v1/accounts/' +
-                                 kamereonaccountid + '/vehicles?' + data.decode("utf-8"))
-    reg.add_header('x-gigya-id_token', gigya_jwttoken)
-    reg.add_header('apikey', KAMEREON_API_KEY)
-    response = urllib.request.urlopen(reg)
-    responsetext = response.read()
-    vehic = json.loads(responsetext)
-
+    # Fahrzeugliste abrufen, um VIN zu ermitteln, falls nicht konfiguriert
+    vehic = req.get_http_session().get(
+        f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/vehicles",
+        headers=headers, params=country_data).json()
     if config.vin is None or len(config.vin) < 10:
         vin = vehic['vehicleLinks'][0]['vin']
     else:
         vin = config.vin
 
-    # Step 8 - battery-status
-    # batt = req.get_http_session().get(f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/kamereon/kca/"
-    #                                   f"car-adapter/v2/cars/{vin}/battery-status",
-    #                                   headers={'x-gigya-id_token': gigya_jwttoken, 'apikey': KAMEREON_API_KEY},
-    #                                   data=country_data).json()
-    # wirft requests.exceptions.HTTPError: 400 Client Error: Bad Request for url:
+    # Batteriestatus abrufen (SoC, Reichweite)
+    batt = req.get_http_session().get(
+        f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/kamereon/kca/"
+        f"car-adapter/v2/cars/{vin}/battery-status",
+        headers=headers, params=country_data).json()
 
-    data = urllib.parse.urlencode(country_data)
-    data = data.encode('Big5')
-    reg = urllib.request.Request(KAMEREON_ROOTURL + '/commerce/v1/accounts/' +
-                                 kamereonaccountid + '/kamereon/kca/car-adapter/v2/cars/'
-                                 + vin + '/battery-status?' + data.decode("utf-8"))
-    reg.add_header('x-gigya-id_token', gigya_jwttoken)
-    reg.add_header('apikey', KAMEREON_API_KEY)
-    response = urllib.request.urlopen(reg)
-    responsetext = response.read()
-    batt = json.loads(responsetext)
-
-    # Step 9 - cockpit data for odometer/totalMileage
-    data = urllib.parse.urlencode(country_data)
-    data = data.encode('Big5')
-    reg = urllib.request.Request(KAMEREON_ROOTURL + '/commerce/v1/accounts/' +
-                                 kamereonaccountid + '/kamereon/kca/car-adapter/v1/cars/'
-                                 + vin + '/cockpit?' + data.decode("utf-8"))
-    reg.add_header('x-gigya-id_token', gigya_jwttoken)
-    reg.add_header('apikey', KAMEREON_API_KEY)
-    response = urllib.request.urlopen(reg)
-    responsetext = response.read()
-    cockpit = json.loads(responsetext)
+    # Cockpit-Daten abrufen (Kilometerstand)
+    cockpit = req.get_http_session().get(
+        f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/kamereon/kca/"
+        f"car-adapter/v1/cars/{vin}/cockpit",
+        headers=headers, params=country_data).json()
 
     return CarState(soc=float(batt['data']['attributes']['batteryLevel']),
                     range=float(batt['data']['attributes']['batteryAutonomy']),

--- a/packages/modules/vehicles/renault/soc.py
+++ b/packages/modules/vehicles/renault/soc.py
@@ -1,16 +1,11 @@
-from typing import List
-
 import logging
 
-from helpermodules.cli import run_using_positional_cli_args
-from modules.common import store
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.abstract_vehicle import VehicleUpdateData
 from modules.common.component_state import CarState
 from modules.common.configurable_vehicle import ConfigurableVehicle
 from modules.vehicles.renault import api
-from modules.vehicles.renault.config import Renault, RenaultConfiguration
-
+from modules.vehicles.renault.config import Renault
 
 log = logging.getLogger(__name__)
 
@@ -19,16 +14,6 @@ def create_vehicle(vehicle_config: Renault, vehicle: int):
     def updater(vehicle_update_data: VehicleUpdateData) -> CarState:
         return api.fetch_soc(vehicle_config.configuration)
     return ConfigurableVehicle(vehicle_config=vehicle_config, component_updater=updater, vehicle=vehicle)
-
-
-def renault_update(user_id: str, password: str, location: str, country: str, vin: str, charge_point: int):
-    log.debug("renault: user_id=" + user_id + "vin=" + vin + "charge_point=" + str(charge_point))
-    store.get_car_value_store(charge_point).store.set(api.fetch_soc(
-        RenaultConfiguration(charge_point, user_id, password, location, country, vin)))
-
-
-def main(argv: List[str]):
-    run_using_positional_cli_args(renault_update, argv)
 
 
 device_descriptor = DeviceDescriptor(configuration_factory=Renault)


### PR DESCRIPTION
Die Kamereon-Aufrufe in fetch_soc() (Fahrzeugliste, Batteriestatus, Cockpit) liefen bisher über rohes urllib.request statt über req.get_http_session(), weil letzteres einen 400 Client Error warf – Ursache war, dass country bei GET-Anfragen fälschlich per data= (Body) statt params= (Query-String) übergeben wurde. Zusätzlich enthielt der Code eine sinnlose Big5-Kodierung, toten Kommentar-Code und eine nicht mehr erreichbare CLI-Funktion (json_update/main) mit einem Tippfehler (.store.set() statt .set()), die seit Umstellung auf den ConfigurableVehicle-Update-Zyklus nirgends mehr aufgerufen wird. Ich habe die Aufrufe konsistent auf req.get_http_session() mit params= umgestellt und den toten Code entfernt. Verifiziert mit echtem Fahrzeug über die openWB-UI: SoC, Reichweite und Kilometerstand werden korrekt abgerufen.