### PR TITLE
Modul: wattsonic solinteg

### DIFF
--- a/packages/modules/devices/mtec/mtec/config.py
+++ b/packages/modules/devices/mtec/mtec/config.py
@@ -15,7 +15,7 @@ class MTecConfiguration:
 
 class MTec:
     def __init__(self,
-                 name: str = "M-Tec",
+                 name: str = "M-Tec, Wattsonic, Solinteg",
                  type: str = "mtec",
                  id: int = 0,
                  configuration: MTecConfiguration = None) -> None:
@@ -36,7 +36,7 @@ class MTecBatConfiguration:
 @auto_str
 class MTecBatSetup(ComponentSetup[MTecBatConfiguration]):
     def __init__(self,
-                 name: str = "M-Tec Speicher",
+                 name: str = "M-Tec, Wattsonic, Solinteg Speicher",
                  type: str = "bat",
                  id: int = 0,
                  configuration: MTecBatConfiguration = None,
@@ -53,7 +53,7 @@ class MTecCounterConfiguration:
 @auto_str
 class MTecCounterSetup(ComponentSetup[MTecCounterConfiguration]):
     def __init__(self,
-                 name: str = "M-Tec Zähler",
+                 name: str = "M-Tec, Wattsonic, Solinteg Zähler",
                  type: str = "counter",
                  id: int = 0,
                  configuration: MTecCounterConfiguration = None,
@@ -70,7 +70,7 @@ class MTecInverterConfiguration:
 @auto_str
 class MTecInverterSetup(ComponentSetup[MTecInverterConfiguration]):
     def __init__(self,
-                 name: str = "M-Tec Wechselrichter",
+                 name: str = "M-Tec, Wattsonic, Solinteg Wechselrichter",
                  type: str = "inverter",
                  id: int = 0,
                  configuration: MTecInverterConfiguration = None,

--- a/packages/modules/devices/mtec/vendor.py
+++ b/packages/modules/devices/mtec/vendor.py
@@ -7,7 +7,7 @@ from modules.devices.vendors import VendorGroup
 class Vendor:
     def __init__(self):
         self.type = Path(__file__).parent.name
-        self.vendor = "M-Tec"
+        self.vendor = "M-Tec, Wattsonic, Solinteg"
         self.group = VendorGroup.VENDORS.value
 
 


### PR DESCRIPTION
Alle 3 Hersteller (M-Tec, Wattsonic, Solinteg) benutzen die gleichen Register.

Doku intern abgelegt.
Wattsonic Test in Ticket #66007252