### PR TITLE
Fix Hausverbrauchszähler: EVU-Zähler darf nie aus dem Log ausgeschlossen werden

### DIFF
--- a/packages/helpermodules/measurement_logging/process_log.py
+++ b/packages/helpermodules/measurement_logging/process_log.py
@@ -575,7 +575,7 @@ def analyse_percentage_totals(entries, totals):
                     totals["consumer"][key][f"energy_imported_{source}"] = decimal_add(
                         current_value, add_value)
             for key, counter in entry["counter"].items():
-                if counter["grid"] is False:
+                if counter["grid"] is False and f"energy_imported_{source}" in counter:
                     if totals["counter"][key].get(f"energy_imported_{source}") is None:
                         totals["counter"][key].update({f"energy_imported_{source}": 0})
                     current_value = totals["counter"][key][f"energy_imported_{source}"]

--- a/packages/helpermodules/measurement_logging/process_log_unit_test.py
+++ b/packages/helpermodules/measurement_logging/process_log_unit_test.py
@@ -248,6 +248,45 @@ def test_analyse_percentage_totals():
     assert result["consumer"]["consumer7"]["energy_imported_cp"] == 246
 
 
+def test_analyse_percentage_totals_entry_missing_grid_counter():
+    # Ein Eintrag, bei dem analyse_percentage() zuvor fehlgeschlagen ist (z.B. weil der EVU-Zähler
+    # nicht als "grid" markiert wurde), hat kein "energy_source" und calc_energy_imported_by_source()
+    # setzt für dessen Zähler dann kein "energy_imported_*". Das darf die Auswertung der übrigen,
+    # intakten Einträge nicht mit einem KeyError abbrechen.
+    entries = [
+        {
+            "hc": {},
+            "cp": {},
+            "consumer": {},
+            "counter": {
+                "counter0": {"grid": False},  # fehlerhafter Eintrag ohne "energy_imported_*"
+            },
+        },
+        {
+            "hc": {},
+            "cp": {},
+            "consumer": {},
+            "counter": {
+                "counter0": {"grid": False, "energy_imported_grid": 100, "energy_imported_pv": 50,
+                             "energy_imported_bat": 20, "energy_imported_cp": 10},
+            },
+        },
+    ]
+    totals = {
+        "hc": {},
+        "cp": {},
+        "consumer": {},
+        "counter": {"counter0": {"grid": False, "energy_imported": 100}},
+    }
+
+    result = analyse_percentage_totals(entries, totals)
+
+    assert result["counter"]["counter0"]["energy_imported_grid"] == 100
+    assert result["counter"]["counter0"]["energy_imported_pv"] == 50
+    assert result["counter"]["counter0"]["energy_imported_bat"] == 20
+    assert result["counter"]["counter0"]["energy_imported_cp"] == 10
+
+
 def test_calc_energy_imported_by_source_message_filtering():
     """Test message filtering when component is in fault state and name is missing."""
     # setup

