### PR TITLE
rewrite dac consumer module

### DIFF
--- a/packages/modules/consumers/generic/dac/config.py
+++ b/packages/modules/consumers/generic/dac/config.py
@@ -13,17 +13,19 @@ class DacConfiguration:
                  ip_address: Optional[str] = None,
                  port: int = 502,
                  modbus_id: int = 1,
-                 model: Model = Model.N4Dac02):
+                 model: str = Model.N4Dac02.name,
+                 full_signal_range: bool = False) -> None:
         self.ip_address = ip_address
         self.port = port
         self.modbus_id = modbus_id
         self.model = model
+        self.full_signal_range = full_signal_range
 
 
 @auto_str
 class Dac(ConsumerSetup[DacConfiguration]):
     def __init__(self,
-                 name: str = "Digital-Analog-Konverter (DAC) 0.01V bis 10.0V",
+                 name: str = "Digital-Analog-Wandler (DAC)",
                  type: str = "dac",
                  id: int = 0,
                  configuration: Optional[DacConfiguration] = None,

--- a/packages/modules/consumers/generic/dac/consumer.py
+++ b/packages/modules/consumers/generic/dac/consumer.py
@@ -4,7 +4,7 @@ from typing import Optional
 from modules.common.abstract_device import DeviceDescriptor
 from modules.common.component_type import ComponentType
 from modules.common.configurable_consumer import ConfigurableConsumer, SetLimitData
-from modules.common.modbus import ModbusDataType, ModbusTcpClient_
+from modules.common.modbus import ModbusTcpClient_
 from modules.common.simcount._simcounter import SimCounterConsumer
 from modules.consumers.generic.dac.config import Dac
 from modules.consumers.generic.dac.model import Model
@@ -27,18 +27,26 @@ def create_consumer(config: Dac):
     def set_power_limit(power_limit: float, data: SetLimitData) -> None:
         power_limit = max(power_limit, 0)
         modbus_id = config.configuration.modbus_id
-        if config.configuration.model == Model.N4Dac02:
-            client.write_register(1, power_limit * 1000 / data.max_power, ModbusDataType.INT_16, unit=modbus_id)
-        elif config.configuration.model == Model.DA02:
-            client.write_register(0x01f4, power_limit * 4000 / data.max_power, ModbusDataType.INT_16, unit=modbus_id)
-        elif config.configuration.model == Model.M120T:
-            #  Ausgabe nicht kleiner 0,9V sonst Leistungsregelung der WP aus
-            power_limit = max(power_limit * 4095 / data.max_power, 370)
-            client.write_register(0x01f4, power_limit, ModbusDataType.INT_16, unit=modbus_id)
-        elif config.configuration.model == Model.AA02B:
-            power_limit = max((power_limit * (4095-820) / data.max_power)+820, 820)
-            #  Ausgabe nicht kleiner 4ma sonst Leistungsregelung der WP aus
-            client.write_register(0x01f4, power_limit, ModbusDataType.INT_16, unit=modbus_id)
+        try:
+            model_settings = Model[config.configuration.model].value
+        except KeyError:
+            raise ValueError(f"Unknown DAC model: {config.configuration.model}")
+
+        # signal range calculation
+        min_value = model_settings["min_value"]
+        max_value = model_settings["max_value"]
+        signal_range = max_value - min_value
+        if not config.configuration.full_signal_range:
+            min_value = round(min_value + signal_range * model_settings["output_type"].value["live_zero_factor"])
+            signal_range *= (1 - model_settings["output_type"].value["live_zero_factor"])
+
+        # power mapping to signal range
+        mapped_power_limit = round(min_value + (power_limit / data.max_power) * signal_range)
+        mapped_power_limit = max(min(mapped_power_limit, max_value), min_value)
+
+        # modbus write
+        client.write_register(model_settings["register"], mapped_power_limit,
+                              model_settings["data_type"], unit=modbus_id)
 
     return ConfigurableConsumer(consumer_config=config,
                                 initializer=initializer,

--- a/packages/modules/consumers/generic/dac/model.py
+++ b/packages/modules/consumers/generic/dac/model.py
@@ -1,8 +1,42 @@
 from enum import Enum
+from typing import TypedDict
+from modules.common.modbus import ModbusDataType
+
+
+class OutputDict(TypedDict):
+    name: str
+    live_zero_factor: float
+
+
+class OutputType(Enum):
+    VOLTAGE = OutputDict(name="voltage", live_zero_factor=0.1)  # (0)1-10V
+    CURRENT = OutputDict(name="current", live_zero_factor=0.2)  # (0)4-20mA
+
+
+class ModelDict(TypedDict):
+    name: str
+    output_type: OutputType
+    min_value: int
+    max_value: int
+    register: int
+    data_type: ModbusDataType
+
+
+def model_dict(name: str, output_type: OutputType, min_value: int, max_value: int,
+               register: int, data_type: ModbusDataType) -> ModelDict:
+    return {
+        "name": name,
+        "output_type": output_type,
+        "min_value": min_value,
+        "max_value": max_value,
+        "register": register,
+        "data_type": data_type
+    }
 
 
 class Model(Enum):
-    N4Dac02 = "N4Dac02"
-    DA02 = "DA02"
-    M120T = "M120T"
-    AA02B = "AA02B"
+    N4Dac02 = model_dict("N4Dac02", OutputType.VOLTAGE, 0, 1000, 1, ModbusDataType.INT_16)
+    DA02 = model_dict("DA02", OutputType.VOLTAGE, 0, 4000, 500, ModbusDataType.INT_16)
+    M120T_AO1 = model_dict("M120T-1", OutputType.VOLTAGE, 0, 4095, 0, ModbusDataType.INT_16)
+    M120T_AO2 = model_dict("M120T-2", OutputType.VOLTAGE, 0, 4095, 1, ModbusDataType.INT_16)
+    AA02B = model_dict("AA02B", OutputType.CURRENT, 0, 4095, 500, ModbusDataType.INT_16)


### PR DESCRIPTION
- add configuration option for "live zero"
- restructure dac model definition
- use generic parameter based calculations
- allow use of first or second analog output for model M120T

UI: https://github.com/openWB/openwb-ui-settings/pull/1070