### PR TITLE
Rabot: fehlenden Zeitraum beim Preisabruf ergänzen

### DIFF
--- a/packages/modules/electricity_pricing/flexible_tariffs/rabot/tariff.py
+++ b/packages/modules/electricity_pricing/flexible_tariffs/rabot/tariff.py
@@ -12,14 +12,23 @@ log = logging.getLogger(__name__)
 
 
 def fetch(config: RabotTariff) -> None:
-    raw_prices = req.get_http_session().get(
+    # Ohne Zeitraum liefert der Proxy isSuccess=true mit 0 Einträgen (consideredDataPeriod: null), siehe #3883 --
+    # Name/Format dieser Parameter ist nicht dokumentiert und an einem echten Rabot-Konto zu verifizieren.
+    now = datetime.datetime.now()
+    params = {
+        "startDate": now.strftime("%Y-%m-%d"),
+        "endDate": (now + datetime.timedelta(days=1)).strftime("%Y-%m-%d"),
+    }
+    url = (
         f"https://rabot.openwb.de/rabot-proxy.php/customers/{config.configuration.customer_number}"
-        f"/contracts/{config.configuration.contract_number}/metrics",
-        timeout=15
-    ).json()["data"]["records"]
+        f"/contracts/{config.configuration.contract_number}/metrics"
+    )
+    response_data = req.get_http_session().get(url, params=params, timeout=15).json()["data"]
+    raw_prices = response_data["records"]
     if len(raw_prices) == 0:
         raise Exception("Es konnten keine Preise vom Rabot-Server abgerufen werden. Bitte prüfe, ob dein Konto mit"
-                        " einem dynamischen Stromvertrag verknüpft ist.")
+                        f" einem dynamischen Stromvertrag verknüpft ist. "
+                        f"(Zeitraum: {params}, Antwort: {response_data})")
     prices: Dict[int, float] = {}
     for data in raw_prices:
         formatted_price = data["value"] / 100000  # ct/kWh -> €/Wh


### PR DESCRIPTION
Fixes #3883

Der Rabot-Tarif ruft dauerhaft keine Preise ab, obwohl Rabot-Support die korrekte Verknüpfung des Vertrags bestätigt hat. Der Fehler "Es konnten keine Preise vom Rabot-Server abgerufen werden..." erscheint bei jedem Regelzyklus erneut, da ohne erfolgreichen Abruf nie ein nächster Abrufzeitpunkt berechnet wird.

### Ursache
`fetch()` ruft den Rabot-Proxy ohne jeden Zeitraum-Parameter auf. Die tatsächliche Antwort im Issue zeigt `isSuccess: true` bei `consideredDataPeriod: null` und `records: []` — der Request kommt an, es wird aber kein Zeitraum angefragt, wodurch der Proxy keine Daten liefert. Andere Module mit vergleichbarer API (z. B. `ostrom`) senden hierfür explizit `startDate`/`endDate`.

### Änderung
- `fetch()` sendet nun `startDate`/`endDate` (heute bis morgen) bei jedem Abruf.
- Die Fehlermeldung enthält bei leerer Antwort zusätzlich den angefragten Zeitraum und die Rohantwort des Servers, um zukünftige Fehlersuche zu erleichtern.

### Bekannte Einschränkung
Name und Format der Zeitraum-Parameter sind nicht dokumentiert (Proxy-Quellcode liegt nicht in diesem Repo). Die Wahl von `startDate`/`endDate` im Format `YYYY-MM-DD` ist eine begründete Vermutung basierend auf der Antwortstruktur und vergleichbaren Modulen, aber nicht an einem echten Rabot-Konto verifiziert.
