### PR TITLE
Kostal Plenticore: use Little Endian

### DIFF
--- a/packages/modules/devices/kostal/kostal_plenticore/bat.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/bat.py
@@ -20,7 +20,6 @@ log = logging.getLogger(__name__)
 class KwargsDict(TypedDict):
     device_id: int
     modbus_id: int
-    endianess: Endian
     client: ModbusTcpClient_
 
 
@@ -32,7 +31,6 @@ class KostalPlenticoreBat(AbstractBat):
     def initialize(self) -> None:
         self.__device_id: int = self.kwargs['device_id']
         self.modbus_id: int = self.kwargs['modbus_id']
-        self.endianess: Endian = self.kwargs['endianess']
         self.client: ModbusTcpClient_ = self.kwargs['client']
         self.store = get_component_value_store(self.component_config.type, self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
@@ -41,14 +39,14 @@ class KostalPlenticoreBat(AbstractBat):
 
     def update(self) -> None:
         power = self.client.read_holding_registers(
-            582, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=self.endianess) * -1
+            582, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=Endian.Little) * -1
         soc = self.client.read_holding_registers(
-            514, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=self.endianess)
+            514, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=Endian.Little)
         if power < 0:
             power = self.client.read_holding_registers(
-                106, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) * -1
+                106, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little) * -1
         bat_current = self.client.read_holding_registers(200, ModbusDataType.FLOAT_32,
-                                                         unit=self.modbus_id, wordorder=self.endianess) * -1
+                                                         unit=self.modbus_id, wordorder=Endian.Little) * -1
         currents = [bat_current / 3] * 3
 
         self.peak_filter.check_values(power)
@@ -77,17 +75,17 @@ class KostalPlenticoreBat(AbstractBat):
             # wiederholt auf Stop setzen damit sich Register nicht zurücksetzt
             log.debug("Aktive Batteriesteuerung. Batterie wird auf Stop gesetzt und nicht entladen")
             self.client.write_register(1034, 0.0, data_type=ModbusDataType.FLOAT_32,
-                                       wordorder=self.endianess, unit=unit)
+                                       wordorder=Endian.Little, unit=unit)
         elif power_limit < 0:
             power_value = float(abs(power_limit))
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W entladen für den Hausverbrauch")
             self.client.write_register(1034, power_value, data_type=ModbusDataType.FLOAT_32,
-                                       wordorder=self.endianess, unit=unit)
+                                       wordorder=Endian.Little, unit=unit)
         elif power_limit > 0:
             power_value = float(abs(power_limit)) * -1
             log.debug(f"Aktive Batteriesteuerung. Batterie wird mit {power_value} W geladen")
             self.client.write_register(1034, power_value, data_type=ModbusDataType.FLOAT_32,
-                                       wordorder=self.endianess, unit=unit)
+                                       wordorder=Endian.Little, unit=unit)
 
 
 def power_limit_controllable(self) -> bool:

--- a/packages/modules/devices/kostal/kostal_plenticore/counter.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/counter.py
@@ -17,7 +17,6 @@ from modules.common.component_type import ComponentType
 class KwargsDict(TypedDict):
     device_id: int
     modbus_id: int
-    endianess: Endian
     client: ModbusTcpClient_
 
 
@@ -29,7 +28,6 @@ class KostalPlenticoreCounter(AbstractCounter):
     def initialize(self) -> None:
         self.__device_id: int = self.kwargs['device_id']
         self.modbus_id: int = self.kwargs['modbus_id']
-        self.endianess: Endian = self.kwargs['endianess']
         self.client: ModbusTcpClient_ = self.kwargs['client']
         self.store = get_component_value_store(self.component_config.type, self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
@@ -38,17 +36,17 @@ class KostalPlenticoreCounter(AbstractCounter):
 
     def update(self) -> None:
         power = self.client.read_holding_registers(
-            252, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess)
+            252, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little)
         power_factor = self.client.read_holding_registers(
-            150, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess)
+            150, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little)
         currents = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) for reg in [222, 232, 242]]
+            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little) for reg in [222, 232, 242]]
         voltages = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) for reg in [230, 240, 250]]
+            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little) for reg in [230, 240, 250]]
         powers = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) for reg in [224, 234, 244]]
+            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little) for reg in [224, 234, 244]]
         frequency = self.client.read_holding_registers(
-            220, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess)
+            220, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little)
 
         self.peak_filter.check_values(power)
         imported, exported = self.sim_counter.sim_count(power)

