### PR TITLE
Zugangsdaten in URLs im Log unkenntlich machen

### DIFF
--- a/packages/helpermodules/logger.py
+++ b/packages/helpermodules/logger.py
@@ -364,7 +364,8 @@ def setup_logging() -> None:
             f.write("Uncaught exception:\n")
             f.write(f"Type: {exc_type}\n")
             f.write(redact_sensitive_info(f"Value: {exc_value}\n"))
-            f.write(f"Traceback:{exc_traceback}\n")
+            import traceback
+            f.write(redact_sensitive_info("".join(traceback.format_tb(exc_traceback))))
     sys.excepthook = handle_unhandled_exception
 
 

--- a/packages/helpermodules/logger.py
+++ b/packages/helpermodules/logger.py
@@ -26,6 +26,9 @@ REDACTION_PATTERNS = [
     (r'"{field}":\s*"(.*?)"', r'"{field}": "***REDACTED***"'),  # "field": "value", JSON formatted data
     (r'\'{field}\':\s*\'(.*?)\'', r"'{field}': '***REDACTED***'")  # 'field': 'value', JSON formatted data
 ]
+# Credentials in a URL (scheme://user:password@host/) carry no field name for REDACTION_PATTERNS
+# to key on. The user name is kept, it is useful when diagnosing authentication problems.
+URL_CREDENTIALS_PATTERN = (r'(\w+://[^/\s:@]*):[^/\s]+@', r'\1:***REDACTED***@')
 
 
 def redact_sensitive_info(message: str, additional_fields: list = None) -> str:
@@ -37,6 +40,9 @@ def redact_sensitive_info(message: str, additional_fields: list = None) -> str:
     redacted are defined in the KNOWN_SENSITIVE_FIELDS list. The function uses
     predefined patterns to identify and replace the sensitive information.
 
