### PR TITLE
Sungrow Microinverter Registeranpassung

### DIFF
--- a/packages/modules/devices/sungrow/sungrow_micro/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow_micro/inverter.py
@@ -35,7 +35,7 @@ class SungrowMicroInverter(AbstractInverter):
         unit = self.device_config.configuration.modbus_id
 
         power = self.__tcp_client.read_holding_registers(32213, ModbusDataType.UINT_16,
-                                                       wordorder=Endian.Little, unit=unit) * -1
+                                                         wordorder=Endian.Little, unit=unit) * -1
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/sungrow/sungrow_micro/inverter.py
+++ b/packages/modules/devices/sungrow/sungrow_micro/inverter.py
@@ -34,7 +34,7 @@ class SungrowMicroInverter(AbstractInverter):
     def update(self) -> float:
         unit = self.device_config.configuration.modbus_id
 
-        power = self.__tcp_client.read_input_registers(32213, ModbusDataType.UINT_32,
+        power = self.__tcp_client.read_holding_registers(32213, ModbusDataType.UINT_16,
                                                        wordorder=Endian.Little, unit=unit) * -1
 
         self.peak_filter.check_values(power)


### PR DESCRIPTION
Mehrere Problemmeldungen, z.B. Ticket #66006613
Zu den Microinvertern gibt es keinerlei Doku. Ob das Modul aktuell zumindest bei einigen Anlagen funktioniert ist nicht geklärt.

Mit der Registeranpassung funktioniert es zumindest bei dieser Kundenanlage. Falls im Nachgang doch Problemmeldungen kommen muss zeitnah eine Auswahlmöglichkeit der Abfragemethode geschaffen werden.

Stand jetzt ist allerdings nicht klar ob das nötig sein wird.