### PR TITLE
fix: loadvars crashes on timed-out counter component

### DIFF
--- a/packages/modules/loadvars.py
+++ b/packages/modules/loadvars.py
@@ -119,6 +119,8 @@ class Loadvars:
         for counter in data.data.counter_data.values():
             try:
                 component = get_finished_component_obj_by_id(counter.num, not_finished_threads)
+                if component is None:
+                    continue
                 if component.component_config.type == "virtual":
                     if len(data.data.counter_all_data.get_entry_of_element(counter.num)["children"]) == 0:
                         thread_name = f"component{component.component_config.id}"


### PR DESCRIPTION
`_update_values_virtual_counter_uncounted_consumption()` prüft `component.component_config.type`
ohne vorher auf `None` zu prüfen. `get_finished_component_obj_by_id()` liefert `None`, wenn das
zugehörige Gerät im Timeout hängt - dann crasht es mit `AttributeError: 'NoneType' object has
no attribute 'component_config'`, statt den Zähler für diesen Zyklus zu überspringen.

`_update_values_of_level_buttom_top()` im selben File macht denselben Aufruf bereits korrekt
mit `None`-Check - dieser PR gleicht die zweite Methode an dasselbe Muster an.