### PR TITLE
Renault: HTTP-Session im SoC-Abruf wiederverwenden, Kilometerstand optional behandeln

### DIFF
--- a/packages/modules/vehicles/renault/api.py
+++ b/packages/modules/vehicles/renault/api.py
@@ -15,32 +15,35 @@ KAMEREON_API_KEY = 'YjkKtHmGfaceeuExUDKGxrLZGGvtVS0J'
 
 def fetch_soc(config: RenaultConfiguration) -> CarState:
     country_data = {'country': config.country}
+    # eine Session für den gesamten Login-/Abfrageablauf verwenden, da Renault/Gigya
+    # sitzungsübergreifend gesetzte Cookies für die Folgeaufrufe benötigt
+    session = req.get_http_session()
 
     # Gigya-Login: Zugangsdaten gegen Session-Cookie tauschen
     payload = {'loginID': config.user_id, 'password': config.password, 'apiKey': GIGYA_API}
-    gigya_session = req.get_http_session().post(f"{GIGYA_ROOTURL}/accounts.login", data=payload).json()
+    gigya_session = session.post(f"{GIGYA_ROOTURL}/accounts.login", data=payload).json()
     gigyacookievalue = gigya_session['sessionInfo']['cookieValue']
 
     # Account-Infos abrufen (liefert personId)
     payload = {'login_token': gigyacookievalue, 'apiKey': GIGYA_API}
-    gigya_account = req.get_http_session().post(f"{GIGYA_ROOTURL}/accounts.getAccountInfo", data=payload).json()
+    gigya_account = session.post(f"{GIGYA_ROOTURL}/accounts.getAccountInfo", data=payload).json()
 
     # JWT für Kamereon-API anfordern
     payload = {'login_token': gigyacookievalue, 'apiKey': GIGYA_API,
                'fields': 'data.personId,data.gigyaDataCenter', 'expiration': 900}
-    gigya_jwt = req.get_http_session().post(f"{GIGYA_ROOTURL}/accounts.getJWT", data=payload).json()
+    gigya_jwt = session.post(f"{GIGYA_ROOTURL}/accounts.getJWT", data=payload).json()
     gigya_jwttoken = gigya_jwt['id_token']
 
     # Kamereon-Account anhand der personId ermitteln
     kamereonpersonid = gigya_account['data']['personId']
     headers = {'x-gigya-id_token': gigya_jwttoken, 'apikey': KAMEREON_API_KEY}
-    kamereon_per = req.get_http_session().get(f"{KAMEREON_ROOTURL}/commerce/v1/persons/{kamereonpersonid}",
-                                              headers=headers, params=country_data).json()
+    kamereon_per = session.get(f"{KAMEREON_ROOTURL}/commerce/v1/persons/{kamereonpersonid}",
+                               headers=headers, params=country_data).json()
     kamereonaccountid = kamereon_per['accounts'][0]['accountId']
     log.debug(f"account id {kamereonaccountid}")
 
     # Fahrzeugliste abrufen, um VIN zu ermitteln, falls nicht konfiguriert
-    vehic = req.get_http_session().get(
+    vehic = session.get(
         f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/vehicles",
         headers=headers, params=country_data).json()
     if config.vin is None or len(config.vin) < 10:
@@ -49,17 +52,22 @@ def fetch_soc(config: RenaultConfiguration) -> CarState:
         vin = config.vin
 
     # Batteriestatus abrufen (SoC, Reichweite)
-    batt = req.get_http_session().get(
+    batt = session.get(
         f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/kamereon/kca/"
         f"car-adapter/v2/cars/{vin}/battery-status",
         headers=headers, params=country_data).json()
 
-    # Cockpit-Daten abrufen (Kilometerstand)
-    cockpit = req.get_http_session().get(
-        f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/kamereon/kca/"
-        f"car-adapter/v1/cars/{vin}/cockpit",
-        headers=headers, params=country_data).json()
+    # Cockpit-Daten abrufen (Kilometerstand); nicht jedes Fahrzeug liefert diesen Wert
+    odometer = None
+    try:
+        cockpit = session.get(
+            f"{KAMEREON_ROOTURL}/commerce/v1/accounts/{kamereonaccountid}/kamereon/kca/"
+            f"car-adapter/v1/cars/{vin}/cockpit",
+            headers=headers, params=country_data).json()
+        odometer = float(cockpit['data']['attributes']['totalMileage'])
+    except Exception:
+        log.debug("Kilometerstand konnte nicht abgerufen werden.", exc_info=True)
 
     return CarState(soc=float(batt['data']['attributes']['batteryLevel']),
                     range=float(batt['data']['attributes']['batteryAutonomy']),
-                    odometer=float(cockpit['data']['attributes']['totalMileage']))
+                    odometer=odometer)


### PR DESCRIPTION
Bisher wurde für jeden der 7 Requests im Login-/Abrufablauf (Gigya-Login, Kamereon-Daten) eine neue Session erzeugt, wodurch Cookies nicht über den Ablauf hinweg erhalten blieben und der SoC-Abruf bei manchen Accounts komplett fehlschlug. Jetzt wird eine einzige Session für den gesamten Ablauf verwendet.

Zusätzlich wird der Kilometerstand (Cockpit-Daten) jetzt mit try/except abgefangen, da nicht jedes Fahrzeug diesen Wert liefert – ein Fehlschlag dort verhindert nicht mehr den Abruf von SoC und Reichweite.

Fixt: https://github.com/openWB/core/discussions/3409#discussioncomment-18138490