### PR TITLE
modbusserver: init strings completely

### DIFF
--- a/packages/helpermodules/modbusserver.py
+++ b/packages/helpermodules/modbusserver.py
@@ -55,13 +55,15 @@ def _form_int16(value: Union[int, float, bool], register: int):
 
 
 def _form_str(value: Optional[str], register: int):
-    if value is None or len(value) == 0:
-        data_store[register] = 0
-    else:
+    string_max_length = 20
+    # initialize all registers to 0 to avoid leftover data from previous, longer values
+    for i in range(0, string_max_length):
+        data_store[register + i] = 0
+    if not (value is None or len(value) == 0):
         bytes = value.encode("utf-8")
         length = len(bytes)
-        if length > 20:
-            raise ValueError("String darf max 20 Zeichen enthalten.")
+        if length > string_max_length:
+            raise ValueError(f"String darf max {string_max_length} Zeichen enthalten.")
         register_offset = 0
         for i in range(0, length, 2):
             try:


### PR DESCRIPTION
without full init, leftover data from previous, longer strings is kept in the registers

came up, when testing implementation of RFID-Reset over modbus in evcc (see #3503)