--- a/packages/helpermodules/measurement_logging/write_log.py
+++ b/packages/helpermodules/measurement_logging/write_log.py
@@ -272,20 +272,24 @@ def create_entry(log_type: LogType, sh_log_data: LegacySmartHomeLogData, previou
 
     for counter in data.data.counter_data.values():
         try:
+            # Der EVU-Zähler muss immer geloggt werden, unabhängig von Hausverbrauchs- oder
+            # extra_meter-Zuordnung - sonst findet process_log.get_grid_counter() keinen Netzzähler mehr.
+            is_grid_counter = counter_all_data.get_id_evu_counter() == counter.num
             is_home_consumption_counter = is_home_consumption_by_counter.get(counter.num, False)
-            if is_home_consumption_counter and home_consumption_counter_count == 1:
+            if not is_grid_counter and is_home_consumption_counter and home_consumption_counter_count == 1:
                 continue
             skip_counter = False
-            for consumer in data.data.consumer_data:
-                if counter.num == data.data.consumer_data[consumer].data.extra_meter:
-                    skip_counter = True
-                    break
+            if not is_grid_counter:
+                for consumer in data.data.consumer_data:
+                    if counter.num == data.data.consumer_data[consumer].data.extra_meter:
+                        skip_counter = True
+                        break
             if skip_counter is False:
                 counter_dict.update(
                     {f"counter{counter.num}": {
                         "imported": counter.data.get.imported,
                         "exported": counter.data.get.exported,
-                        "grid": True if counter_all_data.get_id_evu_counter() == counter.num else False,
+                        "grid": is_grid_counter,
                         "fault_state": counter.data.get.fault_state}})
         except Exception:
             log.exception("Fehler im Werte-Logging-Modul für Zähler "+str(counter))


### PR DESCRIPTION
## Problem

Wer für den EVU-/Netzzähler unter "Im Hausverbrauch berücksichtigen?" **"Ja"** einstellt (der einzig sinnvolle Weg, den Hausverbrauch berechnen zu lassen, wenn kein dedizierter Hausverbrauchs-Zähler vorhanden ist - bei "Automatisch" wird der oberste Zähler wie "Nein" behandelt, siehe Hinweistext in den Zähler-Einstellungen), bekommt ab dann bei jedem Log-Eintrag folgende Fehler:

```
2026-09-11 20:47:52,759 - {helpermodules.measurement_logging.process_log:470} - {ERROR:Commands} - Fehler beim Berechnen des Strom-Mix von 1789152301
Traceback (most recent call last):
File ".../process_log.py", line 422, in analyse_percentage
grid_counter = get_grid_counter(entry)
File ".../process_log.py", line 418, in get_grid_counter
raise KeyError(f"Kein Zähler für das Netz gefunden in Eintrag '{entry['timestamp']}'.")
KeyError: "Kein Zähler für das Netz gefunden in Eintrag '1789152301'."
```

Sobald die Tagesauswertung diese Einträge zusammenfasst, bricht die Berechnung komplett ab:

```
2026-09-11 21:17:14,465 - {helpermodules.measurement_logging.process_log:398} - {ERROR:Commands} - Fehler beim Analysieren der Energiequellen
Traceback (most recent call last):
File ".../process_log.py", line 396, in analyse_energy_source
data["totals"] = analyse_percentage_totals(data["entries"], data["totals"])
File ".../process_log.py", line 582, in analyse_percentage_totals
add_value = counter[f"energy_imported{source}"]
KeyError: 'energy_imported_grid'
2026-09-11 21:17:14,493 - {helpermodules.messaging:60} - {ERROR:Commands} - Messaging: Fehlermeldung: {'source': 'command', 'type': 'danger', 'message': 'Fehler beim Berechnen des Strom-Mix', ...}

```


Ergebnis: Der komplette Strom-Mix (Anteile Netz/PV/Speicher/Ladepunkt am Verbrauch) fällt für den ganzen Tag aus, dauerhaft, bei jedem Aufruf erneut.

## Root Cause

`write_log.py` baut bei jedem Log-Eintrag einen `counter_dict` und überspringt darin Zähler aus zwei Gründen: (1) wenn sie der (einzige) Hausverbrauchs-Zähler sind, (2) wenn sie als `extra_meter` einem Verbraucher zugeordnet sind. Beides schließt bislang **auch den EVU-/Netzzähler selbst** mit ein:


```
for counter in data.data.counter_data.values():
    is_home_consumption_counter = is_home_consumption_by_counter.get(counter.num, False)
    if is_home_consumption_counter and home_consumption_counter_count == 1:
        continue
    ...
    counter_dict.update({f"counter{counter.num}": {..., "grid": True if get_id_evu_counter() == counter.num else False, ...}})

```

Ist der EVU-Zähler explizit als Hausverbrauchs-Zähler markiert ("Ja"), wird er hier komplett aus dem `counter_dict` ausgeschlossen - inklusive seines `"grid": true`-Eintrags. `get_grid_counter()` in `process_log.py` verlangt aber zwingend genau einen Zähler mit `grid: true` pro Eintrag und wirft sonst einen `KeyError`. Dieser propagiert ungefangen bis in `analyse_percentage_totals()`, die für alle Einträge des Tages läuft - ein einziger betroffener Eintrag reißt die komplette Auswertung mit.

Das betrifft nicht nur eine Rand-Konfiguration: Für jede Anlage ohne dedizierten Hausverbrauchs-Zähler ist "EVU-Zähler = Hausverbrauchs-Zähler" die naheliegendste bzw. einzige Möglichkeit, den Hausverbrauch überhaupt zu erfassen.

## Fix
`write_log.py` : EVU-/Netzzähler wird nie mehr übersprungen, unabhängig von Hausverbrauchs- oder `extra_meter`-Zuordnung - er behält immer seinen `"grid": true`-Eintrag im Log.
`process_log.py::analyse_percentage_totals():` zusätzlich defensiv gemacht, analog zu den bereits vorhandenen Guards für `cp/consumer/hc` - ein einzelner Eintrag ohne `energy_imported_*` (z.B. weil er noch mit dem alten, fehlerhaften Log geschrieben wurde) überspringt nur sich selbst statt die gesamte Tagesauswertung abzubrechen.
Wichtig: Punkt 2 repariert nicht rückwirkend bereits geschriebene, fehlerhafte Log-Einträge (denen fehlt der Netzzähler schlicht), verhindert aber, dass ein einzelner solcher Alt-Eintrag die Auswertung für den Rest des Tages mitreißt.