+    Passwords given as URL credentials (scheme://user:password@host/) are redacted as well,
+    those carry no field name to key on.
+
     Args:
         message (str): The log message to be redacted.
 
@@ -44,6 +50,7 @@ def redact_sensitive_info(message: str, additional_fields: list = None) -> str:
         str: The redacted log message.
     """
     fields_to_redact = KNOWN_SENSITIVE_FIELDS + (additional_fields or [])
+    message = re.sub(URL_CREDENTIALS_PATTERN[0], URL_CREDENTIALS_PATTERN[1], message)
     for field in fields_to_redact:
         for pattern, replacement in REDACTION_PATTERNS:
             pattern = pattern.replace('{field}', field)
@@ -344,9 +351,9 @@ def setup_logging() -> None:
         with open(thread_errors_path, "a") as f:
             f.write("Uncaught exception in thread:\n")
             f.write(f"Type: {args.exc_type}\n")
-            f.write(f"Value: {args.exc_value}\n")
+            f.write(redact_sensitive_info(f"Value: {args.exc_value}\n"))
             import traceback
-            traceback.print_tb(args.exc_traceback, file=f)
+            f.write(redact_sensitive_info("".join(traceback.format_tb(args.exc_traceback))))
     threading.excepthook = threading_excepthook
 
     def handle_unhandled_exception(exc_type, exc_value, exc_traceback):
@@ -356,7 +363,7 @@ def setup_logging() -> None:
         with open(thread_errors_path, "a") as f:
             f.write("Uncaught exception:\n")
             f.write(f"Type: {exc_type}\n")
-            f.write(f"Value: {exc_value}\n")
+            f.write(redact_sensitive_info(f"Value: {exc_value}\n"))
             f.write(f"Traceback:{exc_traceback}\n")
     sys.excepthook = handle_unhandled_exception
 

--- a/packages/helpermodules/logger_test.py
+++ b/packages/helpermodules/logger_test.py
@@ -1,0 +1,46 @@
+import pytest
+
+from helpermodules.logger import redact_sensitive_info
+
+
+@pytest.mark.parametrize("message, expected", [
+    pytest.param("connection to ws://openwb:secret@ocpp.example.com/v16/ established",
+                 "connection to ws://openwb:***REDACTED***@ocpp.example.com/v16/ established",
+                 id="websocket url"),
+    pytest.param("wss://openwb:secret@ocpp.example.com:443/v16/",
+                 "wss://openwb:***REDACTED***@ocpp.example.com:443/v16/",
+                 id="port is kept"),
+    pytest.param('{"url": "ws://openwb:secret@ocpp.example.com/v16/", "version": "1.6"}',
+                 '{"url": "ws://openwb:***REDACTED***@ocpp.example.com/v16/", "version": "1.6"}',
+                 id="url embedded in json"),
+    pytest.param("ws://user:p@ssword@host/",
+                 "ws://user:***REDACTED***@host/",
+                 id="at sign within password"),
+    pytest.param("ws://openwb:***REDACTED***@ocpp.example.com/v16/",
+                 "ws://openwb:***REDACTED***@ocpp.example.com/v16/",
+                 id="already redacted"),
+])
+def test_redact_url_credentials(message, expected):
+    assert redact_sensitive_info(message) == expected
+
+
+@pytest.mark.parametrize("message", [
+    pytest.param("http://192.168.1.5:8080/api?value=1", id="url without credentials"),
+    pytest.param("https://api.example.com/mail?to=someone@example.com", id="at sign in query"),
+    pytest.param("http://host:8080 unreachable, contact someone@example.com", id="mail address after url"),
+])
+def test_keep_url_without_credentials(message):
+    assert redact_sensitive_info(message) == message
+
+
+def test_redact_url_credentials_and_known_field():
+    message = '{"url": "ws://openwb:secret@ocpp.example.com/v16/", "password": "abc123"}'
+    expected = '{"url": "ws://openwb:***REDACTED***@ocpp.example.com/v16/", "password": "***REDACTED***"}'
+
+    assert redact_sensitive_info(message) == expected
+
+
+def test_redact_url_credentials_with_sensitive_field_as_user_name():
+    # If the user name matches an entry of KNOWN_SENSITIVE_FIELDS, the field pattern applies on
+    # top and truncates the url. The password is removed in that case as well.
+    assert redact_sensitive_info("ws://token:secret@ocpp.example.com/v16/") == "ws://token=***REDACTED***"


### PR DESCRIPTION
## Problem

Ein Passwort, das als URL-userinfo übergeben wird (`schema://benutzer:passwort@host/`), steht im Klartext im Log. `RedactingFilter` greift nicht: Alle drei `REDACTION_PATTERNS` setzen an einem Feldnamen an (`password=…`, `"password": "…"`), und die userinfo einer URL nach RFC 3986 hat keinen.

Das ist kein Randfall. Mehrere SoC-Module — `json`, `http`, `homeassistant`, `psacc` — bieten ein freies `url`-Feld und **keine** getrennten Felder für Benutzer und Passwort. Für einen Endpunkt hinter Basic Auth ist es der einzige Weg, die Zugangsdaten in die URL zu schreiben, und `requests` unterstützt genau das.

Zwei Stellen protokollieren eine solche URL:

- `packages/modules/vehicles/json/soc.py` gibt die konfigurierte URL auf Debug-Level aus → `soc.log`
- `packages/helpermodules/subdata.py` protokolliert jede MQTT-Nachricht samt Payload, damit landet die Modulkonfiguration selbst in `mqtt.log`

An beiden Handlern hängt bereits ein `RedactingFilter`. Die Absicht, Geheimnisse aus diesen Dateien herauszuhalten, ist also vorhanden — es fehlte lediglich das Muster für diese Form.

## Reproduktion

Ein JSON-SoC-Modul mit `https://benutzer:geheim@nas.local/soc.json` konfiguriert und Debug-Logging aktiviert, ergibt auf dem aktuellen master:

```
soc.log:  … url="https://benutzer:geheim@nas.local/soc.json" soc-pattern="soc" …
mqtt.log: … Payload: {"type": "json", "configuration": {"url": "https://benutzer:geheim@nas.local/soc.json"}}
```

Mit dieser Änderung steht in beiden Dateien `https://benutzer:***REDACTED***@nas.local/soc.json`.

## Änderung

Ein Muster mehr in `redact_sensitive_info()`, damit wirkt es für jeden Handler, an dem bereits ein `RedactingFilter` hängt:

```python
URL_CREDENTIALS_PATTERN = (r'(\w+://[^/\s:@]*):[^/\s]+@', r'\1:***REDACTED***@')
```

**Der Benutzername bleibt sichtbar**, ersetzt wird nur das Passwort. Bei der Diagnose eines Authentifizierungsproblems ist die Auskunft, mit welchem Benutzer verbunden wurde, der nützliche Teil der Logzeile.

Der Wertteil ist bewusst greedy: Enthält das Passwort selbst ein `@`, reicht der Treffer bis zum letzten `@` vor dem Host statt nur bis zum ersten. In allen übrigen Fällen sind beide Varianten identisch. Schrägstrich und Whitespace bleiben ausgeschlossen, dadurch kann ein Treffer nie über die Authority hinaus in Pfad oder Query laufen — eine Mailadresse in einem Query-Parameter bleibt unangetastet.

### thread_errors.log

Die beiden Excepthooks in `setup_logging()` schreiben über `open()`/`write()` und umgehen damit das Logging-Framework und den Filter. Eine ungefangene Exception, die eine URL mit sich trägt — etwa ein `InvalidURI` aus einem Verbindungsaufruf —, landet dort im Klartext. Sie führen ihren Text jetzt durch dieselbe Funktion. Aus `print_tb()` wurde `format_tb()`, weil sich nur ein String filtern lässt; die Ausgabe bleibt unverändert.

## Tests

Neu ist `packages/helpermodules/logger_test.py` mit zehn Fällen, darunter drei, die **unverändert** bleiben müssen: eine URL ohne Zugangsdaten, ein `@` in einem Query-Parameter und eine Mailadresse hinter einer URL.

Ein dokumentierter Randfall: Heißt der Benutzer wie ein Eintrag aus `KNOWN_SENSITIVE_FIELDS` (`token`, `secret`, …), greift zusätzlich das bestehende Feldmuster und kürzt die URL auf `ws://token=***REDACTED***`, weil dessen Wertmuster `[^\s&]+` auch `/` und `@` erlaubt. Das Passwort ist auch in diesem Fall entfernt, es fehlen lediglich Host und Pfad in der Logzeile. Das Verhalten ist von der Reihenfolge der beiden Ersetzungen unabhängig und durch einen Test festgehalten.
