### PR TITLE
Deye: add power register reading

### DIFF
--- a/packages/modules/devices/deye/deye/counter.py
+++ b/packages/modules/devices/deye/deye/counter.py
@@ -58,7 +58,7 @@ class DeyeCounter(AbstractCounter):
             currents = [c / 100 for c in self.client.read_holding_registers(613, [ModbusDataType.INT_16]*3, unit=unit)]
             voltages = [v / 10 for v in self.client.read_holding_registers(644, [ModbusDataType.INT_16]*3, unit=unit)]
             powers = self.client.read_holding_registers(616, [ModbusDataType.INT_16]*3, unit=unit)
-            power = sum(powers)
+            power = self.client.read_holding_registers(625, ModbusDataType.INT_16, unit=unit)
             frequency = self.client.read_holding_registers(609, ModbusDataType.INT_16, unit=unit) / 100
 
         self.peak_filter.check_values(power)


### PR DESCRIPTION
Register laut Doku 625.
Behebt Probleme bei denen die einzelnen Phasen falsches Vorzeichen für die Leistungen liefern.