### PR TITLE
fix: Retry-Wartezeit beim EVSE-Auslesen greift nur beim ersten Fehlversuch

### DIFF
--- a/packages/modules/common/hardware_check.py
+++ b/packages/modules/common/hardware_check.py
@@ -93,7 +93,7 @@ class SeriesHardwareCheckMixin:
                             pymodbus.exceptions.ConnectionException) as e:
                         evse_check_passed = self.handle_exception(e)
                         # nur warten, wenn danach noch ein Versuch folgt
-                        if attempt < MAX_ATTEMPTS - 2 and evse_check_passed is False:
+                        if attempt < MAX_ATTEMPTS - 1 and evse_check_passed is False:
                             time.sleep(RETRY_DELAY_SECONDS)
         except Exception as e:
             evse_check_passed = self.handle_exception(e)


### PR DESCRIPTION
In `request_and_check_hardware()` (`packages/modules/common/hardware_check.py`) soll zwischen den Retry-Versuchen beim EVSE-Auslesen jeweils `RETRY_DELAY_SECONDS` gewartet werden, bevor der nächste Versuch gestartet wird. Die aktuelle Bedingung dafür ist:

```python
if attempt < MAX_ATTEMPTS - 2 and evse_check_passed is False:
    time.sleep(RETRY_DELAY_SECONDS)
```

Bei `MAX_ATTEMPTS = 3` ergibt `MAX_ATTEMPTS - 2 = 1`, die Bedingung `attempt < 1` ist also nur beim allerersten Fehlschlag (`attempt == 0`) erfüllt. Zwischen Versuch 2 und 3 wird dadurch **sofort** erneut probiert, ohne Wartezeit. Der gesamte Retry-Zyklus dauert dadurch effektiv nur eine statt zwei Wartezeiten (~0,3 s statt ~0,6 s) und gibt der Hardware entsprechend weniger Zeit, sich von einem kurzen Bus-Aussetzer zu erholen, bevor `EVSE_BROKEN` geworfen wird.

## Fix

```python
if attempt < MAX_ATTEMPTS - 1 and evse_check_passed is False:
    time.sleep(RETRY_DELAY_SECONDS)
```

Damit wird nach jedem Fehlversuch außer dem letzten gewartet (bei 3 Versuchen: 2 Wartezeiten), statt nur einmal.