### PR TITLE
PV-Laden: bei ausreichend Überschuss direkt mehrphasig statt einphasig starten

### DIFF
--- a/packages/control/chargepoint/chargepoint.py
+++ b/packages/control/chargepoint/chargepoint.py
@@ -459,6 +459,25 @@ class Chargepoint(ChargepointRfidMixin):
         except Exception:
             log.exception("Fehler in der Ladepunkt-Klasse von "+str(self.num))
 
+    def _get_phases_at_pv_charging_start(self, charging_ev: Ev) -> int:
+        # Ist bereits vor Ladestart genug Überschuss für mehrphasiges Laden vorhanden, direkt mehrphasig
+        # starten. Sonst müsste erst einphasig gestartet und nach der Umschaltverzögerung wieder
+        # hochgeschaltet werden, siehe Hilfetext zu "Pufferzeit zwischen automat. Phasenumschaltungen".
+        max_phase_hw = self.get_max_phase_hw()
+        pv_config = data.data.general_data.data.chargemode_config.pv_charging
+        if (self.data.control_parameter.submode == Chargemode.PV_CHARGING and
+                self.data.set.charge_template.data.chargemode.pv_charging.phases_to_use == 0 and
+                max_phase_hw > 1):
+            if self.data.set.charge_template.data.chargemode.pv_charging.feed_in_limit:
+                feed_in_yield = pv_config.feed_in_yield
+            else:
+                feed_in_yield = 0
+            usable_surplus = data.data.counter_all_data.get_evu_counter().get_usable_surplus(feed_in_yield)
+            required_surplus = charging_ev.ev_template.data.min_current * max_phase_hw * 230
+            if usable_surplus > required_surplus:
+                return max_phase_hw
+        return 1
+
     def get_phases_by_selected_chargemode(self, phases_chargemode: int) -> int:
         charging_ev = self.data.set.charging_ev_data
         if self.data.get.evse_signaling == EvseSignaling.HLC:
@@ -480,7 +499,7 @@ class Chargepoint(ChargepointRfidMixin):
                 if ((not charging_ev.ev_template.data.prevent_phase_switch or
                         self.data.set.log.imported_since_plugged == 0) and
                         self.data.config.auto_phase_switch_hw):
-                    phases = 1
+                    phases = self._get_phases_at_pv_charging_start(charging_ev)
                 else:
                     if self.data.set.phases_to_use != 0:
                         phases = self.data.set.phases_to_use

--- a/packages/control/chargepoint/get_phases_test.py
+++ b/packages/control/chargepoint/get_phases_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 from typing import Optional
 import pytest
 
+from control.chargemode import Chargemode
 from control.chargepoint.chargepoint import Chargepoint
 from control.chargepoint.chargepoint_state import ChargepointState
 from control.chargepoint.chargepoint_template import CpTemplate, get_chargepoint_template_default
@@ -98,6 +99,62 @@ def test_get_phases_by_selected_chargemode(cp: Chargepoint, params: Params):
 
     # execution
     phases = cp.get_phases_by_selected_chargemode(params.chargemode_phases)
