### PR TITLE
Koala Sankey diagram

### DIFF
--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -3531,7 +3531,7 @@ class UpdateConfig:
         def upgrade(topic: str, payload) -> Optional[dict]:
             # Add the Sankey diagram to the koala carousel order so it also appears for existing
             # installations.
-            if re.search("^openWB/general/web_theme$", topic) is not None:
+            if topic == "openWB/general/web_theme":
                 configuration_payload = decode_payload(payload)
                 if configuration_payload.get("type") == "koala":
                     configuration = configuration_payload.setdefault("configuration", {})

--- a/packages/helpermodules/update_config.py
+++ b/packages/helpermodules/update_config.py
@@ -58,7 +58,7 @@ NO_MODULE = {"type": None, "configuration": {}}
 
 class UpdateConfig:
 
-    DATASTORE_VERSION = 139
+    DATASTORE_VERSION = 140
 
     valid_topic = [
         "^openWB/bat/config/bat_control_activated$",
@@ -3526,3 +3526,29 @@ class UpdateConfig:
                     return {topic: payload_device}
         self._loop_all_received_topics(upgrade)
         self._append_datastore_version(139)
+
+    def upgrade_datastore_140(self) -> None:
+        def upgrade(topic: str, payload) -> Optional[dict]:
+            # Add the Sankey diagram to the koala carousel order so it also appears for existing
+            # installations.
+            if re.search("^openWB/general/web_theme$", topic) is not None:
+                configuration_payload = decode_payload(payload)
+                if configuration_payload.get("type") == "koala":
+                    configuration = configuration_payload.setdefault("configuration", {})
+                    slide_order = configuration.get("top_carousel_slide_order")
+                    if not isinstance(slide_order, list):
+                        slide_order = [
+                            "flow_diagram",
+                            "history_chart",
+                            "daily_totals",
+                            "sankey_chart",
+                        ]
+                    elif "sankey_chart" not in slide_order:
+                        slide_order.append("sankey_chart")
+                    else:
+                        return None
+                    configuration["top_carousel_slide_order"] = slide_order
+                    return {topic: configuration_payload}
+            return None
+        self._loop_all_received_topics(upgrade)
+        self._append_datastore_version(140)

--- a/packages/modules/web_themes/koala/config.py
+++ b/packages/modules/web_themes/koala/config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from helpermodules.auto_str import auto_str
 
 from modules.common.abstract_device import DeviceDescriptor
@@ -12,7 +14,7 @@ class KoalaWebThemeConfiguration:
                  vehicle_card_view_breakpoint: int = 4,
                  chargePoint_table_search_input_field: bool = False,
                  vehicle_table_search_input_field: bool = False,
-                 top_carousel_slide_order: list = None
+                 top_carousel_slide_order: Optional[list[str]] = None
                  ) -> None:
         self.hide_standard_vehicle = hide_standard_vehicle
         self.history_chart_range = history_chart_range
@@ -35,7 +37,7 @@ class KoalaWebTheme:
                  type: str = "koala",
                  official: bool = True,
                  userManagementSupported: bool = True,
-                 configuration: KoalaWebThemeConfiguration = None) -> None:
+                 configuration: Optional[KoalaWebThemeConfiguration] = None) -> None:
         self.name = name
         self.type = type
         self.official = official

--- a/packages/modules/web_themes/koala/config.py
+++ b/packages/modules/web_themes/koala/config.py
@@ -24,6 +24,7 @@ class KoalaWebThemeConfiguration:
             "flow_diagram",
             "history_chart",
             "daily_totals",
+            "sankey_chart",
         ]
 
 

--- a/packages/modules/web_themes/koala/source/package-lock.json
+++ b/packages/modules/web_themes/koala/source/package-lock.json
@@ -11,6 +11,7 @@
         "@quasar/extras": "^1.18.0",
         "chart.js": "^4.5.1",
         "chartjs-adapter-luxon": "^1.3.1",
+        "chartjs-chart-sankey": "^0.15.0",
         "chartjs-plugin-annotation": "^3.1.0",
         "chartjs-plugin-zoom": "^2.2.0",
         "luxon": "^3.7.2",