--- a/packages/modules/devices/kostal/kostal_plenticore/device.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/device.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 import logging
 from typing import Iterable, Union
-from pymodbus.constants import Endian
 
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.configurable_device import ConfigurableDevice, ComponentFactoryByType, MultiComponentUpdater
-from modules.common.modbus import ModbusDataType, ModbusTcpClient_
+from modules.common.modbus import ModbusTcpClient_
 from modules.devices.kostal.kostal_plenticore.bat import KostalPlenticoreBat
 from modules.devices.kostal.kostal_plenticore.counter import KostalPlenticoreCounter
 from modules.devices.kostal.kostal_plenticore.inverter import KostalPlenticoreInverter
@@ -17,27 +16,23 @@ log = logging.getLogger(__name__)
 
 def create_device(device_config: KostalPlenticore):
     client = None
-    endianess = None
 
     def create_bat_component(component_config: KostalPlenticoreBatSetup):
         return KostalPlenticoreBat(component_config,
                                    device_id=device_config.id,
                                    modbus_id=device_config.configuration.modbus_id,
-                                   endianess=endianess,
                                    client=client)
 
     def create_counter_component(component_config: KostalPlenticoreCounterSetup):
         return KostalPlenticoreCounter(component_config,
                                        device_id=device_config.id,
                                        modbus_id=device_config.configuration.modbus_id,
-                                       endianess=endianess,
                                        client=client)
 
     def create_inverter_component(component_config: KostalPlenticoreInverterSetup):
         return KostalPlenticoreInverter(component_config,
                                         device_id=device_config.id,
                                         modbus_id=device_config.configuration.modbus_id,
-                                        endianess=endianess,
                                         client=client)
 
     def update_components(
@@ -47,10 +42,8 @@ def create_device(device_config: KostalPlenticore):
                 component.update()
 
     def initializer():
-        nonlocal client, endianess
+        nonlocal client
         client = ModbusTcpClient_(device_config.configuration.ip_address, device_config.configuration.port)
-        endianess = Endian.Big if client.read_holding_registers(
-            5, ModbusDataType.UINT_16, unit=device_config.configuration.modbus_id) else Endian.Little
 
     return ConfigurableDevice(
         device_config=device_config,

--- a/packages/modules/devices/kostal/kostal_plenticore/inverter.py
+++ b/packages/modules/devices/kostal/kostal_plenticore/inverter.py
@@ -17,7 +17,6 @@ from modules.common.component_type import ComponentType
 class KwargsDict(TypedDict):
     device_id: int
     modbus_id: int
-    endianess: Endian
     client: ModbusTcpClient_
 
 
@@ -29,7 +28,6 @@ class KostalPlenticoreInverter(AbstractInverter):
     def initialize(self) -> None:
         self.__device_id: int = self.kwargs['device_id']
         self.modbus_id: int = self.kwargs['modbus_id']
-        self.endianess: Endian = self.kwargs['endianess']
         self.client: ModbusTcpClient_ = self.kwargs['client']
         self.store = get_component_value_store(self.component_config.type, self.component_config.id)
         self.fault_state = FaultState(ComponentInfo.from_component_config(self.component_config))
@@ -42,15 +40,15 @@ class KostalPlenticoreInverter(AbstractInverter):
 
     def update(self) -> None:
         power = self.client.read_holding_registers(
-            575, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=self.endianess) * -1
+            575, ModbusDataType.INT_16, unit=self.modbus_id, wordorder=Endian.Little) * -1
         currents = [self.client.read_holding_registers(
-            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) for reg in [154, 160, 166]]
+            reg, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little) for reg in [154, 160, 166]]
         exported = self.client.read_holding_registers(
-            320, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess)
+            320, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little)
         # Try to read dc_power, if it fails just skip it and set to None
         try:
             dc_power = self.client.read_holding_registers(
-                1066, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=self.endianess) * -1
+                1066, ModbusDataType.FLOAT_32, unit=self.modbus_id, wordorder=Endian.Little) * -1
             self.fault_state.no_error()
         except Exception:
             dc_power = None


### PR DESCRIPTION
Es liegt einer der beiden Fehler vor:
- Das Endianess Register liefert bei Neustart und/oder Firmwareupdate einen fehlerhaften Wert.
- Der Kostal fällt bei Neustart und/oder Firmwareupdate kurzzeitig auf die Standard Endianess zurück

Es wird nur noch der Default Wert unterstütztn um Probleme zu vermeiden

GUI: https://github.com/openWB/openwb-ui-settings/pull/1062