+
+    # evaluation
+    assert phases == params.expected_phases
+
+
+class SurplusAtStartParams:
+    def __init__(self,
+                 name: str,
+                 submode: Chargemode,
+                 phases_to_use_config: int,
+                 usable_surplus: float,
+                 min_current: float,
+                 expected_phases: int) -> None:
+        self.name = name
+        self.submode = submode
+        self.phases_to_use_config = phases_to_use_config
+        self.usable_surplus = usable_surplus
+        self.min_current = min_current
+        self.expected_phases = expected_phases
+
+
+surplus_at_start_cases = [
+    SurplusAtStartParams("pv charging, enough surplus: start with max phases", submode=Chargemode.PV_CHARGING,
+                         phases_to_use_config=0, usable_surplus=5000, min_current=6, expected_phases=3),
+    SurplusAtStartParams("pv charging, not enough surplus: start with 1 phase", submode=Chargemode.PV_CHARGING,
+                         phases_to_use_config=0, usable_surplus=100, min_current=6, expected_phases=1),
+    SurplusAtStartParams("pv charging, fixed phases_to_use: no surplus check, start with 1 phase",
+                         submode=Chargemode.PV_CHARGING,
+                         phases_to_use_config=3, usable_surplus=3000, min_current=6, expected_phases=1),
+    SurplusAtStartParams("instant charging: no surplus check, start with 1 phase", submode=Chargemode.INSTANT_CHARGING,
+                         phases_to_use_config=0, usable_surplus=3000, min_current=6, expected_phases=1),
+]
+
+
+@pytest.mark.parametrize("params", surplus_at_start_cases, ids=[c.name for c in surplus_at_start_cases])
+def test_get_phases_at_pv_charging_start_uses_surplus(
+        monkeypatch: pytest.MonkeyPatch, cp: Chargepoint, params: SurplusAtStartParams):
+    # setup
+    cp.data.config.connected_phases = 3
+    cp.data.config.auto_phase_switch_hw = True
+    cp.data.get.charge_state = False
+    cp.data.set.phases_to_use = 3
+    cp.data.get.phases_in_use = 3
+    cp.data.set.log.imported_since_plugged = 0
+    cp.data.control_parameter.submode = params.submode
+    cp.data.control_parameter.phases = 3
+    cp.data.set.charge_template.data.chargemode.pv_charging.phases_to_use = params.phases_to_use_config
+    charging_ev_data = cp.data.set.charging_ev_data
+    charging_ev_data.ev_template.data.prevent_phase_switch = False
+    charging_ev_data.ev_template.data.min_current = params.min_current
+    mock_evu = Mock()
+    monkeypatch.setattr(data.data.counter_all_data, "get_evu_counter", Mock(return_value=mock_evu))
+    monkeypatch.setattr(mock_evu, "get_usable_surplus", Mock(return_value=params.usable_surplus))
+
+    # execution
+    phases = cp.get_phases_by_selected_chargemode(0)
 
     # evaluation
     assert phases == params.expected_phases


### PR DESCRIPTION
Der Hilfetext zur Einstellung "Pufferzeit zwischen automat. Phasenumschaltungen"
verspricht explizit:

> Ist ausreichend Überschuss vorhanden, wird beim Ladestart die
> Umschaltverzögerung nicht abgewartet, sondern direkt mit mehrphasiger
> Ladung begonnen.

Das funktioniert bisher nur zufällig zuverlässig, nicht durchgängig. Es gibt
dafür bereits eine Logik (`switch_on_timer_expired()` in `counter.py`, Meldung
"Der Überschuss ist ausreichend, um direkt mit {} Phasen zu laden."), die beim
Ablauf der Einschaltverzögerung den Überschuss prüft und korrekt direkt mit
maximaler Phasenzahl startet – das funktioniert für sich genommen.

Das Problem liegt an einer zweiten, unabhängigen Stelle: `get_phases_by_selected_chargemode()`
setzt beim Ladestart im Automatikmodus unconditional `phases = 1`, unabhängig
vom Überschuss und unabhängig davon, auf welcher Phasenzahl die Hardware
gerade tatsächlich steht. Stand die Hardware zufällig schon auf 1 Phase,
fällt das nicht auf – `switch_on_timer_expired()` schaltet dann sauber in
einem Schritt auf 3 Phasen hoch. Stand die Hardware aber noch auf 3 Phasen
(z. B. Restzustand vom vorherigen Ladevorgang), wird durch das erzwungene
`phases = 1` unnötig auf 1 Phase heruntergeschaltet, *bevor* die
Überschussprüfung überhaupt zum Zug kommt. Diese Umschaltung setzt den
Zeitstempel für die Umschaltverzögerung zurück, wodurch anschließend die
volle Pufferzeit (Standard 7 Minuten) erneut abgewartet werden muss, bevor
wieder auf 3 Phasen hochgeschaltet wird – das ist der eigentliche Bug, und er
tritt nur bei dieser Vorbedingung auf.

Konkret beobachtet: Ladepunkt wurde gestartet, obwohl bereits ausreichend
PV-Überschuss vorhanden war. Es folgte dennoch eine unnötige Umschaltung
3→1 Phase und danach eine Statusmeldung "Umschaltung von 1 auf 3 Phasen in
7 Min. 41 Sek.", bevor tatsächlich mehrphasig geladen wurde.