@@ -5975,6 +5976,15 @@
       "peerDependencies": {
         "chart.js": ">=3.0.0",
         "luxon": ">=1.0.0"
+      }
+    },
+    "node_modules/chartjs-chart-sankey": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/chartjs-chart-sankey/-/chartjs-chart-sankey-0.15.0.tgz",
+      "integrity": "sha512-NU0RHKPcUr6iXco2UvzXPA+z0TK/I11m1Pgy+6GqwdrmaGEiD3WQeNFF8NDxyJPkTFYQ/9kKijPQzuHBit41Dg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.3.0"
       }
     },
     "node_modules/chartjs-plugin-annotation": {

--- a/packages/modules/web_themes/koala/source/package.json
+++ b/packages/modules/web_themes/koala/source/package.json
@@ -17,6 +17,7 @@
     "@quasar/extras": "^1.18.0",
     "chart.js": "^4.5.1",
     "chartjs-adapter-luxon": "^1.3.1",
+    "chartjs-chart-sankey": "^0.15.0",
     "chartjs-plugin-annotation": "^3.1.0",
     "chartjs-plugin-zoom": "^2.2.0",
     "luxon": "^3.7.2",

--- a/packages/modules/web_themes/koala/source/quasar.config.ts
+++ b/packages/modules/web_themes/koala/source/quasar.config.ts
@@ -13,7 +13,7 @@ export default defineConfig((ctx) => {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli-vite/boot-files
-    boot: ['store-init'],
+    boot: ['store-init', 'chart-defaults'],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ['app.scss'],

--- a/packages/modules/web_themes/koala/source/src/boot/chart-defaults.ts
+++ b/packages/modules/web_themes/koala/source/src/boot/chart-defaults.ts
@@ -1,0 +1,12 @@
+import { boot } from 'quasar/wrappers';
+import { Chart } from 'chart.js';
+
+// Chart.js draws in its own Helvetica/Arial stack, which resolves to a
+// different face on every platform and matches none of them to the Roboto the
+// rest of the app is set in. Set the global default rather than a per-chart
+// `options.font`: scale ticks and axis titles resolve their font through
+// Chart.defaults, not through the chart's options, so a per-chart setting
+// reaches only the plugins that read `chart.options.font` by hand.
+export default boot(() => {
+  Chart.defaults.font.family = "'Roboto', sans-serif";
+});

--- a/packages/modules/web_themes/koala/source/src/components/ChartCarousel.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChartCarousel.vue
@@ -51,6 +51,7 @@ import { useQuasar } from 'quasar';
 import EnergyFlowChart from './charts/energyFlowChart/EnergyFlowChart.vue';
 import HistoryChart from './charts/historyChart/HistoryChart.vue';
 import DailyTotals from './charts/dailyTotals/DailyTotals.vue';
+import SankeyChart from './charts/sankeyChart/SankeyChart.vue';
 import { useLocalDataStore } from 'src/stores/localData-store';
 import { useMqttStore } from 'src/stores/mqtt-store';
 
@@ -78,27 +79,27 @@ const componentMap = {
   flow_diagram: EnergyFlowChart,
   history_chart: HistoryChart,
   daily_totals: DailyTotals,
+  sankey_chart: SankeyChart,
 };
 
+// Order used when no stored order exists. Also the source of truth for which
+// slides may be auto-appended to an existing (older) stored order.
+const defaultSlideOrder = Object.keys(componentMap);
+
 const chartCarouselItems = computed(() => {
-  const slideOrder = mqttStore.themeConfiguration?.top_carousel_slide_order;
-  if (!slideOrder || slideOrder.length === 0) {
-    return [
-      {
-        name: 'flow_diagram',
-        component: EnergyFlowChart,
-      },
-      {
-        name: 'history_chart',
-        component: HistoryChart,
-      },
-      {
-        name: 'daily_totals',
-        component: DailyTotals,
-      },
-    ];
+  const storedOrder =
+    mqttStore.themeConfiguration?.top_carousel_slide_order ?? [];
+  const order = storedOrder.length > 0 ? [...storedOrder] : defaultSlideOrder;
+
+  // Append any known slide missing from a stored order, so slides added in an
+  // update appear for existing installs without discarding a custom ordering.
+  for (const name of defaultSlideOrder) {
+    if (!order.includes(name)) {
+      order.push(name);
+    }
   }
-  return slideOrder
+
+  return order
     .map((name) => ({
       name,
       component: componentMap[name as keyof typeof componentMap],

--- a/packages/modules/web_themes/koala/source/src/components/ChartCarousel.vue
+++ b/packages/modules/web_themes/koala/source/src/components/ChartCarousel.vue
@@ -82,24 +82,29 @@ const componentMap = {
   sankey_chart: SankeyChart,
 };
 
-// Order used when no stored order exists. Also the source of truth for which
-// slides may be auto-appended to an existing (older) stored order.
-const defaultSlideOrder = Object.keys(componentMap);
-
 const chartCarouselItems = computed(() => {
-  const storedOrder =
-    mqttStore.themeConfiguration?.top_carousel_slide_order ?? [];
-  const order = storedOrder.length > 0 ? [...storedOrder] : defaultSlideOrder;
-
-  // Append any known slide missing from a stored order, so slides added in an
-  // update appear for existing installs without discarding a custom ordering.
-  for (const name of defaultSlideOrder) {
-    if (!order.includes(name)) {
-      order.push(name);
-    }
+  const slideOrder = mqttStore.themeConfiguration?.top_carousel_slide_order;
+  if (!slideOrder || slideOrder.length === 0) {
+    return [
+      {
+        name: 'flow_diagram',
+        component: EnergyFlowChart,
+      },
+      {
+        name: 'history_chart',
+        component: HistoryChart,
+      },
+      {
+        name: 'daily_totals',
+        component: DailyTotals,
+      },
+      {
+        name: 'sankey_chart',
+        component: SankeyChart,
+      },
+    ];
   }
-
-  return order
+  return slideOrder
     .map((name) => ({
       name,
       component: componentMap[name as keyof typeof componentMap],

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -35,7 +35,7 @@ defineOptions({ name: 'SankeyChart' });
 defineProps<{ showLegend?: boolean }>();
 
 const $q = useQuasar();
-const { allocation, colorForNode } = useSankeyData();
+const { allocation, colorForNode, labelColor } = useSankeyData();
 
 const hasFlows = computed(() => allocation.value.edges.length > 0);
 
@@ -62,6 +62,8 @@ const chartData = computed<ChartData<'sankey'>>(() => {
     columns[node.id] = sources.some((source) => source.id === node.id) ? 0 : 1;
   }
 
+  const textColor = labelColor();
+
   return {
     datasets: [
       {
@@ -73,6 +75,10 @@ const chartData = computed<ChartData<'sankey'>>(() => {
         colorTo: (ctx) => colorForNode(ctx.raw.to),
         colorMode: 'gradient',
         borderWidth: 0,
+        color: textColor,
+        nodeLabels: { color: textColor },
+        nodeWidth: 16,
+        nodePadding: 12,
       },
     ],
   };

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -3,6 +3,7 @@
     <div class="chart-wrapper">
       <ChartjsSankey
         v-if="hasFlows"
+        :key="edgeCount"
         :data="chartData"
         :options="chartOptions"
         :plugins="chartPlugins"
@@ -46,6 +47,14 @@ const $q = useQuasar();
 const { allocation, colorForNode, labelColor } = useSankeyData();
 
 const hasFlows = computed(() => allocation.value.edges.length > 0);
+
+// Remount the chart whenever the number of flows changes. The sankey plugin
+// rebuilds its whole node map on every parse, but Chart.js parses twice when
+// data grows — once for the existing elements, then again for the inserted
+// ones. The second parse discards the node objects the existing flows point
+// at, so those flows color orphans while the chart paints the new nodes, which
+// have no color and fall back to black. A fresh chart parses only once.
+const edgeCount = computed(() => allocation.value.edges.length);
 
 const { hoverPlugin, focusColors } = useSankeyHover(colorForNode);
 const chartPlugins = [hoverPlugin];

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -19,23 +19,24 @@
 import { computed } from 'vue';
 import { useQuasar } from 'quasar';
 import { createTypedChart } from 'vue-chartjs';
-import { Tooltip, LinearScale } from 'chart.js';
+import { LinearScale } from 'chart.js';
 import { SankeyController, Flow } from 'chartjs-chart-sankey';
-import type { ChartData, ChartOptions, TooltipItem } from 'chart.js';
+import type { ChartData, ChartOptions } from 'chart.js';
 import type { SankeyDataPoint } from 'chartjs-chart-sankey';
 import { useSankeyData } from './useSankeyData';
 import { useSankeyHover } from './useSankeyHover';
+import { createFlowLabels } from './sankey-flow-labels';
 
 // A typed sankey component (like vue-chartjs's built-in Line/Bar) so the
 // `data`/`options` props are fixed to 'sankey' instead of the whole ChartType
 // union. createTypedChart also registers what we pass: the sankey controller
 // and element, plus the LinearScale its defaults require (non-obvious, since a
-// sankey shows no axes) and the Tooltip.
+// sankey shows no axes). The Tooltip is deliberately not registered — values
+// are drawn on the flows instead, see sankey-flow-labels.
 const ChartjsSankey = createTypedChart('sankey', [
   SankeyController,
   Flow,
   LinearScale,
-  Tooltip,
 ]);
 
 defineOptions({ name: 'SankeyChart' });
@@ -56,9 +57,6 @@ const hasFlows = computed(() => allocation.value.edges.length > 0);
 // have no color and fall back to black. A fresh chart parses only once.
 const edgeCount = computed(() => allocation.value.edges.length);
 
-const { hoverPlugin, focusColors } = useSankeyHover(colorForNode);
-const chartPlugins = [hoverPlugin];
-
 const formatWatts = (watts: number): string => {
   if (Math.abs(watts) >= 1000) {
     return `${(watts / 1000).toLocaleString('de-DE', {
@@ -68,6 +66,12 @@ const formatWatts = (watts: number): string => {
   }
   return `${Math.round(watts)} W`;
 };
+
+const { hoverPlugin, focusColors } = useSankeyHover(colorForNode);
+const chartPlugins = [
+  hoverPlugin,
+  createFlowLabels({ format: formatWatts, color: labelColor }),
+];
 
 const chartData = computed<ChartData<'sankey'>>(() => {
   // Reference the theme so a light/dark toggle rebuilds data and re-resolves
@@ -120,18 +124,6 @@ const chartOptions = computed<ChartOptions<'sankey'>>(() => ({
   responsive: true,
   maintainAspectRatio: false,
   animation: false,
-  plugins: {
-    tooltip: {
-      callbacks: {
-        label: (item: TooltipItem<'sankey'>) => {
-          const raw = item.raw as SankeyDataPoint;
-          const from = allocation.value.nodes.find((node) => node.id === raw.from);
-          const to = allocation.value.nodes.find((node) => node.id === raw.to);
-          return `${from?.label ?? raw.from} → ${to?.label ?? raw.to}: ${formatWatts(raw.flow)}`;
-        },
-      },
-    },
-  },
 }));
 </script>
 

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -67,10 +67,14 @@ const formatWatts = (watts: number): string => {
   return `${Math.round(watts)} W`;
 };
 
-const { hoverPlugin, focusColors } = useSankeyHover(colorForNode);
+const { hoverPlugin, focusColors, dimIfUnfocused } = useSankeyHover(colorForNode);
+
 const chartPlugins = [
   hoverPlugin,
-  createFlowLabels({ format: formatWatts, color: labelColor }),
+  createFlowLabels({
+    format: formatWatts,
+    color: (dataIndex) => dimIfUnfocused(labelColor(), dataIndex),
+  }),
 ];
 
 const chartData = computed<ChartData<'sankey'>>(() => {

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -19,7 +19,7 @@
 import { computed } from 'vue';
 import { useQuasar } from 'quasar';
 import { createTypedChart } from 'vue-chartjs';
-import { LinearScale } from 'chart.js';
+import { LinearScale, Tooltip } from 'chart.js';
 import { SankeyController, Flow } from 'chartjs-chart-sankey';
 import type { ChartData, ChartOptions } from 'chart.js';
 import type { SankeyDataPoint } from 'chartjs-chart-sankey';
@@ -31,12 +31,14 @@ import { createFlowLabels } from './sankey-flow-labels';
 // `data`/`options` props are fixed to 'sankey' instead of the whole ChartType
 // union. createTypedChart also registers what we pass: the sankey controller
 // and element, plus the LinearScale its defaults require (non-obvious, since a
-// sankey shows no axes). The Tooltip is deliberately not registered — values
-// are drawn on the flows instead, see sankey-flow-labels.
+// sankey shows no axes). The Tooltip is the fallback for values that
+// sankey-flow-labels could not draw on the flow itself: a band too thin to
+// hold a line of text, or a label with nowhere to go that did not collide.
 const ChartjsSankey = createTypedChart('sankey', [
   SankeyController,
   Flow,
   LinearScale,
+  Tooltip,
 ]);
 
 defineOptions({ name: 'SankeyChart' });
@@ -128,6 +130,16 @@ const chartOptions = computed<ChartOptions<'sankey'>>(() => ({
   responsive: true,
   maintainAspectRatio: false,
   animation: false,
+  plugins: {
+    tooltip: {
+      displayColors: false,
+      callbacks: {
+        // The default title is the flow's index, which means nothing here.
+        title: () => '',
+        label: (item) => formatWatts((item.raw as SankeyDataPoint).flow),
+      },
+    },
+  },
 }));
 </script>
 

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -1,8 +1,10 @@
 <template>
-  <div class="sankey-chart-wrapper">
-    <ChartjsSankey v-if="hasFlows" :data="chartData" :options="chartOptions" />
-    <div v-else class="sankey-empty text-grey text-center">
-      Aktuell kein Energiefluss
+  <div class="chart-container">
+    <div class="chart-wrapper">
+      <ChartjsSankey v-if="hasFlows" :data="chartData" :options="chartOptions" />
+      <div v-else class="sankey-empty text-grey text-center">
+        Aktuell kein Energiefluss
+      </div>
     </div>
   </div>
 </template>
@@ -103,15 +105,31 @@ const chartOptions = computed<ChartOptions<'sankey'>>(() => ({
 </script>
 
 <style scoped>
-.sankey-chart-wrapper {
+.chart-container {
   width: 100%;
   height: 100%;
-  min-height: 300px;
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+}
+
+.chart-wrapper {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  position: relative;
+}
+
+.chart-wrapper > canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.sankey-empty {
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-}
-.sankey-empty {
   font-size: 1rem;
 }
 </style>

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -73,8 +73,10 @@ const chartData = computed<ChartData<'sankey'>>(() => {
         data: edges.map((edge) => ({ from: edge.from, to: edge.to, flow: edge.flow })),
         labels,
         column: columns,
-        colorFrom: (ctx) => colorForNode(ctx.raw.from),
-        colorTo: (ctx) => colorForNode(ctx.raw.to),
+        colorFrom: (ctx) =>
+          colorForNode((ctx.raw as SankeyDataPoint | undefined)?.from ?? ''),
+        colorTo: (ctx) =>
+          colorForNode((ctx.raw as SankeyDataPoint | undefined)?.to ?? ''),
         colorMode: 'gradient',
         borderWidth: 0,
         color: textColor,
@@ -89,6 +91,7 @@ const chartData = computed<ChartData<'sankey'>>(() => {
 const chartOptions = computed<ChartOptions<'sankey'>>(() => ({
   responsive: true,
   maintainAspectRatio: false,
+  animation: false,
   plugins: {
     tooltip: {
       callbacks: {

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -87,13 +87,28 @@ const chartData = computed<ChartData<'sankey'>>(() => {
   // Chart.js calls later) is what makes this recompute on every hover change.
   const flowColor = focusColors();
 
-  const { edges, nodes, sources } = allocation.value;
+  const { edges, nodes, sources, sinks } = allocation.value;
   const labels: Record<string, string> = {};
   const columns: Record<string, number> = {};
   for (const node of nodes) {
     labels[node.id] = node.label;
     columns[node.id] = sources.some((source) => source.id === node.id) ? 0 : 1;
   }
+
+  // Assign a per-column priority from node power.
+  // Sources descending (largest on top).
+  // Sinks ascending (largest on the bottom).
+  const priority: Record<string, number> = {};
+  [...sources]
+    .sort((a, b) => b.power - a.power)
+    .forEach((node, index) => {
+      priority[node.id] = index;
+    });
+  [...sinks]
+    .sort((a, b) => a.power - b.power)
+    .forEach((node, index) => {
+      priority[node.id] = index;
+    });
 
   const textColor = labelColor();
 
@@ -108,6 +123,7 @@ const chartData = computed<ChartData<'sankey'>>(() => {
         })),
         labels,
         column: columns,
+        priority,
         colorFrom: (ctx) =>
           flowColor(
             (ctx.raw as SankeyDataPoint | undefined)?.from ?? '',

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="sankey-chart-wrapper">
+    <ChartjsSankey v-if="hasFlows" :data="chartData" :options="chartOptions" />
+    <div v-else class="sankey-empty text-grey text-center">
+      Aktuell kein Energiefluss
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useQuasar } from 'quasar';
+import { createTypedChart } from 'vue-chartjs';
+import { Tooltip, LinearScale } from 'chart.js';
+import { SankeyController, Flow } from 'chartjs-chart-sankey';
+import type { ChartData, ChartOptions, TooltipItem } from 'chart.js';
+import type { SankeyDataPoint } from 'chartjs-chart-sankey';
+import { useSankeyData } from './useSankeyData';
+
+// A typed sankey component (like vue-chartjs's built-in Line/Bar) so the
+// `data`/`options` props are fixed to 'sankey' instead of the whole ChartType
+// union. createTypedChart also registers what we pass: the sankey controller
+// and element, plus the LinearScale its defaults require (non-obvious, since a
+// sankey shows no axes) and the Tooltip.
+const ChartjsSankey = createTypedChart('sankey', [
+  SankeyController,
+  Flow,
+  LinearScale,
+  Tooltip,
+]);
+
+defineOptions({ name: 'SankeyChart' });
+
+// Accepted for parity with the other carousel charts; not used here.
+defineProps<{ showLegend?: boolean }>();
+
+const $q = useQuasar();
+const { allocation, colorForNode } = useSankeyData();
+
+const hasFlows = computed(() => allocation.value.edges.length > 0);
+
+const formatWatts = (watts: number): string => {
+  if (Math.abs(watts) >= 1000) {
+    return `${(watts / 1000).toLocaleString('de-DE', {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    })} kW`;
+  }
+  return `${Math.round(watts)} W`;
+};
+
+const chartData = computed<ChartData<'sankey'>>(() => {
+  // Reference the theme so a light/dark toggle rebuilds data and re-resolves
+  // the CSS color variables.
+  void $q.dark.isActive;
+
+  const { edges, nodes, sources } = allocation.value;
+  const labels: Record<string, string> = {};
+  const columns: Record<string, number> = {};
+  for (const node of nodes) {
+    labels[node.id] = node.label;
+    columns[node.id] = sources.some((source) => source.id === node.id) ? 0 : 1;
+  }
+
+  return {
+    datasets: [
+      {
+        label: 'Energiefluss',
+        data: edges.map((edge) => ({ from: edge.from, to: edge.to, flow: edge.flow })),
+        labels,
+        column: columns,
+        colorFrom: (ctx) => colorForNode(ctx.raw.from),
+        colorTo: (ctx) => colorForNode(ctx.raw.to),
+        colorMode: 'gradient',
+        borderWidth: 0,
+      },
+    ],
+  };
+});
+
+const chartOptions = computed<ChartOptions<'sankey'>>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    tooltip: {
+      callbacks: {
+        label: (item: TooltipItem<'sankey'>) => {
+          const raw = item.raw as SankeyDataPoint;
+          const from = allocation.value.nodes.find((node) => node.id === raw.from);
+          const to = allocation.value.nodes.find((node) => node.id === raw.to);
+          return `${from?.label ?? raw.from} → ${to?.label ?? raw.to}: ${formatWatts(raw.flow)}`;
+        },
+      },
+    },
+  },
+}));
+</script>
+
+<style scoped>
+.sankey-chart-wrapper {
+  width: 100%;
+  height: 100%;
+  min-height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sankey-empty {
+  font-size: 1rem;
+}
+</style>

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="chart-container">
     <div class="chart-wrapper">
-      <ChartjsSankey v-if="hasFlows" :data="chartData" :options="chartOptions" />
+      <ChartjsSankey
+        v-if="hasFlows"
+        :data="chartData"
+        :options="chartOptions"
+        :plugins="chartPlugins"
+      />
       <div v-else class="sankey-empty text-grey text-center">
         Aktuell kein Energiefluss
       </div>
@@ -10,12 +15,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useQuasar } from 'quasar';
 import { createTypedChart } from 'vue-chartjs';
 import { Tooltip, LinearScale } from 'chart.js';
 import { SankeyController, Flow } from 'chartjs-chart-sankey';
-import type { ChartData, ChartOptions, TooltipItem } from 'chart.js';
+import type { ChartData, ChartOptions, Plugin, TooltipItem } from 'chart.js';
 import type { SankeyDataPoint } from 'chartjs-chart-sankey';
 import { useSankeyData } from './useSankeyData';
 
@@ -41,6 +46,79 @@ const { allocation, colorForNode, labelColor } = useSankeyData();
 
 const hasFlows = computed(() => allocation.value.edges.length > 0);
 
+// Index of the flow currently under the cursor (null = none). Used to fade all
+// other flows so the hovered one stands out, like other Sankey products.
+const hoveredIndex = ref<number | null>(null);
+
+// Non-hovered flows are pushed toward grey so the hovered one keeps its color.
+// The plugin re-applies its own alpha to flow gradients, so fading by alpha
+// alone changes only the nodes, not the flows — we must change the RGB.
+const FADE_TOWARD = 150; // mid grey (neutral in light and dark)
+const FADE_AMOUNT = 0.65; // 0 = untouched, 1 = fully grey
+
+// Parse a hex or rgb/rgba colour string to its RGB channels.
+const toRgb = (color: string): { r: number; g: number; b: number } | null => {
+  if (color.startsWith('#')) {
+    let hex = color.slice(1);
+    if (hex.length === 3) {
+      hex = hex
+        .split('')
+        .map((char) => char + char)
+        .join('');
+    }
+    const value = parseInt(hex, 16);
+    return { r: (value >> 16) & 255, g: (value >> 8) & 255, b: value & 255 };
+  }
+  const match = color.match(/rgba?\(([^)]+)\)/);
+  if (match) {
+    const [r, g, b] = match[1].split(',').map((part) => parseInt(part.trim(), 10));
+    return { r, g, b };
+  }
+  return null;
+};
+
+// Faded version of a colour for non-hovered flows: mixed toward grey.
+const fade = (color: string): string => {
+  const rgb = toRgb(color);
+  if (rgb === null) {
+    return color;
+  }
+  const mix = (channel: number) =>
+    Math.round(channel * (1 - FADE_AMOUNT) + FADE_TOWARD * FADE_AMOUNT);
+  return `rgb(${mix(rgb.r)}, ${mix(rgb.g)}, ${mix(rgb.b)})`;
+};
+
+// The color for one end of a flow, faded when another flow is hovered.
+// `hovered` is passed in (not read from the ref) so that chartData, which
+// captures it, re-runs and yields a fresh dataset whenever the hover changes —
+// that is what forces Chart.js to re-resolve the flow colors.
+const flowColor = (
+  nodeId: string,
+  dataIndex: number,
+  hovered: number | null,
+): string => {
+  const base = colorForNode(nodeId);
+  return hovered !== null && dataIndex !== hovered ? fade(base) : base;
+};
+
+// Hover is tracked from a plugin rather than the `onHover` option
+const hoverFocus: Plugin<'sankey'> = {
+  id: 'sankeyHoverFocus',
+  afterEvent(chart, args) {
+    // Ignore the post-update replay: it re-reports a stale in-area position and
+    // would resurrect a highlight we just cleared.
+    if (args.replay) {
+      return;
+    }
+    const left = !args.inChartArea || args.event.type === 'mouseout';
+    hoveredIndex.value = left
+      ? null
+      : (chart.getActiveElements()[0]?.index ?? null);
+  },
+};
+
+const chartPlugins = [hoverFocus];
+
 const formatWatts = (watts: number): string => {
   if (Math.abs(watts) >= 1000) {
     return `${(watts / 1000).toLocaleString('de-DE', {
@@ -55,6 +133,11 @@ const chartData = computed<ChartData<'sankey'>>(() => {
   // Reference the theme so a light/dark toggle rebuilds data and re-resolves
   // the CSS color variables.
   void $q.dark.isActive;
+
+  // Capturing the hovered flow here makes this recompute (and emit a fresh
+  // dataset) on every hover change, which is what forces Chart.js to re-resolve
+  // the flow colors
+  const hovered = hoveredIndex.value;
 
   const { edges, nodes, sources } = allocation.value;
   const labels: Record<string, string> = {};
@@ -74,9 +157,17 @@ const chartData = computed<ChartData<'sankey'>>(() => {
         labels,
         column: columns,
         colorFrom: (ctx) =>
-          colorForNode((ctx.raw as SankeyDataPoint | undefined)?.from ?? ''),
+          flowColor(
+            (ctx.raw as SankeyDataPoint | undefined)?.from ?? '',
+            ctx.dataIndex,
+            hovered,
+          ),
         colorTo: (ctx) =>
-          colorForNode((ctx.raw as SankeyDataPoint | undefined)?.to ?? ''),
+          flowColor(
+            (ctx.raw as SankeyDataPoint | undefined)?.to ?? '',
+            ctx.dataIndex,
+            hovered,
+          ),
         colorMode: 'gradient',
         borderWidth: 0,
         color: textColor,

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -71,13 +71,11 @@ const formatWatts = (watts: number): string => {
 
 const { hoverPlugin, focusColors, dimIfUnfocused } = useSankeyHover(colorForNode);
 
-const chartPlugins = [
-  hoverPlugin,
-  createFlowLabels({
-    format: formatWatts,
-    color: (dataIndex) => dimIfUnfocused(labelColor(), dataIndex),
-  }),
-];
+const flowLabels = createFlowLabels({
+  format: formatWatts,
+  color: (dataIndex) => dimIfUnfocused(labelColor(), dataIndex),
+});
+const chartPlugins = [hoverPlugin, flowLabels.plugin];
 
 const chartData = computed<ChartData<'sankey'>>(() => {
   // Reference the theme so a light/dark toggle rebuilds data and re-resolves
@@ -133,8 +131,9 @@ const chartOptions = computed<ChartOptions<'sankey'>>(() => ({
   plugins: {
     tooltip: {
       displayColors: false,
+      // Only flows whose value is not already drawn on the band.
+      filter: (item) => !flowLabels.labelled.has(item.dataIndex),
       callbacks: {
-        // The default title is the flow's index, which means nothing here.
         title: () => '',
         label: (item) => formatWatts((item.raw as SankeyDataPoint).flow),
       },

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -61,7 +61,7 @@ const edgeCount = computed(() => allocation.value.edges.length);
 
 const formatWatts = (watts: number): string => {
   if (Math.abs(watts) >= 1000) {
-    return `${(watts / 1000).toLocaleString('de-DE', {
+    return `${(watts / 1000).toLocaleString(undefined, {
       minimumFractionDigits: 1,
       maximumFractionDigits: 1,
     })} kW`;
@@ -69,7 +69,8 @@ const formatWatts = (watts: number): string => {
   return `${Math.round(watts)} W`;
 };
 
-const { hoverPlugin, focusColors, dimIfUnfocused } = useSankeyHover(colorForNode);
+const { hoverPlugin, focusColors, dimIfUnfocused } =
+  useSankeyHover(colorForNode);
 
 const flowLabels = createFlowLabels({
   format: formatWatts,
@@ -100,7 +101,11 @@ const chartData = computed<ChartData<'sankey'>>(() => {
     datasets: [
       {
         label: 'Energiefluss',
-        data: edges.map((edge) => ({ from: edge.from, to: edge.to, flow: edge.flow })),
+        data: edges.map((edge) => ({
+          from: edge.from,
+          to: edge.to,
+          flow: edge.flow,
+        })),
         labels,
         column: columns,
         colorFrom: (ctx) =>

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/SankeyChart.vue
@@ -15,14 +15,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { useQuasar } from 'quasar';
 import { createTypedChart } from 'vue-chartjs';
 import { Tooltip, LinearScale } from 'chart.js';
 import { SankeyController, Flow } from 'chartjs-chart-sankey';
-import type { ChartData, ChartOptions, Plugin, TooltipItem } from 'chart.js';
+import type { ChartData, ChartOptions, TooltipItem } from 'chart.js';
 import type { SankeyDataPoint } from 'chartjs-chart-sankey';
 import { useSankeyData } from './useSankeyData';
+import { useSankeyHover } from './useSankeyHover';
 
 // A typed sankey component (like vue-chartjs's built-in Line/Bar) so the
 // `data`/`options` props are fixed to 'sankey' instead of the whole ChartType
@@ -46,78 +47,8 @@ const { allocation, colorForNode, labelColor } = useSankeyData();
 
 const hasFlows = computed(() => allocation.value.edges.length > 0);
 
-// Index of the flow currently under the cursor (null = none). Used to fade all
-// other flows so the hovered one stands out, like other Sankey products.
-const hoveredIndex = ref<number | null>(null);
-
-// Non-hovered flows are pushed toward grey so the hovered one keeps its color.
-// The plugin re-applies its own alpha to flow gradients, so fading by alpha
-// alone changes only the nodes, not the flows — we must change the RGB.
-const FADE_TOWARD = 150; // mid grey (neutral in light and dark)
-const FADE_AMOUNT = 0.65; // 0 = untouched, 1 = fully grey
-
-// Parse a hex or rgb/rgba colour string to its RGB channels.
-const toRgb = (color: string): { r: number; g: number; b: number } | null => {
-  if (color.startsWith('#')) {
-    let hex = color.slice(1);
-    if (hex.length === 3) {
-      hex = hex
-        .split('')
-        .map((char) => char + char)
-        .join('');
-    }
-    const value = parseInt(hex, 16);
-    return { r: (value >> 16) & 255, g: (value >> 8) & 255, b: value & 255 };
-  }
-  const match = color.match(/rgba?\(([^)]+)\)/);
-  if (match) {
-    const [r, g, b] = match[1].split(',').map((part) => parseInt(part.trim(), 10));
-    return { r, g, b };
-  }
-  return null;
-};
-
-// Faded version of a colour for non-hovered flows: mixed toward grey.
-const fade = (color: string): string => {
-  const rgb = toRgb(color);
-  if (rgb === null) {
-    return color;
-  }
-  const mix = (channel: number) =>
-    Math.round(channel * (1 - FADE_AMOUNT) + FADE_TOWARD * FADE_AMOUNT);
-  return `rgb(${mix(rgb.r)}, ${mix(rgb.g)}, ${mix(rgb.b)})`;
-};
-
-// The color for one end of a flow, faded when another flow is hovered.
-// `hovered` is passed in (not read from the ref) so that chartData, which
-// captures it, re-runs and yields a fresh dataset whenever the hover changes —
-// that is what forces Chart.js to re-resolve the flow colors.
-const flowColor = (
-  nodeId: string,
-  dataIndex: number,
-  hovered: number | null,
-): string => {
-  const base = colorForNode(nodeId);
-  return hovered !== null && dataIndex !== hovered ? fade(base) : base;
-};
-
-// Hover is tracked from a plugin rather than the `onHover` option
-const hoverFocus: Plugin<'sankey'> = {
-  id: 'sankeyHoverFocus',
-  afterEvent(chart, args) {
-    // Ignore the post-update replay: it re-reports a stale in-area position and
-    // would resurrect a highlight we just cleared.
-    if (args.replay) {
-      return;
-    }
-    const left = !args.inChartArea || args.event.type === 'mouseout';
-    hoveredIndex.value = left
-      ? null
-      : (chart.getActiveElements()[0]?.index ?? null);
-  },
-};
-
-const chartPlugins = [hoverFocus];
+const { hoverPlugin, focusColors } = useSankeyHover(colorForNode);
+const chartPlugins = [hoverPlugin];
 
 const formatWatts = (watts: number): string => {
   if (Math.abs(watts) >= 1000) {
@@ -134,10 +65,9 @@ const chartData = computed<ChartData<'sankey'>>(() => {
   // the CSS color variables.
   void $q.dark.isActive;
 
-  // Capturing the hovered flow here makes this recompute (and emit a fresh
-  // dataset) on every hover change, which is what forces Chart.js to re-resolve
-  // the flow colors
-  const hovered = hoveredIndex.value;
+  // Reading the hover state here (rather than in the color callbacks, which
+  // Chart.js calls later) is what makes this recompute on every hover change.
+  const flowColor = focusColors();
 
   const { edges, nodes, sources } = allocation.value;
   const labels: Record<string, string> = {};
@@ -160,13 +90,11 @@ const chartData = computed<ChartData<'sankey'>>(() => {
           flowColor(
             (ctx.raw as SankeyDataPoint | undefined)?.from ?? '',
             ctx.dataIndex,
-            hovered,
           ),
         colorTo: (ctx) =>
           flowColor(
             (ctx.raw as SankeyDataPoint | undefined)?.to ?? '',
             ctx.dataIndex,
-            hovered,
           ),
         colorMode: 'gradient',
         borderWidth: 0,

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/energy-allocation.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/energy-allocation.ts
@@ -1,0 +1,148 @@
+/** Fixed node ids. Chargepoints/consumers use dynamic ids (see input). */
+export const NODE_GRID = 'grid';
+export const NODE_PV = 'pv';
+export const NODE_BATTERY = 'battery';
+export const NODE_HOUSE = 'house';
+
+/**
+ * Raw signed power per component, using the same sign conventions as the
+ * existing EnergyFlowChart / store getters:
+ *   grid    : + import (source)   | - export (sink)
+ *   pv      : - production (source)| + consumption (rare)
+ *   battery : + charging (sink)   | - discharging (source)
+ *   cp/consumer power: + drawing (sink) | - feeding back, e.g. V2G (source)
+ */
+export interface EnergyFlowInput {
+  grid: number;
+  pv: number;
+  battery: number;
+  chargePoints: DynamicNodeInput[];
+  consumers: DynamicNodeInput[];
+}
+
+export interface DynamicNodeInput {
+  id: string;
+  label: string;
+  power: number;
+}
+
+export interface FlowNode {
+  id: string;
+  label: string;
+  power: number;
+}
+
+export interface FlowEdge {
+  from: string;
+  to: string;
+  flow: number;
+}
+
+export interface AllocationResult {
+  edges: FlowEdge[];
+  /** Every node that participates, so the caller can build labels + columns. */
+  nodes: FlowNode[];
+  sources: FlowNode[];
+  sinks: FlowNode[];
+  totalSources: number;
+  totalSinks: number;
+  imbalance: number;
+}
+
+const MIN_EDGE_WATTS = 1;
+
+/**
+ * Split the raw component totals into source and sink nodes with positive
+ * magnitudes. Household consumption is added as the residual so the diagram
+ * balances by construction.
+ */
+function classifyNodes(input: EnergyFlowInput): {
+  sources: FlowNode[];
+  sinks: FlowNode[];
+} {
+  const sources: FlowNode[] = [];
+  const sinks: FlowNode[] = [];
+
+  if (input.grid > 0) {
+    sources.push({ id: NODE_GRID, label: 'Netz', power: input.grid });
+  } else if (input.grid < 0) {
+    sinks.push({ id: NODE_GRID, label: 'Netz', power: -input.grid });
+  }
+
+  if (input.pv < 0) {
+    sources.push({ id: NODE_PV, label: 'PV', power: -input.pv });
+  }
+
+  if (input.battery > 0) {
+    sinks.push({ id: NODE_BATTERY, label: 'Speicher', power: input.battery });
+  } else if (input.battery < 0) {
+    sources.push({
+      id: NODE_BATTERY,
+      label: 'Speicher',
+      power: -input.battery,
+    });
+  }
+
+  for (const cp of input.chargePoints) {
+    if (cp.power > 0) {
+      sinks.push({ id: cp.id, label: cp.label, power: cp.power });
+    } else if (cp.power < 0) {
+      sources.push({ id: cp.id, label: cp.label, power: -cp.power });
+    }
+  }
+
+  for (const consumer of input.consumers) {
+    if (consumer.power > 0) {
+      sinks.push({ id: consumer.id, label: consumer.label, power: consumer.power });
+    } else if (consumer.power < 0) {
+      sources.push({ id: consumer.id, label: consumer.label, power: -consumer.power });
+    }
+  }
+
+  // Household consumption = balancing residual.
+  const totalSources = sumPower(sources);
+  const otherSinks = sumPower(sinks);
+  const house = Math.max(0, totalSources - otherSinks);
+  if (house > 0) {
+    sinks.push({ id: NODE_HOUSE, label: 'Hausverbrauch', power: house });
+  }
+
+  return { sources, sinks };
+}
+
+function sumPower(nodes: FlowNode[]): number {
+  return nodes.reduce((total, node) => total + node.power, 0);
+}
+
+/**
+ * Compute the Sankey edges from the raw component totals using the uniform
+ * proportional rule. Returns edges plus the classified nodes and totals.
+ */
+export function allocate(input: EnergyFlowInput): AllocationResult {
+  const { sources, sinks } = classifyNodes(input);
+  const totalSources = sumPower(sources);
+  const totalSinks = sumPower(sinks);
+
+  const edges: FlowEdge[] = [];
+  if (totalSources > 0 && totalSinks > 0) {
+    for (const source of sources) {
+      const share = source.power / totalSources;
+      for (const sink of sinks) {
+        const flow = sink.power * share;
+        if (flow >= MIN_EDGE_WATTS) {
+          edges.push({ from: source.id, to: sink.id, flow });
+        }
+      }
+    }
+  }
+
+  return {
+    edges,
+    nodes: [...sources, ...sinks],
+    sources,
+    sinks,
+    totalSources,
+    totalSinks,
+    imbalance: totalSources - totalSinks,
+  };
+}

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/energy-allocation.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/energy-allocation.ts
@@ -114,6 +114,27 @@ function sumPower(nodes: FlowNode[]): number {
   return nodes.reduce((total, node) => total + node.power, 0);
 }
 
+export interface GroupOptions {
+  threshold: number;
+  id: string;
+  label: string;
+}
+
+/**
+ * Collapse a list of dynamic nodes (chargePoints or consumers) into a single
+ * aggregated node once it exceeds the threshold.
+ */
+export function groupNodes(
+  nodes: DynamicNodeInput[],
+  options: GroupOptions,
+): DynamicNodeInput[] {
+  if (nodes.length <= options.threshold) {
+    return nodes;
+  }
+  const power = nodes.reduce((total, node) => total + node.power, 0);
+  return [{ id: options.id, label: options.label, power }];
+}
+
 /**
  * Compute the Sankey edges from the raw component totals using the uniform
  * proportional rule. Returns edges plus the classified nodes and totals.

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/energy-allocation.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/energy-allocation.ts
@@ -18,6 +18,17 @@ export interface EnergyFlowInput {
   battery: number;
   chargePoints: DynamicNodeInput[];
   consumers: DynamicNodeInput[];
+  /**
+   * Hybrid inverter/battery pairs. A hybrid battery charges from its inverter's
+   * PV directly on the shared DC bus, before the remaining PV mixes with grid
+   * on the AC side. Absent/empty means no hybrid handling (standard behavior).
+   */
+  hybrid?: HybridPair[];
+}
+
+export interface HybridPair {
+  inverterPv: number;
+  batteryCharge: number;
 }
 
 export interface DynamicNodeInput {
@@ -136,19 +147,64 @@ export function groupNodes(
 }
 
 /**
- * Compute the Sankey edges from the raw component totals using the uniform
- * proportional rule. Returns edges plus the classified nodes and totals.
+ * Compute the Sankey edges from the raw component totals.
+ *
+ * Rule: uniform proportional (every sink gets the same source mix), with one
+ * pre-step for hybrid systems. On a hybrid inverter the battery charges from
+ * that inverter's PV directly on the DC bus, upstream of where PV and grid mix
+ * on the AC side. So we first carve a fixed PV -> battery edge for that DC
+ * charge, then run the proportional rule on whatever source/sink power remains.
+ * With no hybrid pairs this reduces to plain uniform proportional.
  */
 export function allocate(input: EnergyFlowInput): AllocationResult {
   const { sources, sinks } = classifyNodes(input);
   const totalSources = sumPower(sources);
   const totalSinks = sumPower(sinks);
 
+  // Hybrid carve-out: PV routed to hybrid batteries on the DC bus.
+  const pvNode = sources.find((node) => node.id === NODE_PV);
+  const batteryNode = sinks.find((node) => node.id === NODE_BATTERY);
+  let pvDirectToBattery = 0;
+  if (pvNode !== undefined && batteryNode !== undefined) {
+    for (const pair of input.hybrid ?? []) {
+      pvDirectToBattery += Math.min(pair.inverterPv, pair.batteryCharge);
+    }
+    // Never route more than the PV we actually have or the battery took.
+    pvDirectToBattery = Math.max(
+      0,
+      Math.min(pvDirectToBattery, pvNode.power, batteryNode.power),
+    );
+  }
+
+  // Amounts fed into the proportional pass, with the DC charge removed. Node
+  // totals are reconstituted from (fixed edge + proportional edges), so node
+  // sizes in the diagram stay correct.
+  const propSources = sources.map((node) =>
+    node.id === NODE_PV
+      ? { ...node, power: node.power - pvDirectToBattery }
+      : node,
+  );
+  const propSinks = sinks.map((node) =>
+    node.id === NODE_BATTERY
+      ? { ...node, power: node.power - pvDirectToBattery }
+      : node,
+  );
+  const remainingSourceTotal = sumPower(propSources);
+
   const edges: FlowEdge[] = [];
-  if (totalSources > 0 && totalSinks > 0) {
-    for (const source of sources) {
-      const share = source.power / totalSources;
-      for (const sink of sinks) {
+  if (pvDirectToBattery >= MIN_EDGE_WATTS) {
+    edges.push({ from: NODE_PV, to: NODE_BATTERY, flow: pvDirectToBattery });
+  }
+  if (remainingSourceTotal > 0) {
+    for (const source of propSources) {
+      if (source.power <= 0) {
+        continue;
+      }
+      const share = source.power / remainingSourceTotal;
+      for (const sink of propSinks) {
+        if (sink.power <= 0) {
+          continue;
+        }
         const flow = sink.power * share;
         if (flow >= MIN_EDGE_WATTS) {
           edges.push({ from: source.id, to: sink.id, flow });

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/energy-allocation.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/energy-allocation.ts
@@ -147,6 +147,28 @@ export function groupNodes(
 }
 
 /**
+ * Fold edges sharing the same from/to into one summed edge. The hybrid
+ * carve-out and the proportional pass can both emit a PV -> battery edge
+ * whenever both nodes still have power left over (any system with a second
+ * inverter or a second battery). Left unmerged that draws two ribbons between
+ * the same pair of nodes and lists two tooltip entries for one flow.
+ */
+function mergeEdges(edges: FlowEdge[]): FlowEdge[] {
+  const merged: FlowEdge[] = [];
+  for (const edge of edges) {
+    const existing = merged.find(
+      (candidate) => candidate.from === edge.from && candidate.to === edge.to,
+    );
+    if (existing === undefined) {
+      merged.push({ ...edge });
+    } else {
+      existing.flow += edge.flow;
+    }
+  }
+  return merged;
+}
+
+/**
  * Compute the Sankey edges from the raw component totals.
  *
  * Rule: uniform proportional (every sink gets the same source mix), with one
@@ -214,7 +236,7 @@ export function allocate(input: EnergyFlowInput): AllocationResult {
   }
 
   return {
-    edges,
+    edges: mergeEdges(edges),
     nodes: [...sources, ...sinks],
     sources,
     sinks,

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/sankey-flow-labels.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/sankey-flow-labels.ts
@@ -1,0 +1,63 @@
+/**
+ * Value labels drawn in the middle of each flow.
+ *
+ * The plugin has a built-in `flowLabels` option, but it renders the raw flow
+ * number (`${this.flow}` in Flow.draw), so there is no way to format watts as
+ * "6,90 kW". This draws the labels ourselves instead, with the same formatting
+ * the rest of the theme uses.
+ */
+import { defaults } from 'chart.js';
+import { toFont } from 'chart.js/helpers';
+import type { Plugin } from 'chart.js';
+
+// Clear space to leave either side of the text.
+const HORIZONTAL_MARGIN = 8;
+
+interface FlowGeometry {
+  flow: number;
+  height: number;
+  x: number;
+  x2: number;
+  y: number;
+  y2: number;
+}
+
+export function createFlowLabels(options: {
+  format: (watts: number) => string;
+  color: () => string;
+}): Plugin<'sankey'> {
+  return {
+    id: 'sankeyFlowLabels',
+    afterDatasetsDraw(chart) {
+      const { ctx } = chart;
+      const flows = chart.getDatasetMeta(0).data as unknown as FlowGeometry[];
+      // Same font the plugin resolves for the node labels, so the two sets of
+      // text match.
+      const font = toFont(chart.options.font ?? defaults.font);
+
+      ctx.save();
+      ctx.font = font.string;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = options.color();
+
+      for (const flow of flows) {
+        // Bands thinner than a line of text cannot hold the label legibly.
+        if (flow.height < font.lineHeight) {
+          continue;
+        }
+        const text = options.format(flow.flow);
+        if (
+          ctx.measureText(text).width >
+          flow.x2 - flow.x - HORIZONTAL_MARGIN
+        ) {
+          continue;
+        }
+        const x = (flow.x + flow.x2) / 2;
+        const y = (flow.y + flow.y2) / 2 + flow.height / 2;
+        ctx.fillText(text, x, y);
+      }
+      ctx.restore();
+    },
+  };
+}

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/sankey-flow-labels.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/sankey-flow-labels.ts
@@ -59,8 +59,11 @@ function overlaps(a: LabelBox, b: LabelBox): boolean {
 export function createFlowLabels(options: {
   format: (watts: number) => string;
   color: (dataIndex: number) => string;
-}): Plugin<'sankey'> {
-  return {
+}): { plugin: Plugin<'sankey'>; labelled: ReadonlySet<number> } {
+  // tooltip not displayed for flows with labels.
+  const labelled = new Set<number>();
+
+  const plugin: Plugin<'sankey'> = {
     id: 'sankeyFlowLabels',
     afterDatasetsDraw(chart) {
       const { ctx } = chart;
@@ -75,6 +78,7 @@ export function createFlowLabels(options: {
       ctx.textBaseline = 'middle';
 
       const placed: LabelBox[] = [];
+      labelled.clear();
 
       for (const [dataIndex, flow] of flows.entries()) {
         // Bands thinner than a line of text cannot hold the label legibly.
@@ -113,10 +117,13 @@ export function createFlowLabels(options: {
         }
 
         placed.push(box);
+        labelled.add(dataIndex);
         ctx.fillStyle = options.color(dataIndex);
         ctx.fillText(text, center.x, center.y);
       }
       ctx.restore();
     },
   };
+
+  return { plugin, labelled };
 }

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/sankey-flow-labels.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/sankey-flow-labels.ts
@@ -1,17 +1,29 @@
 /**
- * Value labels drawn in the middle of each flow.
+ * Value labels drawn on each flow.
  *
  * The plugin has a built-in `flowLabels` option, but it renders the raw flow
  * number (`${this.flow}` in Flow.draw), so there is no way to format watts as
  * "6,90 kW". This draws the labels ourselves instead, with the same formatting
  * the rest of the theme uses.
+ *
+ * Labels are placed along the flow rather than always at its midpoint: two
+ * flows that cross can pass through the same point, and stacking their values
+ * there leaves both unreadable. A label that still cannot be placed is left
+ * out, and the tooltip carries its value instead.
  */
 import { defaults } from 'chart.js';
 import { toFont } from 'chart.js/helpers';
 import type { Plugin } from 'chart.js';
 
-// Clear space to leave either side of the text.
-const HORIZONTAL_MARGIN = 8;
+const HORIZONTAL_CLEARANCE = 8;
+
+const VERTICAL_MARGIN = 2;
+
+// Positions to try along the flow, as a fraction of its length. The midpoint
+// first, then alternating outwards, so a label moves the shortest distance
+// that clears its neighbours. Staying clear of the ends leaves the node labels
+// alone and avoids the steepest part of the curve.
+const POSITIONS = [0.5, 0.35, 0.65, 0.25, 0.75, 0.15, 0.85];
 
 interface FlowGeometry {
   flow: number;
@@ -20,6 +32,28 @@ interface FlowGeometry {
   x2: number;
   y: number;
   y2: number;
+}
+
+interface LabelBox {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+// Center of the flow band at `t`, 0 being the left node and 1 the right.
+function centerAt(flow: FlowGeometry, t: number): { x: number; y: number } {
+  // start + (distance to travel) × (fraction travelled at t)
+  return {
+    x: flow.x + (flow.x2 - flow.x) * t * (2 - 3 * t + 2 * t * t),
+    y: flow.y + (flow.y2 - flow.y) * t * t * (3 - 2 * t) + flow.height / 2,
+  };
+}
+
+function overlaps(a: LabelBox, b: LabelBox): boolean {
+  return (
+    a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top
+  );
 }
 
 export function createFlowLabels(options: {
@@ -40,24 +74,47 @@ export function createFlowLabels(options: {
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
 
-      // The index is the flow's position in the dataset, which is what the
-      // hover focus keys off, so `color` can dim a label with its band.
+      const placed: LabelBox[] = [];
+
       for (const [dataIndex, flow] of flows.entries()) {
         // Bands thinner than a line of text cannot hold the label legibly.
         if (flow.height < font.lineHeight) {
           continue;
         }
         const text = options.format(flow.flow);
-        if (
-          ctx.measureText(text).width >
-          flow.x2 - flow.x - HORIZONTAL_MARGIN
-        ) {
+        const halfWidth =
+          ctx.measureText(text).width / 2 + HORIZONTAL_CLEARANCE / 2;
+        const halfHeight = font.lineHeight / 2 + VERTICAL_MARGIN;
+        // First position that fits between the two nodes and clears every
+        // label already placed.
+        let center: { x: number; y: number } | undefined;
+        let box: LabelBox | undefined;
+        for (const t of POSITIONS) {
+          const candidate = centerAt(flow, t);
+          const candidateBox = {
+            left: candidate.x - halfWidth,
+            right: candidate.x + halfWidth,
+            top: candidate.y - halfHeight,
+            bottom: candidate.y + halfHeight,
+          };
+          if (candidateBox.left < flow.x || candidateBox.right > flow.x2) {
+            continue;
+          }
+          if (placed.some((other) => overlaps(candidateBox, other))) {
+            continue;
+          }
+          center = candidate;
+          box = candidateBox;
+          break;
+        }
+        // Nowhere left to put it: leave this one to the tooltip.
+        if (center === undefined || box === undefined) {
           continue;
         }
-        const x = (flow.x + flow.x2) / 2;
-        const y = (flow.y + flow.y2) / 2 + flow.height / 2;
+
+        placed.push(box);
         ctx.fillStyle = options.color(dataIndex);
-        ctx.fillText(text, x, y);
+        ctx.fillText(text, center.x, center.y);
       }
       ctx.restore();
     },

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/sankey-flow-labels.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/sankey-flow-labels.ts
@@ -24,7 +24,7 @@ interface FlowGeometry {
 
 export function createFlowLabels(options: {
   format: (watts: number) => string;
-  color: () => string;
+  color: (dataIndex: number) => string;
 }): Plugin<'sankey'> {
   return {
     id: 'sankeyFlowLabels',
@@ -39,9 +39,10 @@ export function createFlowLabels(options: {
       ctx.font = font.string;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillStyle = options.color();
 
-      for (const flow of flows) {
+      // The index is the flow's position in the dataset, which is what the
+      // hover focus keys off, so `color` can dim a label with its band.
+      for (const [dataIndex, flow] of flows.entries()) {
         // Bands thinner than a line of text cannot hold the label legibly.
         if (flow.height < font.lineHeight) {
           continue;
@@ -55,6 +56,7 @@ export function createFlowLabels(options: {
         }
         const x = (flow.x + flow.x2) / 2;
         const y = (flow.y + flow.y2) / 2 + flow.height / 2;
+        ctx.fillStyle = options.color(dataIndex);
         ctx.fillText(text, x, y);
       }
       ctx.restore();

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyData.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyData.ts
@@ -40,6 +40,16 @@ export function useSankeyData() {
     }),
   );
 
+  // Hybrid inverter/battery pairs: how much of each hybrid battery's charge is
+  // covered by its own inverter's PV on the DC bus. pvPowerIndividual reports
+  // production as negative; batteryPower reports charging as positive.
+  const hybrid = computed(() =>
+    mqttStore.hybridInverters.map(({ inverterId, batteryId }) => ({
+      inverterPv: Math.max(0, -num(mqttStore.pvPowerIndividual(inverterId, 'value'))),
+      batteryCharge: Math.max(0, num(mqttStore.batteryPower(batteryId, 'value'))),
+    })),
+  );
+
   const allocation = computed<AllocationResult>(() =>
     allocate({
       grid: num(mqttStore.counterPower('value')),
@@ -49,6 +59,7 @@ export function useSankeyData() {
         : 0,
       chargePoints: chargePoints.value,
       consumers: consumers.value,
+      hybrid: hybrid.value,
     }),
   );
 

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyData.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyData.ts
@@ -1,0 +1,71 @@
+/**
+ * Store adapter for the live Sankey diagram.
+ */
+import { computed } from 'vue';
+import { useMqttStore } from 'src/stores/mqtt-store';
+import { allocate, type AllocationResult } from './energy-allocation';
+
+export function useSankeyData() {
+  const mqttStore = useMqttStore();
+
+  const num = (value: unknown): number => Number(value) || 0;
+
+  const chargePoints = computed(() =>
+    mqttStore.chargePointIds.map((id) => ({
+      id: `cp${id}`,
+      label: mqttStore.chargePointName(id) || `Ladepunkt ${id}`,
+      power: num(mqttStore.chargePointPower(id, 'value')),
+    })),
+  );
+
+  // Consumers placeholder
+  const consumers = computed(() => []);
+
+  const allocation = computed<AllocationResult>(() =>
+    allocate({
+      grid: num(mqttStore.counterPower('value')),
+      pv: mqttStore.pvConfigured ? num(mqttStore.pvPowerTotal('value')) : 0,
+      battery: mqttStore.batteryConfigured
+        ? num(mqttStore.batteryTotalPower('value'))
+        : 0,
+      chargePoints: chargePoints.value,
+      consumers: consumers.value,
+    }),
+  );
+
+  /**
+   * Resolve the display color for a node id.
+   */
+  const colorForNode = (id: string): string => {
+    switch (id) {
+      case 'grid':
+        return cssVar('--q-grid-stroke');
+      case 'pv':
+        return cssVar('--q-pv-stroke');
+      case 'battery':
+        return cssVar('--q-battery-stroke');
+      case 'house':
+        return cssVar('--q-home-stroke');
+    }
+    if (id.startsWith('cp')) {
+      const cpId = Number(id.slice(2));
+      return mqttStore.chargePointColor(cpId) || cssVar('--q-charge-point-stroke');
+    }
+    //placeholder
+    return cssVar('--q-vehicle-stroke');
+  };
+
+  return { allocation, colorForNode };
+}
+
+/**
+ * Read a CSS custom property as a concrete color string. Resolved against
+ * document.body (not documentElement) so the `.body--dark` overrides apply.
+ */
+function cssVar(name: string): string {
+  if (typeof document === 'undefined') {
+    return '#888888';
+  }
+  const value = getComputedStyle(document.body).getPropertyValue(name).trim();
+  return value || '#888888';
+}

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyData.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyData.ts
@@ -3,7 +3,17 @@
  */
 import { computed } from 'vue';
 import { useMqttStore } from 'src/stores/mqtt-store';
-import { allocate, type AllocationResult } from './energy-allocation';
+import {
+  allocate,
+  groupNodes,
+  type AllocationResult,
+  type DynamicNodeInput,
+} from './energy-allocation';
+
+// Aggregate chargepoints/consumers into a single node once there are more than the threshold.
+const GROUP_THRESHOLD = 3;
+const CP_GROUP_ID = 'cp_group';
+const CONSUMER_GROUP_ID = 'consumer_group';
 
 export function useSankeyData() {
   const mqttStore = useMqttStore();
@@ -11,15 +21,24 @@ export function useSankeyData() {
   const num = (value: unknown): number => Number(value) || 0;
 
   const chargePoints = computed(() =>
-    mqttStore.chargePointIds.map((id) => ({
-      id: `cp${id}`,
-      label: mqttStore.chargePointName(id) || `Ladepunkt ${id}`,
-      power: num(mqttStore.chargePointPower(id, 'value')),
-    })),
+    groupNodes(
+      mqttStore.chargePointIds.map((id) => ({
+        id: `cp${id}`,
+        label: mqttStore.chargePointName(id) || `Ladepunkt ${id}`,
+        power: num(mqttStore.chargePointPower(id, 'value')),
+      })),
+      { threshold: GROUP_THRESHOLD, id: CP_GROUP_ID, label: 'Ladepunkte' },
+    ),
   );
 
-  // Consumers placeholder
-  const consumers = computed(() => []);
+  // Consumer placeholder
+  const consumers = computed(() =>
+    groupNodes([] as DynamicNodeInput[], {
+      threshold: GROUP_THRESHOLD,
+      id: CONSUMER_GROUP_ID,
+      label: 'Verbraucher',
+    }),
+  );
 
   const allocation = computed<AllocationResult>(() =>
     allocate({
@@ -46,16 +65,29 @@ export function useSankeyData() {
         return cssVar('--q-battery-stroke');
       case 'house':
         return cssVar('--q-home-stroke');
+      case CP_GROUP_ID:
+        return cssVar('--q-charge-point-stroke');
+      case CONSUMER_GROUP_ID:
+        return cssVar('--q-vehicle-stroke');
     }
     if (id.startsWith('cp')) {
       const cpId = Number(id.slice(2));
       return mqttStore.chargePointColor(cpId) || cssVar('--q-charge-point-stroke');
     }
-    //placeholder
+    // Placeholder
     return cssVar('--q-vehicle-stroke');
   };
 
-  return { allocation, colorForNode };
+
+  //Node-label color for dark mode / light mode.
+  const labelColor = (): string => {
+    if (typeof document === 'undefined') {
+      return '#000000';
+    }
+    return getComputedStyle(document.body).color || '#000000';
+  };
+
+  return { allocation, colorForNode, labelColor };
 }
 
 /**

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyHover.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyHover.ts
@@ -1,0 +1,100 @@
+/**
+ * Hover focus for the Sankey diagram: the flow under the cursor keeps its
+ * color while every other flow is dimmed toward grey, so the hovered one
+ * stands out.
+ */
+import { ref } from 'vue';
+import type { Plugin } from 'chart.js';
+
+// Non-hovered flows are pushed toward grey. The sankey plugin re-applies its
+// own alpha to flow gradients, so fading by alpha alone would change only the
+// nodes, not the flows — we must change the RGB.
+const FADE_TOWARD = 150; // mid grey (neutral in light and dark)
+const FADE_AMOUNT = 0.65; // 0 = untouched, 1 = fully grey
+
+export function useSankeyHover(colorForNode: (id: string) => string) {
+  // Index of the flow under the cursor, as a position in the dataset's `data`
+  // array (null = none).
+  const hoveredIndex = ref<number | null>(null);
+
+  /**
+   * Tracks the hovered flow. This is a plugin rather than the `onHover` option
+   * because Chart.js only calls onHover for events inside the chart area, so a
+   * mouseout could never clear the highlight that way. Chart.js also replays
+   * the last in-area event after every update(), which would re-apply the
+   * highlight that same repaint was meant to clear. afterEvent sees every
+   * event, mouseout included, and can tell a replay from a real one.
+   */
+  const hoverPlugin: Plugin<'sankey'> = {
+    id: 'sankeyHoverFocus',
+    afterEvent(chart, args) {
+      // Ignore the post-update replay: it re-reports a stale in-area position
+      // and would resurrect a highlight we just cleared.
+      if (args.replay) {
+        return;
+      }
+      const left = !args.inChartArea || args.event.type === 'mouseout';
+      hoveredIndex.value = left
+        ? null
+        : (chart.getActiveElements()[0]?.index ?? null);
+    },
+  };
+
+  /**
+   * Returns the color function for one end of a flow: the node's own color,
+   * or a faded version when a different flow is hovered.
+   *
+   * Call this inside the computed that builds the chart data, and call it
+   * afresh on every recompute: it reads the hover state there, which is what
+   * makes the dataset rebuild — and Chart.js re-resolve the flow colors — when
+   * the hover changes. Hoisting the result out of the computed would freeze
+   * the highlight.
+   */
+  const focusColors = () => {
+    const hovered = hoveredIndex.value;
+    return (nodeId: string, dataIndex: number): string => {
+      const base = colorForNode(nodeId);
+      return hovered !== null && dataIndex !== hovered ? fade(base) : base;
+    };
+  };
+
+  return { hoverPlugin, focusColors };
+}
+
+/**
+ * Faded version of a color for non-hovered flows: mixed toward grey.
+ */
+function fade(color: string): string {
+  const rgb = toRgb(color);
+  if (rgb === null) {
+    return color;
+  }
+  const mix = (channel: number) =>
+    Math.round(channel * (1 - FADE_AMOUNT) + FADE_TOWARD * FADE_AMOUNT);
+  return `rgb(${mix(rgb.r)}, ${mix(rgb.g)}, ${mix(rgb.b)})`;
+}
+
+/**
+ * Parse a hex or rgb/rgba color string to its RGB channels.
+ */
+function toRgb(color: string): { r: number; g: number; b: number } | null {
+  if (color.startsWith('#')) {
+    let hex = color.slice(1);
+    if (hex.length === 3) {
+      hex = hex
+        .split('')
+        .map((char) => char + char)
+        .join('');
+    }
+    const value = parseInt(hex, 16);
+    return { r: (value >> 16) & 255, g: (value >> 8) & 255, b: value & 255 };
+  }
+  const match = color.match(/rgba?\(([^)]+)\)/);
+  if (match) {
+    const [r, g, b] = match[1]
+      .split(',')
+      .map((part) => parseInt(part.trim(), 10));
+    return { r, g, b };
+  }
+  return null;
+}

--- a/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyHover.ts
+++ b/packages/modules/web_themes/koala/source/src/components/charts/sankeyChart/useSankeyHover.ts
@@ -58,7 +58,17 @@ export function useSankeyHover(colorForNode: (id: string) => string) {
     };
   };
 
-  return { hoverPlugin, focusColors };
+  /**
+   * Fades an arbitrary color unless its flow is the hovered one, for things
+   * drawn outside the dataset — the flow value labels, which would otherwise
+   * stay at full contrast over a dimmed band.
+   */
+  const dimIfUnfocused = (color: string, dataIndex: number): string => {
+    const hovered = hoveredIndex.value;
+    return hovered !== null && dataIndex !== hovered ? fade(color) : color;
+  };
+
+  return { hoverPlugin, focusColors, dimIfUnfocused };
 }
 
 /**

--- a/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
+++ b/packages/modules/web_themes/koala/source/src/stores/mqtt-store.ts
@@ -3937,6 +3937,34 @@ export const useMqttStore = defineStore('mqtt', () => {
     );
   });
 
+   /**
+   * Get the hybrid inverter/battery pairs. A battery is treated as "hybrid"
+   * when it is a direct child of an inverter in the component hierarchy
+   * The pairing is needed for the flow calculation - (Sankey Chart).
+   * @returns array of { inverterId, batteryId } pairs
+   */
+  const hybridInverters = computed(() => {
+    const result: { inverterId: number; batteryId: number }[] = [];
+    function walk(nodes: Hierarchy[] | undefined) {
+      if (nodes === undefined) {
+        return;
+      }
+      nodes.forEach((node) => {
+        if (node.type === 'inverter') {
+          const firstBatChild = node.children.find(
+            (child) => child.type === 'bat',
+          );
+          if (firstBatChild !== undefined) {
+            result.push({ inverterId: node.id, batteryId: firstBatChild.id });
+          }
+        }
+        walk(node.children);
+      });
+    }
+    walk(getValue.value('openWB/counter/get/hierarchy') as Hierarchy[]);
+    return result;
+  });
+
   /**
    * Get pv power
    * @param returnType type of return value, 'textValue', 'value', 'scaledValue', 'scaledUnit' or 'object'
@@ -4284,6 +4312,7 @@ export const useMqttStore = defineStore('mqtt', () => {
     homeDailyYield,
     // PV data
     pvConfigured,
+    hybridInverters,
     pvPowerTotal,
     pvDailyExported,
     pvIds,


### PR DESCRIPTION
Das Sankey-Diagramm wurde dem oberen Karussell als separate Slide hinzugefügt.

Das Sankey-Diagramm visualisiert die aktuellen Energieflüsse und zeigt, welcher Anteil jeder Quelle – PV, Netz, Speicher – auf welche Senke – Haus, Ladepunkte, Speicher – entfällt.

Abhängigkeit: Dieser PR gehört zu https://github.com/openWB/openwb-ui-settings/pull/1071 im Settings-Repository und sollte gemeinsam mit diesem gemergt werden. Dort wird das Sankey-Diagramm in die Sortierung der oberen Karussell-Slides aufgenommen.

Bei Hybrid-Wechselrichtern lädt der Speicher direkt per DC aus der eigenen PV. Das Diagramm erkennt dies an der Gerätehierarchie (Speicher als Kind des Wechselrichters) und ordnet die Speicherladung zuerst der PV zu – statt sie anteilig auf alle Quellen zu verteilen.

Wenn mehr als drei Ladepunkte konfiguriert sind, werden die Ladepunkte zu einem einzigen Sink mit der Bezeichnung „Ladepunkte“ zusammengefasst.


plugin:
Für das Diagramm nutzen wir das Chart.js-Plugin chartjs-chart-sankey (npm-Paket). Trotz niedriger Versionsnummer wird es von kurkle, einem der Chart.js-Kernentwickler, gepflegt – wir bleiben damit innerhalb einer Bibliothek.

Eigener Code (Hover & Beschriftung):

Ergänzt wurde eigener Code für zwei Dinge:

Hervorhebung beim Überfahren: Der Fluss unter dem Cursor bleibt farbig, alle anderen Flüsse und ihre Beschriftungen werden ins Graue abgedunkelt.
Die Hover-Hervorhebung des Sankey-Plugins ist sehr dezent. Daher wurde ein eigener, deutlicherer Hover-Fokus für eine bessere Visualisierung implementiert.

Wertbeschriftung: Jeder Fluss trägt seine Leistung mit nachgestellter Einheit (z. B. „6,90 kW"); überlappende Labels werden entlang des Flusses versetzt, der Rest per Tooltip gezeigt.


Die Schriftart für die Chart-JS im Koala-Theme wurde global angepasst, sodass sie nun mit der Schriftart der restlichen Anwendung übereinstimmt.

<img width="1614" height="1137" alt="Bildschirmfoto vom 2026-08-31 12-00-27" src="https://github.com/user-attachments/assets/5a89735a-6a1f-43ea-aa7c-6461dbe56a38" />

<img width="1618" height="1178" alt="Bildschirmfoto vom 2026-08-31 13-37-44" src="https://github.com/user-attachments/assets/6ccb9b18-8caf-4f80-9e2b-443ad60770b3" />

Hover:
<img width="1534" height="614" alt="Bildschirmfoto vom 2026-08-31 13-38-20" src="https://github.com/user-attachments/assets/80d48e16-f552-4b3f-bc15-bd839ab0f0b1" />

Label Verschiebung:
<img width="905" height="402" alt="Bildschirmfoto vom 2026-08-31 13-39-32" src="https://github.com/user-attachments/assets/4b8322d6-92b4-4feb-b934-47d72e7d2881" />

Tooltip:
<img width="916" height="475" alt="Bildschirmfoto vom 2026-08-31 13-40-26" src="https://github.com/user-attachments/assets/0b82b934-4e7b-49c2-8df9-368d3a2b1757" />

Ladepunkt-Zusammenführung.
<img width="887" height="477" alt="Bildschirmfoto vom 2026-08-31 13-43-33" src="https://github.com/user-attachments/assets/aa4e2ebf-b87e-4989-9f81-8ffb915c640b" />

Slide Reinfolge einstellbar unter Einstellungen:
<img width="1145" height="637" alt="Bildschirmfoto vom 2026-08-31 14-57-00" src="https://github.com/user-attachments/assets/4c7857fc-f591-4bd1-a549-514052436443" />

