### PR TITLE
fix: hybrid inverters with multiple batteries

### DIFF
--- a/packages/modules/common/store/_inverter.py
+++ b/packages/modules/common/store/_inverter.py
@@ -50,7 +50,6 @@ class PurgeInverterState:
             for c in children:
                 if c.get("type") == "bat":
                     hybrid.append(f'bat{c["id"]}')
-                    break
             if len(hybrid):
                 for bat in hybrid:
                     bat_get = data.data.bat_data[bat].data.get


### PR DESCRIPTION
Ticket #66006745

Bei der Suche nach untergeordneten Speichern stoppt der Algorithmus aktuell beim ersten Treffer.
Bei Systemen mit mehreren DC-Speichern wird daher nur der erste beachtet.