### PR TITLE
fix(vehicles/kia): populate odometer (Kilometerstand) in vehicle status

### DIFF
--- a/packages/modules/vehicles/kia/api.py
+++ b/packages/modules/vehicles/kia/api.py
@@ -877,12 +877,20 @@ def getStatusFull(vehicle_id: str, control_token: str,
         range = float(response_dict['resMsg']['state']['Vehicle']['Drivetrain']
                                    ['FuelSystem']['DTE']['Total'])
 
+        odometer = None
+        try:
+            odometer = float(response_dict['resMsg']['state']['Vehicle']
+                                          ['Drivetrain']['Odometer'])
+        except (KeyError, TypeError, ValueError):
+            log.warning("kia.getStatusFull: odometer not available in "
+                        "vehicle status response")
+
     except Exception:
         log.exception("kia.getStatusFull: receiving update error: " +
                       response)
         raise
 
-    return CarState(soc, range)
+    return CarState(soc=soc, range=range, odometer=odometer)
 
 # ---------- main function ----------
 


### PR DESCRIPTION
The CCS2 status parser in getStatusFull() only extracted SoC and range, so CarState.odometer stayed None and the openWB status page showed an empty 'Kilometerstand - km'. Read the mileage from the same Drivetrain subtree the range is taken from (Vehicle.Drivetrain.Odometer, a direct km scalar, matching hyundai_kia_connect_api ApiImplType1 CCS2 parsing) and pass it into CarState. Wrapped in try/except so a missing field degrades gracefully instead of breaking the whole status update.